### PR TITLE
#96 Improve command line parser performance.

### DIFF
--- a/fuse_ll/src/fuse/mod.rs
+++ b/fuse_ll/src/fuse/mod.rs
@@ -28,7 +28,7 @@ pub use request::Request;
 pub use session::Session;
 // pub use session::{Session, BackgroundSession};
 
-pub(crate) use mount::options_validator;
+pub use mount::options_validator;
 mod abi;
 mod argument;
 mod channel;


### PR DESCRIPTION
Use hashmap to store mount options to reduce search to O(1)