### PR TITLE
fix trivial_numeric_casts on ARM64

### DIFF
--- a/async_fuse/src/fs/util.rs
+++ b/async_fuse/src/fs/util.rs
@@ -145,10 +145,13 @@ pub async fn load_attr(fd: RawFd) -> nix::Result<FileAttr> {
         crtime: crtime.unwrap_or(nt),
         kind,
         perm,
-        nlink: st.st_nlink as u32,
+        #[cfg(target_arch = "aarch64")]
+        nlink: st.st_nlink,
+        #[cfg(target_arch = "x86_64")]
+        nlink: st.st_nlink as u32, // TODO: need safe check for u64 to u32
         uid: st.st_uid,
         gid: st.st_gid,
-        rdev: st.st_rdev as u32,
+        rdev: st.st_rdev as u32, // TODO: need safe check for u64 to u32
         #[cfg(target_os = "linux")]
         flags: 0,
         #[cfg(target_os = "macos")]


### PR DESCRIPTION
PR #74 is passed on GitHub action, but it's failed on ARM64. Maybe we need GitHub action on ARM64 as well.

```
error: trivial numeric cast: `u32` as `u32`
   --> async_fuse/src/fs/util.rs:148:16
    |
148 |         nlink: st.st_nlink as u32,
    |                ^^^^^^^^^^^^^^^^^^
    |
note: the lint level is defined here
   --> async_fuse/src/main.rs:13:5
    |
13  |     trivial_numeric_casts,
    |     ^^^^^^^^^^^^^^^^^^^^^
    = help: cast can be replaced by coercion; this might require a temporary variable

error: aborting due to previous error
```