### PR TITLE
deny some lint warnings which are allowed by default

### DIFF
--- a/async_fuse/src/fs/dir.rs
+++ b/async_fuse/src/fs/dir.rs
@@ -67,7 +67,7 @@ impl DirEntry {
     }
 
     fn from_dirent(de: dirent) -> Self {
-        let ino = de.d_ino as INum;
+        let ino = de.d_ino;
 
         let name = unsafe { OsStr::from_bytes(CStr::from_ptr(de.d_name.as_ptr()).to_bytes()) };
 

--- a/async_fuse/src/fs/node.rs
+++ b/async_fuse/src/fs/node.rs
@@ -417,7 +417,7 @@ impl Node {
                 ino,
             ))?;
             unsafe {
-                file_data_vec.set_len(read_size as usize);
+                file_data_vec.set_len(read_size);
             }
             // TODO: should explicitly highlight the error type?
             Ok::<Vec<u8>, anyhow::Error>(file_data_vec)

--- a/async_fuse/src/fs/util.rs
+++ b/async_fuse/src/fs/util.rs
@@ -130,9 +130,9 @@ pub async fn load_attr(fd: RawFd) -> nix::Result<FileAttr> {
     let ctime = UNIX_EPOCH.checked_add(Duration::new(st.st_ctime as u64, st.st_ctime_nsec as u32));
     let crtime = build_crtime(&st);
 
-    let perm = parse_mode_bits(st.st_mode as u32);
+    let perm = parse_mode_bits(st.st_mode.into());
     debug!("load_attr() got file permission={}", perm);
-    let kind = parse_sflag(st.st_mode as u32);
+    let kind = parse_sflag(st.st_mode.into());
 
     let nt = SystemTime::now();
     let attr = FileAttr {
@@ -166,7 +166,7 @@ pub fn time_from_system_time(system_time: &SystemTime) -> anyhow::Result<(u64, u
 }
 
 pub fn mode_from_kind_and_perm(kind: SFlag, perm: u16) -> u32 {
-    (match kind {
+    let file_type: u32 = (match kind {
         SFlag::S_IFIFO => libc::S_IFIFO,
         SFlag::S_IFCHR => libc::S_IFCHR,
         SFlag::S_IFBLK => libc::S_IFBLK,
@@ -175,8 +175,10 @@ pub fn mode_from_kind_and_perm(kind: SFlag, perm: u16) -> u32 {
         SFlag::S_IFLNK => libc::S_IFLNK,
         SFlag::S_IFSOCK => libc::S_IFSOCK,
         _ => panic!("unknown SFlag type={:?}", kind),
-    }) as u32
-        | perm as u32
+    })
+    .into();
+    let file_perm: u32 = perm.into();
+    file_type | file_perm
 }
 
 pub fn convert_to_fuse_attr(attr: FileAttr) -> anyhow::Result<FuseAttr> {

--- a/async_fuse/src/fuse_reply.rs
+++ b/async_fuse/src/fuse_reply.rs
@@ -17,7 +17,7 @@ use super::protocol::*;
 
 // TODO: remove it
 fn mode_from_kind_and_perm(kind: SFlag, perm: u16) -> u32 {
-    (match kind {
+    let file_type: u32 = (match kind {
         SFlag::S_IFIFO => libc::S_IFIFO,
         SFlag::S_IFCHR => libc::S_IFCHR,
         SFlag::S_IFBLK => libc::S_IFBLK,
@@ -26,8 +26,10 @@ fn mode_from_kind_and_perm(kind: SFlag, perm: u16) -> u32 {
         SFlag::S_IFLNK => libc::S_IFLNK,
         SFlag::S_IFSOCK => libc::S_IFSOCK,
         _ => panic!("unknown SFlag type={:?}", kind),
-    }) as u32
-        | perm as u32
+    })
+    .into();
+    let file_perm: u32 = perm.into();
+    file_type | file_perm
 }
 
 #[derive(Debug)]

--- a/async_fuse/src/main.rs
+++ b/async_fuse/src/main.rs
@@ -1,3 +1,29 @@
+#![deny(
+    // The following are allowed by default lints according to
+    // https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+    anonymous_parameters,
+    bare_trait_objects,
+    // box_pointers, TODO: fix box pointers
+    elided_lifetimes_in_paths,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    // missing_docs, TODO: add documents
+    // single_use_lifetimes, TODO: fix lifetime names only used once
+    // trivial_casts, TODO: remove trivial casts in code
+    trivial_numeric_casts,
+    // unreachable_pub, TODO: fix unreachable pub
+    // unsafe_code,
+    unstable_features,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    // unused_results, TODO: fix unused results
+    variant_size_differences,
+
+    // Treat warnings as errors
+    // warnings, TODO: treat all wanings as errors
+)]
+
 use log::debug;
 
 mod channel;


### PR DESCRIPTION
there are many lint warnings are allowed by default, so deny these allowed lint warnings.
some lint warnings need to fixed before deny them.
add some more issue to track them.