### PR TITLE
add meta data to cargo.toml

### DIFF
--- a/async_fuse/Cargo.toml
+++ b/async_fuse/Cargo.toml
@@ -3,6 +3,12 @@ name = "async_fuse"
 version = "0.1.0"
 authors = ["Pu Wang <nicolas.weeks@gmail.com>"]
 edition = "2018"
+description = "Distributed cloud native storage system"
+repository = "https://github.com/datenlord/datenlord"
+readme = "README.md"
+license = "MIT"
+keywords = ["Storage"]
+categories = ["filesystem"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/fuse_ll/Cargo.toml
+++ b/fuse_ll/Cargo.toml
@@ -3,6 +3,12 @@ name = "fuse_ll"
 version = "0.1.0"
 authors = ["Pu Wang <nicolas.weeks@gmail.com>"]
 edition = "2018"
+description = "Distributed cloud native storage system"
+repository = "https://github.com/datenlord/datenlord"
+readme = "README.md"
+license = "MIT"
+keywords = ["Storage"]
+categories = ["filesystem"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This is the Rust version of the [K8S host path CSI](https://github.com/kubernetes-csi/csi-driver-host-path) demo.