### PR TITLE
Fix CI error that install fio failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install CSI dependencies
-        run: sudo apt install -y cmake g++ libprotobuf-dev protobuf-compiler
+        run: |
+          sudo apt update
+          sudo apt install -y cmake g++ libprotobuf-dev protobuf-compiler
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -54,7 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install benchmark tool fio
-        run: sudo apt install -y fio
+        run: | 
+          sudo apt update
+          sudo apt install -y fio
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -76,7 +80,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install CSI dependencies
-        run: sudo apt install -y cmake g++ libprotobuf-dev protobuf-compiler
+        run: |
+          sudo apt update
+          sudo apt install -y cmake g++ libprotobuf-dev protobuf-compiler
       - name: Check out code
         uses: actions/checkout@v2
       - name: Prepare Rust environment
@@ -119,7 +125,9 @@ jobs:
     #      - 2380:2380
     steps:
       - name: Install CSI dependencies
-        run: sudo apt install -y cmake g++ libprotobuf-dev protobuf-compiler
+        run: |
+          sudo apt update
+          sudo apt install -y cmake g++ libprotobuf-dev protobuf-compiler
       - name: Set up Docker
         id: buildx
         uses: docker/setup-buildx-action@v1
@@ -202,7 +210,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install CSI dependencies
-        run: sudo apt install -y cmake g++ libprotobuf-dev protobuf-compiler
+        run: |
+          sudo apt update
+          sudo apt install -y cmake g++ libprotobuf-dev protobuf-compiler
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -219,7 +229,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install CSI dependencies
-        run: sudo apt install -y cmake g++ libprotobuf-dev protobuf-compiler
+        run: | 
+          sudo apt update
+          sudo apt install -y cmake g++ libprotobuf-dev protobuf-compiler
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install toolchain


### PR DESCRIPTION
According to
https://github.com/actions/virtual-environments/issues/2250,
running `apt update` before installing any software.