### PR TITLE
Enable travis-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        crate: cargo-audit
-        use-tool-cache: true
     - uses: actions-rs/audit-check@v1.2.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,10 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,37 @@ branches:
   only: 
     - master
 
-arch:
-  - amd64
-  - arm64
-
 os: 
   - linux
 
 language: rust
 
-rust:
-  - stable
-  - nightly
-  - 1.46.0 # MSRV
-
 jobs:
+  include:
+    - name: amd64-linux-msrv
+      arch: amd64
+      rust: 1.46.0 # MSRV
+
+    - name: amd64-linux-stable
+      arch: amd64
+      rust: stable
+
+    - name: amd64-linux-nightly
+      arch: amd64
+      rust: nightly
+
+    - name: arm64-linux-msrv
+      arch: arm64
+      rust: 1.46.0 # MSRV
+
+    - name: arm64-linux-stable
+      arch: arm64
+      rust: stable
+
+    - name: arm64-linux-nightly
+      arch: arm64
+      rust: nightly
+
   allow_failures:
     - rust: nightly
     - arch: arm64 # FIXME: test failed on ARM64

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+branches:
+  only: 
+    - master
+
+arch:
+  - amd64
+  - arm64
+
+os: 
+  - linux
+
+language: rust
+
+rust:
+  - stable
+  - nightly
+  - 1.46.0 # MSRV
+
+jobs:
+  allow_failures:
+    - rust: nightly
+    - arch: arm64 # FIXME: test failed on ARM64
+  fast_finish: true
+
+cache: cargo
+
+script:
+  - cargo build --verbose
+  - ./scripts/test.sh

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+function show_result()
+{
+    rv="$1"
+    tag="$2"
+
+    if [ "$rv" -eq 0 ]; then
+        echo "$tag: passed"
+    else
+        echo "$tag: failed with $rv"
+    fi
+
+    return $rv
+}
+
+function run_tests()
+{
+    # NOTE: run non-root test
+    set -o pipefail
+    cargo test 2>&1 | tee cargo_test.log
+    rv=$?
+    set +o pipefail
+
+    show_result $rv "non-root test"
+    if [ "$rv" -ne 0 ]; then
+        return $rv
+    fi
+
+    # NOTE: run root test
+    test_bin_path=`grep Running cargo_test.log | awk '{print $2}'`
+    echo $test_bin_path
+    sudo $test_bin_path
+    rv=$?
+
+    show_result $rv "root test"
+    if [ "$rv" -ne 0 ]; then
+        return $rv
+    fi
+
+    return 0
+}
+
+function teardown()
+{
+    rm cargo_test.log
+}
+
+
+run_tests
+rv=$?
+teardown
+exit $rv


### PR DESCRIPTION
This pr adds 6 checks:

|arch|os|rust|
|-|-|-|
|AMD64|ubuntu 16.04|msrv|
|Arm64|ubuntu 16.04|msrv|
|AMD64|ubuntu 16.04|stable|
|Arm64|ubuntu 16.04|stable|
|AMD64|ubuntu 16.04|nightly|
|Arm64|ubuntu 16.04|nightly|


Build status:

<https://travis-ci.com/github/datenlord/datenlord>

References:

1. <https://docs.travis-ci.com/user/languages/rust/>
2. <https://docs.travis-ci.com/user/reference/linux/>
3. <https://docs.travis-ci.com/user/reference/osx/>