### PR TITLE
async fuse integration tests

### DIFF
--- a/async_fuse/Cargo.toml
+++ b/async_fuse/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.31"
-# async-std = "1.6.2"
 env_logger = "0.6.0"
 futures = "0.3.5"
 futures-core = "0.3.5"

--- a/async_fuse/src/fs/mod.rs
+++ b/async_fuse/src/fs/mod.rs
@@ -43,11 +43,9 @@ impl FileSystem {
         let parent_node = self.cache.get_mut(&parent);
         debug_assert!(
             parent_node.is_some(),
-            format!(
-                "create_node_helper() found fs is inconsistent, \
+            "create_node_helper() found fs is inconsistent, \
                 parent of ino={} should be in cache before create it new child",
-                parent,
-            )
+            parent,
         );
         let parent_node = parent_node.unwrap(); // safe to use unwrap() here
         if let Some(occupied) = parent_node.get_entry(&node_name) {
@@ -114,11 +112,9 @@ impl FileSystem {
             let node = self.cache.get(&ino);
             debug_assert!(
                 node.is_some(),
-                format!(
-                    "may_deferred_delete_node_helper() failed to \
+                "may_deferred_delete_node_helper() failed to \
                         find the i-node of ino={} to remove",
-                    ino,
-                )
+                ino,
             );
             let node = node.unwrap(); // safe to use unwrap() here
 
@@ -136,11 +132,10 @@ impl FileSystem {
             let parent_node = self.cache.get_mut(&parent_ino);
             debug_assert!(
                 parent_node.is_some(),
-                format!(
-                    "helper_get_parent_inode() failed to \
+                "helper_get_parent_inode() failed to \
                         find the parent of ino={} for i-node of ino={}",
-                    parent_ino, ino,
-                )
+                parent_ino,
+                ino,
             );
             let parent_node = parent_node.unwrap(); // safe to use unwrap() here
 
@@ -157,10 +152,8 @@ impl FileSystem {
             let insert_result = self.trash.insert(ino); // check thread-safe in case of deferred deletion race
             debug_assert!(
                 insert_result,
-                format!(
-                    "failed to insert node of ino={} into trash for deferred deletion",
-                    ino,
-                ),
+                "failed to insert node of ino={} into trash for deferred deletion",
+                ino,
             );
             debug!(
                 "may_deferred_delete_node_helper() defered removed \
@@ -202,11 +195,9 @@ impl FileSystem {
             let parent_node = self.cache.get(&parent);
             debug_assert!(
                 parent_node.is_some(),
-                format!(
-                    "remove_node_helper() found fs is inconsistent, \
+                "remove_node_helper() found fs is inconsistent, \
                         parent of ino={} should be in cache before remove its child",
-                    parent,
-                )
+                parent,
             );
             let parent_node = parent_node.unwrap(); // safe to use unwrap() here
             match parent_node.get_entry(&node_name) {
@@ -226,13 +217,13 @@ impl FileSystem {
                         let dir_node = self.cache.get(&node_ino);
                         debug_assert!(
                             dir_node.is_some(),
-                            format!(
-                                "remove_node_helper() found fs is inconsistent, \
+                            "remove_node_helper() found fs is inconsistent, \
                                     directory name={:?} of ino={} \
                                     found under the parent of ino={}, \
                                     but no i-node found for this directory",
-                                node_name, node_ino, parent,
-                            )
+                            node_name,
+                            node_ino,
+                            parent,
                         );
                         let dir_node = dir_node.unwrap(); // safe to use unwrap() here
                         if !dir_node.is_node_data_empty() {
@@ -314,11 +305,9 @@ impl FileSystem {
             let parent_node = self.cache.get(&parent);
             debug_assert!(
                 parent_node.is_some(),
-                format!(
-                    "lookup() found fs is inconsistent, \
+                "lookup() found fs is inconsistent, \
                         the parent i-node of ino={} should be in cache",
-                    parent
-                ),
+                parent
             );
             let parent_node = parent_node.unwrap(); // safe to use unwrap() here
             match parent_node.get_entry(&child_name) {
@@ -369,11 +358,9 @@ impl FileSystem {
             let parent_node = self.cache.get_mut(&parent);
             debug_assert!(
                 parent_node.is_some(),
-                format!(
-                    "lookup() found fs is inconsistent, \
+                "lookup() found fs is inconsistent, \
                         parent i-node of ino={} should be in cache",
-                    parent,
-                ),
+                parent,
             );
             let parent_node = parent_node.unwrap(); // safe to use unwrap() here
             let child_node = match child_type {
@@ -411,11 +398,9 @@ impl FileSystem {
         let node = self.cache.get(&ino);
         debug_assert!(
             node.is_some(),
-            format!(
-                "getattr() found fs is inconsistent, \
+            "getattr() found fs is inconsistent, \
                     the i-node of ino={} should be in cache",
-                ino,
-            )
+            ino,
         );
         let node = node.unwrap(); // safe to use unwrap() here
         let attr = node.get_attr();
@@ -453,10 +438,8 @@ impl FileSystem {
         let node = self.cache.get(&ino);
         debug_assert!(
             node.is_some(),
-            format!(
-                "open() found fs is inconsistent, the i-node of ino={} should be in cache",
-                ino,
-            )
+            "open() found fs is inconsistent, the i-node of ino={} should be in cache",
+            ino,
         );
         let node = node.unwrap(); // safe to use unwrap() here
         let oflags = util::parse_oflag(flags);
@@ -483,11 +466,9 @@ impl FileSystem {
             let node = self.cache.get(&ino);
             debug_assert!(
                 node.is_some(),
-                format!(
-                    "forget() found fs is inconsistent, \
+                "forget() found fs is inconsistent, \
                         the i-node of ino={} should be in cache",
-                    ino,
-                )
+                ino,
             );
             let node = node.unwrap(); // safe to use unwrap() here
             let previous_count = node.dec_lookup_count_by(nlookup);
@@ -507,11 +488,9 @@ impl FileSystem {
                     let deleted_node = self.cache.remove(&ino);
                     debug_assert!(
                         deleted_node.is_some(),
-                        format!(
-                            "forget() found fs is inconsistent, node of ino={} \
+                        "forget() found fs is inconsistent, node of ino={} \
                                 found in trash, but no i-node found for deferred deletion",
-                            ino,
-                        )
+                        ino,
                     );
                     let deleted_node = deleted_node.unwrap(); // safe to use unwrap() here
                     self.trash.remove(&ino);
@@ -553,11 +532,9 @@ impl FileSystem {
         let node = self.cache.get_mut(&ino);
         debug_assert!(
             node.is_some(),
-            format!(
-                "setattr() found fs is inconsistent, \
+            "setattr() found fs is inconsistent, \
                     the i-node of ino={} should be in cache",
-                ino,
-            )
+            ino,
         );
         let node = node.unwrap(); // safe to use unwrap() here
         let mut attr = node.get_attr();
@@ -783,10 +760,8 @@ impl FileSystem {
         let node = self.cache.get_mut(&ino);
         debug_assert!(
             node.is_some(),
-            format!(
-                "read() found fs is inconsistent, the i-node of ino={} should be in cache",
-                ino,
-            )
+            "read() found fs is inconsistent, the i-node of ino={} should be in cache",
+            ino,
         );
         let node = node.unwrap(); // safe to use unwrap() here
         if node.need_load_file_data() {
@@ -843,11 +818,9 @@ impl FileSystem {
         let inode = self.cache.get_mut(&ino);
         debug_assert!(
             inode.is_some(),
-            format!(
-                "write() found fs is inconsistent, \
+            "write() found fs is inconsistent, \
                     the i-node of ino={} should be in cache",
-                ino,
-            )
+            ino,
         );
         let inode = inode.unwrap(); // safe to use unwrap() here
         let oflags = util::parse_oflag(flags);
@@ -929,11 +902,9 @@ impl FileSystem {
         let node = self.cache.get(&ino);
         debug_assert!(
             node.is_some(),
-            format!(
-                "release() found fs is inconsistent, \
+            "release() found fs is inconsistent, \
                     the i-node of ino={} should be in cache",
-                ino,
-            ),
+            ino,
         );
         let node = node.unwrap(); // safe to use unwrap() here
         let fd = fh as RawFd;
@@ -1033,10 +1004,8 @@ impl FileSystem {
         let node = self.cache.get(&ino);
         debug_assert!(
             node.is_some(),
-            format!(
-                "opendir() found fs is inconsistent, the i-node of ino={} should be in cache",
-                ino,
-            )
+            "opendir() found fs is inconsistent, the i-node of ino={} should be in cache",
+            ino,
         );
         let node = node.unwrap(); // safe to use unwrap() here
         let oflags = util::parse_oflag(flags);
@@ -1095,11 +1064,9 @@ impl FileSystem {
         let node = self.cache.get(&ino);
         debug_assert!(
             node.is_some(),
-            format!(
-                "readdir() found fs is inconsistent, \
+            "readdir() found fs is inconsistent, \
                     the i-node of ino={} should be in cache",
-                ino,
-            )
+            ino,
         );
         let node = node.unwrap(); // safe to use unwrap() here
         let num_child_entries = node.read_dir(readdir_helper);
@@ -1132,11 +1099,9 @@ impl FileSystem {
         let node = self.cache.get(&ino);
         debug_assert!(
             node.is_some(),
-            format!(
-                "releasedir() found fs is inconsistent, \
+            "releasedir() found fs is inconsistent, \
                     the i-node of ino={} should be in cache",
-                ino,
-            )
+            ino,
         );
         let node = node.unwrap(); // safe to use unwrap() here
         blocking!(unistd::close(fh as RawFd)).unwrap_or_else(|_| {
@@ -1192,11 +1157,9 @@ impl FileSystem {
         let node = self.cache.get(&ino);
         debug_assert!(
             node.is_some(),
-            format!(
-                "statfs() found fs is inconsistent, \
+            "statfs() found fs is inconsistent, \
                     the i-node of ino={} should be in cache",
-                ino,
-            )
+            ino,
         );
         let node = node.unwrap(); // safe to use unwrap() here
         let fd = node.get_fd();

--- a/async_fuse/src/fs/node.rs
+++ b/async_fuse/src/fs/node.rs
@@ -217,10 +217,8 @@ impl Node {
         if create_dir {
             debug_assert!(
                 !dir_data.contains_key(&child_dir_name),
-                format!(
-                    "open_child_dir_helper() cannot create duplicated directory name={:?}",
-                    child_dir_name
-                ),
+                "open_child_dir_helper() cannot create duplicated directory name={:?}",
+                child_dir_name
             );
             let child_dir_name_clone = child_dir_name.clone();
             blocking!(stat::mkdirat(fd, child_dir_name_clone.as_os_str(), mode)).context(
@@ -307,10 +305,8 @@ impl Node {
         if create_file {
             debug_assert!(
                 !dir_data.contains_key(&child_file_name),
-                format!(
-                    "open_child_file_helper() cannot create duplicated file name={:?}",
-                    child_file_name
-                ),
+                "open_child_file_helper() cannot create duplicated file name={:?}",
+                child_file_name
             );
             debug_assert!(oflags.contains(OFlag::O_CREAT));
         }
@@ -478,13 +474,11 @@ impl Node {
         let removed_entry = dir_data.remove(child_name.as_os_str());
         debug_assert!(
             removed_entry.is_some(),
-            format!(
-                "unlink_entry() found fs is inconsistent, the entry of name={:?} \
+            "unlink_entry() found fs is inconsistent, the entry of name={:?} \
                 is not in directory of name={:?} and ino={}",
-                child_name,
-                self.get_name(),
-                self.get_ino(),
-            ),
+            child_name,
+            self.get_name(),
+            self.get_ino(),
         );
         let removed_entry = removed_entry.unwrap(); // safe to use unwrap() here
         let child_name_clone = child_name.clone();
@@ -525,7 +519,7 @@ impl Node {
     pub fn read_dir(&self, func: impl FnOnce(&BTreeMap<OsString, DirEntry>) -> usize) -> usize {
         // debug_assert!(
         //     !self.need_load_file_data(),
-        //     format!("directory data should be load before read"),
+        //     "directory data should be load before read",
         // );
         let dir_data = match &self.data {
             NodeData::DirData(dir_data) => dir_data,

--- a/async_fuse/src/fs/util.rs
+++ b/async_fuse/src/fs/util.rs
@@ -45,10 +45,8 @@ pub struct FileAttr {
 pub fn parse_oflag(flags: u32) -> OFlag {
     debug_assert!(
         flags < std::i32::MAX as u32,
-        format!(
-            "helper_parse_oflag() found flags={} overflow, larger than u16::MAX",
-            flags,
-        ),
+        "helper_parse_oflag() found flags={} overflow, larger than u16::MAX",
+        flags,
     );
     let oflags = OFlag::from_bits_truncate(flags as i32);
     debug!("helper_parse_oflag() read file flags={:?}", oflags);
@@ -58,10 +56,8 @@ pub fn parse_oflag(flags: u32) -> OFlag {
 pub fn parse_mode(mode: u32) -> Mode {
     debug_assert!(
         mode < std::u16::MAX as u32,
-        format!(
-            "helper_parse_mode() found mode={} overflow, larger than u16::MAX",
-            mode,
-        ),
+        "helper_parse_mode() found mode={} overflow, larger than u16::MAX",
+        mode,
     );
 
     #[cfg(target_os = "linux")]
@@ -84,10 +80,8 @@ pub fn parse_mode_bits(mode: u32) -> u16 {
 pub fn parse_sflag(flags: u32) -> SFlag {
     debug_assert!(
         flags < std::u16::MAX as u32,
-        format!(
-            "parse_sflag() found flags={} overflow, larger than u16::MAX",
-            flags,
-        ),
+        "parse_sflag() found flags={} overflow, larger than u16::MAX",
+        flags,
     );
 
     #[cfg(target_os = "linux")]

--- a/async_fuse/src/fuse_request.rs
+++ b/async_fuse/src/fuse_request.rs
@@ -670,7 +670,9 @@ impl<'a> Request<'a> {
         // Check data size
         debug_assert!(
             data_len >= header.len as usize, // TODO: why not daten_len == header.len?
-            format!("failed to assert {} >= {}", data_len, header.len),
+            "failed to assert {} >= {}",
+            data_len,
+            header.len,
         );
         // Parse/check operation arguments
         let operation = Operation::parse(header.opcode, &mut data)?;

--- a/async_fuse/src/main.rs
+++ b/async_fuse/src/main.rs
@@ -32,6 +32,9 @@ fn main() -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod test {
+    mod integration_tests;
+    mod test_util;
+
     use futures::prelude::*;
     use futures::stream::StreamExt;
     use smol::{self, blocking};

--- a/async_fuse/src/session.rs
+++ b/async_fuse/src/session.rs
@@ -261,10 +261,9 @@ impl Session {
         }
         debug_assert!(
             arg.max_readahead <= MAX_WRITE_SIZE,
-            format!(
-                "the max readahead={} larger than max write size 16M={}",
-                arg.max_readahead, MAX_WRITE_SIZE
-            ),
+            "the max readahead={} larger than max write size 16M={}",
+            arg.max_readahead,
+            MAX_WRITE_SIZE,
         );
         let flags = arg.flags & INIT_FLAGS; // TODO: handle init flags properly
         #[cfg(not(feature = "abi-7-13"))]

--- a/async_fuse/src/test/integration_tests.rs
+++ b/async_fuse/src/test/integration_tests.rs
@@ -1,0 +1,356 @@
+use log::info; // debug, warn
+use nix::dir::Dir;
+use nix::fcntl::{self, OFlag};
+use nix::sys::stat::Mode;
+use nix::unistd::{self, Whence};
+use std::collections::HashSet;
+use std::fs;
+use std::iter;
+use std::path::Path;
+
+use super::test_util::{self, DEFAULT_MOUNT_DIR, FILE_CONTENT};
+
+fn test_file_manipulation_rust_way(mount_dir: &Path) -> anyhow::Result<()> {
+    info!("file manipulation Rust style");
+    let file_path = Path::new(&mount_dir).join("tmp.txt");
+    fs::write(&file_path, FILE_CONTENT)?;
+    let bytes = fs::read(&file_path)?;
+    let content = String::from_utf8(bytes)?;
+    fs::remove_file(&file_path)?; // immediate deletion
+
+    assert_eq!(content, FILE_CONTENT);
+    assert!(
+        !file_path.exists(),
+        "the file {:?} should have been removed",
+        file_path,
+    );
+    Ok(())
+}
+
+fn test_file_manipulation_nix_way(mount_dir: &Path) -> anyhow::Result<()> {
+    info!("file manipulation C style");
+    let file_path = Path::new(&mount_dir).join("tmp.test");
+    let oflags = OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_RDWR;
+    let fd = fcntl::open(&file_path, oflags, Mode::empty())?;
+
+    let write_size = unistd::write(fd, FILE_CONTENT.as_bytes())?;
+    assert_eq!(
+        write_size,
+        FILE_CONTENT.len(),
+        "the file write size {} is not the same as the expected size {}",
+        write_size,
+        FILE_CONTENT.len(),
+    );
+
+    unistd::lseek(fd, 0, Whence::SeekSet)?;
+    let mut buffer: Vec<u8> = iter::repeat(0u8).take(FILE_CONTENT.len()).collect();
+    let read_size = unistd::read(fd, &mut *buffer)?;
+    assert_eq!(
+        read_size,
+        FILE_CONTENT.len(),
+        "the file read size {} is not the same as the expected size {}",
+        read_size,
+        FILE_CONTENT.len(),
+    );
+    let content = String::from_utf8(buffer)?;
+    assert_eq!(
+        content, FILE_CONTENT,
+        "the file read result is not the same as the expected content",
+    );
+    unistd::close(fd)?;
+
+    unistd::unlink(&file_path)?; // immediate deletion
+    assert!(
+        !file_path.exists(),
+        "the file {:?} should have been removed",
+        file_path,
+    );
+    Ok(())
+}
+
+fn test_dir_manipulation_nix_way(mount_dir: &Path) -> anyhow::Result<()> {
+    info!("directory manipulation C style");
+    let dir_path = Path::new(&mount_dir).join("test_dir");
+    let dir_mode = Mode::from_bits_truncate(0o755);
+    if dir_path.exists() {
+        fs::remove_dir_all(&dir_path)?;
+    }
+    unistd::mkdir(&dir_path, dir_mode)?;
+
+    let repeat_times = 3;
+    let mut sub_dirs = HashSet::new();
+    for i in 0..repeat_times {
+        let sub_dir_name = format!("test_sub_dir_{}", i);
+        let sub_dir_path = dir_path.join(&sub_dir_name);
+        unistd::mkdir(&sub_dir_path, dir_mode)?;
+        sub_dirs.insert(sub_dir_name);
+    }
+
+    let oflags = OFlag::O_RDONLY;
+    let mut dir_fd = Dir::open(&dir_path, oflags, Mode::empty())?;
+    let count = dir_fd
+        .iter()
+        .filter(nix::Result::is_ok)
+        .map(|e| -> nix::dir::Entry {
+            e.unwrap() // safe to use unwrap() here
+        })
+        .filter(|e| {
+            let bytes = e.file_name().to_bytes();
+            !bytes.starts_with(&[b'.']) // skip hidden entries, '.' and '..'
+        })
+        .map(|e| -> anyhow::Result<()> {
+            let bytes = e.file_name().to_bytes(); // safe to use unwrap() here
+            let byte_vec = Vec::from(bytes);
+            let str_name = String::from_utf8(byte_vec)?;
+            assert!(
+                sub_dirs.contains(&str_name),
+                "the sub directory name {} should be in the hashmap {:?}",
+                str_name,
+                sub_dirs,
+            );
+            Ok(())
+        })
+        .count();
+    assert_eq!(
+        count,
+        sub_dirs.len(),
+        "the number of directory items {} is not as the expected number {}",
+        count,
+        sub_dirs.len()
+    );
+
+    // Clean up
+    fs::remove_dir_all(&dir_path)?;
+    Ok(())
+}
+
+fn test_deferred_deletion(mount_dir: &Path) -> anyhow::Result<()> {
+    info!("file deletion deferred");
+    let file_path = Path::new(&mount_dir).join("test_file.txt");
+    let oflags = OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_RDWR;
+    let file_mode = Mode::from_bits_truncate(0o644);
+    let fd = fcntl::open(&file_path, oflags, file_mode)?;
+    unistd::unlink(&file_path)?; // deferred deletion
+
+    let repeat_times = 3;
+    for _ in 0..repeat_times {
+        let write_size = unistd::write(fd, FILE_CONTENT.as_bytes())?;
+        assert_eq!(
+            write_size,
+            FILE_CONTENT.len(),
+            "the file write size {} is not the same as the expected size {}",
+            write_size,
+            FILE_CONTENT.len(),
+        );
+    }
+    unistd::fsync(fd)?;
+
+    let mut buffer: Vec<u8> = iter::repeat(0u8)
+        .take(FILE_CONTENT.len() * repeat_times)
+        .collect();
+    unistd::lseek(fd, 0, Whence::SeekSet)?;
+    let read_size = unistd::read(fd, &mut *buffer)?;
+    let content = String::from_utf8(buffer)?;
+    unistd::close(fd)?;
+
+    assert_eq!(
+        read_size,
+        FILE_CONTENT.len() * repeat_times,
+        "the file read size {} is not the same as the expected size {}",
+        read_size,
+        FILE_CONTENT.len() * repeat_times,
+    );
+    let str_content: String = iter::repeat(FILE_CONTENT).take(repeat_times).collect();
+    assert_eq!(
+        content, str_content,
+        "the file read result is not the same as the expected content",
+    );
+
+    assert!(
+        !file_path.exists(),
+        "the file {:?} should have been removed",
+        file_path,
+    );
+    Ok(())
+}
+
+fn test_rename_file(mount_dir: &Path) -> anyhow::Result<()> {
+    info!("rename file");
+    let from_dir = Path::new(&mount_dir).join("from_dir");
+    if from_dir.exists() {
+        fs::remove_dir_all(&from_dir)?;
+    }
+    fs::create_dir(&from_dir)?;
+
+    let to_dir = Path::new(&mount_dir).join("to_dir");
+    if to_dir.exists() {
+        fs::remove_dir_all(&to_dir)?;
+    }
+    fs::create_dir(&to_dir)?;
+
+    let old_file = from_dir.join("old.txt");
+    fs::write(&old_file, FILE_CONTENT)?;
+
+    let new_file = to_dir.join("new.txt");
+
+    fs::rename(&old_file, &new_file)?;
+
+    let bytes = fs::read(&new_file)?;
+    let content = String::from_utf8(bytes)?;
+    assert_eq!(
+        content, FILE_CONTENT,
+        "the file read result is not the same as the expected content",
+    );
+
+    assert!(
+        !old_file.exists(),
+        "the old file {:?} should have been removed",
+        old_file,
+    );
+    assert!(
+        new_file.exists(),
+        "the new file {:?} should exist",
+        new_file,
+    );
+
+    // Clean up
+    fs::remove_dir_all(&from_dir)?;
+    fs::remove_dir_all(&to_dir)?;
+    Ok(())
+}
+
+fn test_rename_file_no_replace(mount_dir: &Path) -> anyhow::Result<()> {
+    info!("rename file no replace");
+    let oflags = OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_RDWR;
+    let file_mode = Mode::from_bits_truncate(0o644);
+
+    let old_file = Path::new(&mount_dir).join("old.txt");
+    let old_fd = fcntl::open(&old_file, oflags, file_mode)?;
+    let write_size = unistd::write(old_fd, FILE_CONTENT.as_bytes())?;
+    assert_eq!(
+        write_size,
+        FILE_CONTENT.len(),
+        "the file write size {} is not the same as the expected size {}",
+        write_size,
+        FILE_CONTENT.len(),
+    );
+
+    let new_file = Path::new(&mount_dir).join("new.txt");
+    let new_fd = fcntl::open(&new_file, oflags, file_mode)?;
+    let write_size = unistd::write(new_fd, FILE_CONTENT.as_bytes())?;
+    assert_eq!(
+        write_size,
+        FILE_CONTENT.len(),
+        "the file write size {} is not the same as the expected size {}",
+        write_size,
+        FILE_CONTENT.len(),
+    );
+
+    fs::rename(&old_file, &new_file).expect_err(&"rename no replace should fail".to_string());
+
+    let mut buffer: Vec<u8> = iter::repeat(0u8).take(FILE_CONTENT.len()).collect();
+    unistd::lseek(old_fd, 0, Whence::SeekSet)?;
+    let read_size = unistd::read(old_fd, &mut *buffer)?;
+    let content = String::from_utf8(buffer)?;
+    unistd::close(old_fd)?;
+    assert_eq!(
+        read_size,
+        FILE_CONTENT.len(),
+        "the file read size {} is not the same as the expected size {}",
+        read_size,
+        FILE_CONTENT.len(),
+    );
+    assert_eq!(
+        content, FILE_CONTENT,
+        "the file read result is not the same as the expected content",
+    );
+
+    let mut buffer: Vec<u8> = iter::repeat(0u8).take(FILE_CONTENT.len()).collect();
+    unistd::lseek(new_fd, 0, Whence::SeekSet)?;
+    let read_size = unistd::read(new_fd, &mut *buffer)?;
+    let content = String::from_utf8(buffer)?;
+    unistd::close(new_fd)?;
+    assert_eq!(
+        read_size,
+        FILE_CONTENT.len(),
+        "the file read size {} is not the same as the expected size {}",
+        read_size,
+        FILE_CONTENT.len(),
+    );
+    assert_eq!(
+        content, FILE_CONTENT,
+        "the file read result is not the same as the expected content",
+    );
+
+    assert!(
+        old_file.exists(),
+        "the old file {:?} should exist",
+        new_file,
+    );
+    assert!(
+        new_file.exists(),
+        "the new file {:?} should exist",
+        new_file,
+    );
+
+    // Clean up
+    fs::remove_file(&old_file)?;
+    fs::remove_file(&new_file)?;
+    Ok(())
+}
+
+fn test_rename_dir(mount_dir: &Path) -> anyhow::Result<()> {
+    info!("rename directory");
+    let from_dir = Path::new(&mount_dir).join("from_dir");
+    if from_dir.exists() {
+        fs::remove_dir_all(&from_dir)?;
+    }
+    fs::create_dir(&from_dir)?;
+
+    let to_dir = Path::new(&mount_dir).join("to_dir");
+    if to_dir.exists() {
+        fs::remove_dir_all(&to_dir)?;
+    }
+    fs::create_dir(&to_dir)?;
+
+    let old_sub_dir = from_dir.join("old_sub");
+    fs::create_dir(&old_sub_dir)?;
+    let new_sub_dir = to_dir.join("new_sub");
+    fs::rename(&old_sub_dir, &new_sub_dir)?;
+
+    assert!(
+        !old_sub_dir.exists(),
+        "the old direcotry {:?} should have been removed",
+        old_sub_dir
+    );
+    assert!(
+        new_sub_dir.exists(),
+        "the new direcotry {:?} should exist",
+        new_sub_dir,
+    );
+
+    // Clean up
+    fs::remove_dir_all(&from_dir)?;
+    fs::remove_dir_all(&to_dir)?;
+    Ok(())
+}
+
+#[test]
+fn run_test() -> anyhow::Result<()> {
+    let mount_dir = Path::new(DEFAULT_MOUNT_DIR);
+
+    let th = test_util::setup(&mount_dir)?;
+
+    info!("begin integration test");
+    test_file_manipulation_rust_way(&mount_dir)?;
+    test_file_manipulation_nix_way(&mount_dir)?;
+    test_dir_manipulation_nix_way(&mount_dir)?;
+    test_deferred_deletion(&mount_dir)?;
+    // TODO: enable thiese test after implemented rename()
+    // test_rename_file_no_replace(&mount_dir)?;
+    // test_rename_file(&mount_dir)?;
+    // test_rename_dir(&mount_dir)?;
+
+    test_util::teardown(&mount_dir, th)?;
+    Ok(())
+}

--- a/async_fuse/src/test/test_util.rs
+++ b/async_fuse/src/test/test_util.rs
@@ -1,0 +1,67 @@
+use log::{debug, info}; // warn, error
+use smol::Task;
+use std::fs;
+use std::path::Path;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use super::super::{mount, session::Session};
+
+pub const DEFAULT_MOUNT_DIR: &str = "../fuse_test";
+pub const FILE_CONTENT: &str = "0123456789ABCDEF";
+
+pub fn setup(mount_path: impl AsRef<Path>) -> anyhow::Result<JoinHandle<()>> {
+    env_logger::init();
+    let mut mount_dir = mount_path.as_ref().to_path_buf();
+    mount_dir = smol::block_on(async move {
+        let result = mount::umount(&mount_dir).await;
+        if result.is_ok() {
+            debug!("umounted {:?} before setup", mount_dir);
+        }
+        mount_dir
+    });
+
+    if mount_dir.exists() {
+        fs::remove_dir_all(&mount_dir)?;
+    }
+    fs::create_dir_all(&mount_dir)?;
+    let abs_root_path = fs::canonicalize(&mount_dir)?;
+
+    let fs_task = Task::spawn(async move {
+        async fn run_fs(mount_point: impl AsRef<Path>) -> anyhow::Result<()> {
+            let ss = Session::new(mount_point).await?;
+            ss.run().await?;
+            Ok(())
+        };
+        if let Err(e) = run_fs(&abs_root_path).await {
+            panic!("failed to run filesystem, the error is: {}", e);
+        }
+    });
+    // do not block main thread
+    let th = thread::spawn(|| {
+        smol::run(async { fs_task.await });
+        debug!("spawned a thread for smol::run()");
+    });
+    debug!("async_fuse task spawned");
+    let seconds = 2;
+    debug!("sleep {} seconds for setup", seconds);
+    thread::sleep(Duration::new(seconds, 0));
+
+    info!("setup finished");
+    Ok(th)
+}
+
+pub fn teardown(mount_dir: impl AsRef<Path>, th: JoinHandle<()>) -> anyhow::Result<()> {
+    info!("begin teardown");
+    let seconds = 1;
+    debug!("sleep {} seconds for teardown", seconds);
+    thread::sleep(Duration::new(seconds, 0));
+
+    smol::block_on(async {
+        mount::umount(&mount_dir).await.unwrap(); // TODO: remove unwrap()
+    });
+    let abs_mount_path = fs::canonicalize(mount_dir)?;
+    fs::remove_dir_all(&abs_mount_path)?;
+    th.join().unwrap(); // TODO: remove unwrap()
+    Ok(())
+}


### PR DESCRIPTION
added integration tests for async fuse.
since async fuse is a binary crate, so the integration tests have to be under src directory.
cargo clippy won't check test code.
#56