### PR TITLE
#48 fix clippy 2

### DIFF
--- a/async_fuse/src/fs/node.rs
+++ b/async_fuse/src/fs/node.rs
@@ -120,6 +120,7 @@ impl Node {
             .fetch_sub(nlookup as i64, atomic::Ordering::Relaxed)
     }
 
+    #[allow(dead_code)]
     async fn load_attribute(&self) -> anyhow::Result<FileAttr> {
         let attr = util::load_attr(self.fd).await.context(format!(
             "load_attribute() failed to get the attribute of the node ino={}",
@@ -440,6 +441,7 @@ impl Node {
         }
     }
 
+    #[allow(dead_code)]
     fn insert_entry(&mut self, child_entry: DirEntry) -> Option<DirEntry> {
         let dir_data = match &mut self.data {
             NodeData::DirData(dir_data) => dir_data,
@@ -649,6 +651,7 @@ impl Node {
         Ok(root_node)
     }
 
+    #[allow(dead_code)]
     fn move_file(
         old_parent_node: &Node,
         old_name: &OsStr,

--- a/async_fuse/src/fuse_read.rs
+++ b/async_fuse/src/fuse_read.rs
@@ -17,6 +17,7 @@ pin_project! {
 }
 
 impl<R: AsyncRead> FuseBufReadStream<R> {
+    #[allow(dead_code)]
     pub fn with_capacity(capacity: usize, reader: R) -> FuseBufReadStream<R> {
         FuseBufReadStream {
             reader,

--- a/async_fuse/src/fuse_reply.rs
+++ b/async_fuse/src/fuse_reply.rs
@@ -355,6 +355,7 @@ impl ReplyOpen {
     }
 
     /// Reply to a request with the given error code
+    #[allow(dead_code)]
     pub async fn error(self, err: c_int) -> anyhow::Result<()> {
         self.reply.send_error(err).await
     }

--- a/fuse_ll/Cargo.toml
+++ b/fuse_ll/Cargo.toml
@@ -12,6 +12,7 @@ libc = "0.2"
 log = "0.4.6"
 nix = "0.17.0"
 clap = "2.33.1"
+bincode = "1.3.1"
 
 [dev-dependencies]
 fuse_ll = { path = "." }

--- a/fuse_ll/src/fuse/abi.rs
+++ b/fuse_ll/src/fuse/abi.rs
@@ -142,7 +142,7 @@ pub mod consts {
     pub const FOPEN_PURGE_UBC: u32 = 1 << 31;
 
     // Init request/reply flags
-    pub const FUSE_ASYNC_READ: u32 = 1 << 0; // asynchronous read requests
+    pub const FUSE_ASYNC_READ: u32 = 1; // asynchronous read requests
     pub const FUSE_POSIX_LOCKS: u32 = 1 << 1; // remote locking for POSIX file locks
     #[cfg(feature = "abi-7-9")]
     pub const FUSE_FILE_OPS: u32 = 1 << 2; // kernel sends file handle for fstat, etc...
@@ -183,7 +183,7 @@ pub mod consts {
     pub const CUSE_UNRESTRICTED_IOCTL: u32 = 1 << 0; // use unrestricted ioctl
 
     // Release flags
-    pub const FUSE_RELEASE_FLUSH: u32 = 1 << 0;
+    pub const FUSE_RELEASE_FLUSH: u32 = 1;
     #[cfg(feature = "abi-7-17")]
     pub const FUSE_RELEASE_FLOCK_UNLOCK: u32 = 1 << 1;
 

--- a/fuse_ll/src/fuse/mod.rs
+++ b/fuse_ll/src/fuse/mod.rs
@@ -22,7 +22,7 @@ pub use reply::ReplyXTimes;
 pub use reply::ReplyXattr;
 pub use reply::{
     Reply, ReplyAttr, ReplyBmap, ReplyCreate, ReplyData, ReplyDirectory, ReplyEmpty, ReplyEntry,
-    ReplyLock, ReplyOpen, ReplyStatfs, ReplyWrite,
+    ReplyLock, ReplyOpen, ReplyStatfs, ReplyStatfsParam, ReplyWrite,
 };
 pub use request::Request;
 pub use session::Session;
@@ -389,7 +389,16 @@ pub trait Filesystem {
 
     /// Get file system statistics.
     fn statfs(&mut self, _req: &Request<'_>, _ino: u64, reply: ReplyStatfs) {
-        reply.statfs(0, 0, 0, 0, 0, 512, 255, 0);
+        reply.statfs(&ReplyStatfsParam {
+            blocks: 0,
+            bfree: 0,
+            bavail: 0,
+            files: 0,
+            ffree: 0,
+            bsize: 512,
+            namelen: 255,
+            frsize: 0,
+        });
     }
 
     /// Set an extended attribute.


### PR DESCRIPTION
introduce bincode to fix ptrtransform warning.
ignore all unused code.

Note: We need to implement our serialize lib to simplify
byte level write and read.