### PR TITLE
Changed FileAttr to shared Arc<parking_lot::RwLock<...>>

### DIFF
--- a/src/async_fuse/memfs/dist/mod.rs
+++ b/src/async_fuse/memfs/dist/mod.rs
@@ -7,5 +7,3 @@ pub mod response;
 pub mod server;
 /// Tcp communication module
 mod tcp;
-/// Serializable types module
-pub mod types;

--- a/src/async_fuse/memfs/dist/response.rs
+++ b/src/async_fuse/memfs/dist/response.rs
@@ -2,8 +2,8 @@
 
 use super::super::dir::DirEntry;
 use super::super::fs_util::FileAttr;
+use super::super::serial::{self, SerialDirEntry, SerialFileAttr};
 use super::request::Index;
-use super::types::{self, SerialDirEntry, SerialFileAttr};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -23,7 +23,7 @@ fn serialize_direntry_map(map: &BTreeMap<String, DirEntry>) -> Vec<u8> {
 
     // Checked before
     for (name, entry) in map {
-        target.insert(name.clone(), types::dir_entry_to_serial(entry));
+        target.insert(name.clone(), serial::dir_entry_to_serial(entry));
     }
 
     let target = Some(target);
@@ -42,7 +42,7 @@ fn deserialize_direntry_map(bin: &[u8]) -> Option<BTreeMap<String, DirEntry>> {
 
         // Checked before
         for (ref name, ref entry) in map {
-            target.insert(name.clone(), types::serial_to_dir_entry(entry));
+            target.insert(name.clone(), serial::serial_to_dir_entry(entry));
         }
 
         Some(target)
@@ -117,7 +117,7 @@ pub fn get_attr_none() -> Vec<u8> {
 /// Serialize `GetAttr` response
 #[must_use]
 pub fn get_attr(attr: &FileAttr) -> Vec<u8> {
-    let serial_attr = Some(types::file_attr_to_serial(attr));
+    let serial_attr = Some(serial::file_attr_to_serial(attr));
     bincode::serialize(&serial_attr)
         .unwrap_or_else(|e| panic!("fail to serialize `GetAttr` response, {e}"))
 }
@@ -147,5 +147,5 @@ pub fn deserialize_get_attr(bin: &[u8]) -> Option<FileAttr> {
     let attr_opt: Option<SerialFileAttr> = bincode::deserialize(bin)
         .unwrap_or_else(|e| panic!("fail to deserialize DirEntry Map, {e}"));
 
-    attr_opt.map(|attr| types::serial_to_file_attr(&attr))
+    attr_opt.map(|attr| serial::serial_to_file_attr(&attr))
 }

--- a/src/async_fuse/memfs/dist/server.rs
+++ b/src/async_fuse/memfs/dist/server.rs
@@ -5,13 +5,14 @@ use super::super::dir::DirEntry;
 use super::super::node::Node;
 use super::super::s3_metadata::S3MetaData;
 use super::super::s3_node::S3Node;
+use super::super::serial::{self, SerialFileAttr};
 use super::request::{self, DistRequest, OpArgs, RemoveArgs, RemoveDirEntryArgs, UpdateDirArgs};
 use super::response;
 use super::tcp;
-use super::types::{self, SerialFileAttr};
 use crate::async_fuse::memfs::s3_wrapper::S3BackEnd;
 use crate::async_fuse::memfs::RenameParam;
 use log::debug;
+use parking_lot::RwLock;
 use std::fmt::{self, Debug};
 use std::sync::Arc;
 use tokio::net::TcpStream;
@@ -149,10 +150,6 @@ async fn dispatch<S: S3BackEnd + Send + Sync + 'static>(
             remove(stream, meta, args).await?;
             Ok(true)
         }
-        DistRequest::GetInodeNum => {
-            get_inode_num(stream, &meta).await?;
-            Ok(true)
-        }
     }
 }
 
@@ -233,17 +230,18 @@ async fn update_dir<S: S3BackEnd + Send + Sync + 'static>(
     let mut path2inum = meta.path2inum.write().await;
     if let Some(parent_inum) = path2inum.get(&args.parent_path) {
         if let Some(parent_node) = cache.get_mut(parent_inum) {
-            let child_attr = args.child_attr;
+            let child_attr_serial = args.child_attr;
+            let child_attr = Arc::new(RwLock::new(serial::serial_to_file_attr(&child_attr_serial)));
             let child_node = S3Node::new_child_node_of_parent(
                 parent_node,
                 &args.child_name,
-                types::serial_to_file_attr(&child_attr),
+                Arc::clone(&child_attr),
                 args.target_path,
             );
 
             let child_ino = child_node.get_ino();
-            let child_type = child_node.get_type();
-            let entry = DirEntry::new(child_ino, args.child_name.clone(), child_type);
+            // let child_type = child_node.get_type();
+            let entry = DirEntry::new(args.child_name.clone(), child_attr);
             // Add to parent node
             parent_node
                 .get_dir_data_mut()
@@ -322,7 +320,7 @@ async fn push_attr<S: S3BackEnd + Send + Sync + 'static>(
         if let Some(node) = meta.cache.write().await.get_mut(&inum) {
             // Keep iNum
             let old_attr = node.get_attr();
-            let mut new_attr = types::serial_to_file_attr(attr);
+            let mut new_attr = serial::serial_to_file_attr(attr);
             new_attr.ino = old_attr.ino;
 
             node._set_attr(new_attr, false);
@@ -355,7 +353,7 @@ async fn remove<S: S3BackEnd + Send + Sync + 'static>(
         .remove_node_local(
             args.parent,
             &args.child_name,
-            types::serial_to_entry_type(&args.child_type),
+            serial::serial_to_entry_type(&args.child_type),
             true,
         )
         .await
@@ -366,15 +364,5 @@ async fn remove<S: S3BackEnd + Send + Sync + 'static>(
         );
     }
     tcp::write_message(stream, &response::remove()).await?;
-    Ok(())
-}
-
-/// Handle `GetInodeNum` request
-async fn get_inode_num<S: S3BackEnd + Send + Sync + 'static>(
-    stream: &mut TcpStream,
-    _meta: &Arc<S3MetaData<S>>,
-) -> anyhow::Result<()> {
-    // let inum = meta.cur_inum();
-    tcp::write_u32(stream, 0).await?;
     Ok(())
 }

--- a/src/async_fuse/memfs/dist/tcp.rs
+++ b/src/async_fuse/memfs/dist/tcp.rs
@@ -45,6 +45,7 @@ pub async fn write_message_vector(
 }
 
 /// Write u32 to tcp stream
+#[allow(dead_code)]
 pub async fn write_u32(stream: &mut TcpStream, num: u32) -> anyhow::Result<()> {
     let num_buf = num.to_be_bytes();
     stream.write_all(&num_buf).await?;
@@ -53,6 +54,7 @@ pub async fn write_u32(stream: &mut TcpStream, num: u32) -> anyhow::Result<()> {
 }
 
 /// Read u32 from tcp stream
+#[allow(dead_code)]
 pub async fn read_u32(stream: &mut TcpStream) -> anyhow::Result<u32> {
     let mut local_buf: [u8; 4] = [0; 4];
     stream.read_exact(&mut local_buf).await?;

--- a/src/async_fuse/memfs/mod.rs
+++ b/src/async_fuse/memfs/mod.rs
@@ -14,6 +14,9 @@ mod s3_metadata;
 mod s3_node;
 /// S3 backend wrapper module
 pub mod s3_wrapper;
+/// Serializable types module
+pub mod serial;
+
 use std::collections::BTreeMap;
 use std::os::unix::ffi::OsStringExt;
 use std::os::unix::prelude::RawFd;

--- a/src/async_fuse/memfs/node.rs
+++ b/src/async_fuse/memfs/node.rs
@@ -17,6 +17,7 @@ use nix::fcntl::{self, FcntlArg, OFlag};
 use nix::sys::stat::SFlag;
 use nix::sys::stat::{self, Mode};
 use nix::{sys::time::TimeSpec, unistd};
+use parking_lot::RwLock;
 use std::collections::BTreeMap;
 use std::collections::VecDeque;
 use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
@@ -86,13 +87,13 @@ pub trait Node: Sized {
     async fn load_child_symlink(
         &self,
         child_symlink_name: &str,
-        remote: Option<FileAttr>,
+        child_attr: Arc<RwLock<FileAttr>>,
     ) -> anyhow::Result<Self>;
     /// Open sub-directory in a directory
     async fn open_child_dir(
         &self,
         child_dir_name: &str,
-        remote: Option<FileAttr>,
+        child_attr: Arc<RwLock<FileAttr>>,
     ) -> anyhow::Result<Self>;
     /// Create sub-directory in a directory
     async fn create_child_dir(
@@ -105,7 +106,7 @@ pub trait Node: Sized {
     async fn open_child_file(
         &self,
         child_file_name: &str,
-        remote: Option<FileAttr>,
+        child_attr: Arc<RwLock<FileAttr>>,
         oflags: OFlag,
         global_cache: Arc<GlobalCache>,
     ) -> anyhow::Result<Self>;
@@ -177,7 +178,7 @@ pub struct DefaultNode {
     /// Full abstract path
     full_path: String,
     /// DefaultNode attribute
-    attr: FileAttr,
+    attr: Arc<RwLock<FileAttr>>,
     /// DefaultNode data
     data: DefaultNodeData,
     /// DefaultNode fd
@@ -199,7 +200,9 @@ impl Drop for DefaultNode {
             panic!(
                 "DefaultNode::drop() failed to clode the file handler \
                     of the node name={:?} ino={}, the error is: {}",
-                self.name, self.attr.ino, err,
+                self.name,
+                self.attr.read().ino,
+                err,
             );
         });
     }
@@ -211,7 +214,7 @@ impl DefaultNode {
         parent: u64,
         name: &str,
         full_path: String,
-        attr: FileAttr,
+        attr: Arc<RwLock<FileAttr>>,
         data: DefaultNodeData,
         fd: RawFd,
         meta: Arc<DefaultMetaData>,
@@ -465,7 +468,7 @@ impl DefaultNode {
             root_ino,
             name,
             "/".to_owned(),
-            attr,
+            Arc::new(RwLock::new(attr)),
             DefaultNodeData::Directory(BTreeMap::new()),
             dir_fd,
             meta,
@@ -491,7 +494,7 @@ impl Node for DefaultNode {
     /// Set node i-number
     #[inline]
     fn set_ino(&mut self, ino: INum) {
-        self.attr.ino = ino;
+        self.attr.write().ino = ino;
     }
 
     /// Get node fd
@@ -543,7 +546,7 @@ impl Node for DefaultNode {
     /// Get node attribute
     #[inline]
     fn get_attr(&self) -> FileAttr {
-        self.attr
+        *self.attr.read()
     }
 
     /// Set node attribute
@@ -554,7 +557,7 @@ impl Node for DefaultNode {
             DefaultNodeData::RegFile(..) => debug_assert_eq!(new_attr.kind, SFlag::S_IFREG),
             DefaultNodeData::SymLink(..) => debug_assert_eq!(new_attr.kind, SFlag::S_IFLNK),
         }
-        self.attr = new_attr;
+        *self.attr.write() = new_attr;
         old_attr
     }
 
@@ -689,7 +692,7 @@ impl Node for DefaultNode {
     /// check whether to load directory entry data or not
     fn need_load_dir_data(&self) -> bool {
         debug_assert_eq!(
-            self.attr.kind,
+            self.attr.read().kind,
             SFlag::S_IFDIR,
             "fobidden to check non-directory node need load data or not",
         );
@@ -699,12 +702,12 @@ impl Node for DefaultNode {
     /// Check whether to load file content data or not
     async fn need_load_file_data(&self, offset: usize, len: usize) -> bool {
         debug_assert_eq!(
-            self.attr.kind,
+            self.attr.read().kind,
             SFlag::S_IFREG,
             "fobidden to check non-file node need load data or not",
         );
 
-        if offset >= self.attr.size.cast() {
+        if offset >= self.attr.read().size.cast() {
             return false;
         }
 
@@ -768,24 +771,23 @@ impl Node for DefaultNode {
                 "create_child_symlink() failed to open symlink itself with name={child_symlink_name:?} \
                 under parent ino={ino}",
             ))?;
-        let child_attr = fs_util::load_attr(child_fd)
+        let child_attr = {
+            let child_attr = fs_util::load_attr(child_fd)
             // let child_attr = util::load_symlink_attr(fd, child_symlink_name.clone())
             .await
             .context(format!(
                 "create_child_symlink() failed to get the attribute of the new symlink={child_symlink_name:?}",
             ))?;
-        debug_assert_eq!(SFlag::S_IFLNK, child_attr.kind);
+            debug_assert_eq!(SFlag::S_IFLNK, child_attr.kind);
+            Arc::new(RwLock::new(child_attr))
+        };
 
         let target_path = {
             // insert new entry to parent directory
             // TODO: support thread-safe
             let previous_value = dir_data.insert(
                 child_symlink_name.to_owned(),
-                DirEntry::new(
-                    child_attr.ino,
-                    child_symlink_name.to_owned(),
-                    SFlag::S_IFLNK,
-                ),
+                DirEntry::new(child_symlink_name.to_owned(), Arc::clone(&child_attr)),
             );
             debug_assert!(previous_value.is_none()); // double check creation race
             target_path
@@ -810,7 +812,7 @@ impl Node for DefaultNode {
     async fn load_child_symlink(
         &self,
         child_symlink_name: &str,
-        _remote: Option<FileAttr>,
+        child_attr: Arc<RwLock<FileAttr>>,
     ) -> anyhow::Result<Self> {
         let ino = self.get_ino();
         let fd = self.fd;
@@ -821,13 +823,16 @@ impl Node for DefaultNode {
             "load_child_symlink() failed to open symlink itself with name={child_symlink_name:?} \
                 under parent ino={ino}",
         ))?;
-        let child_attr = fs_util::load_attr(child_fd)
-            // let child_attr = util::load_symlink_attr(fd, child_symlink_name.clone())
-            .await
-            .context(format!(
-                "load_child_symlink() failed to get the attribute of the new symlink={child_symlink_name:?}",
-            ))?;
-        debug_assert_eq!(SFlag::S_IFLNK, child_attr.kind);
+        *child_attr.write() = {
+            let child_attr = fs_util::load_attr(child_fd)
+                // let child_attr = util::load_symlink_attr(fd, child_symlink_name.clone())
+                .await
+                .context(format!(
+                    "load_child_symlink() failed to get the attribute of the new symlink={child_symlink_name:?}",
+                ))?;
+            debug_assert_eq!(SFlag::S_IFLNK, child_attr.kind);
+            child_attr
+        };
 
         let target_path = {
             let child_symlink_name_string = child_symlink_name.to_owned();
@@ -861,7 +866,7 @@ impl Node for DefaultNode {
     async fn open_child_dir(
         &self,
         child_dir_name: &str,
-        _remote: Option<FileAttr>,
+        child_attr: Arc<RwLock<FileAttr>>,
     ) -> anyhow::Result<Self> {
         let ino = self.get_ino();
         let fd = self.fd;
@@ -873,11 +878,14 @@ impl Node for DefaultNode {
                     under parent ino={ino}",
             ))?;
 
-        // get new directory attribute
-        let child_attr = fs_util::load_attr(child_raw_fd).await.context(format!(
-            "open_child_dir() failed to get the attribute of the new child directory={child_dir_name:?}",
-        ))?;
-        debug_assert_eq!(SFlag::S_IFDIR, child_attr.kind);
+        *child_attr.write() = {
+            // get new directory attribute
+            let child_attr = fs_util::load_attr(child_raw_fd).await.context(format!(
+                "open_child_dir() failed to get the attribute of the new child directory={child_dir_name:?}",
+            ))?;
+            debug_assert_eq!(SFlag::S_IFDIR, child_attr.kind);
+            child_attr
+        };
 
         let mut full_path = self.full_path().to_owned();
         full_path.push_str(child_dir_name);
@@ -928,17 +936,20 @@ impl Node for DefaultNode {
                     under parent ino={ino}",
             ))?;
 
-        // get new directory attribute
-        let child_attr = fs_util::load_attr(child_raw_fd).await.context(format!(
-            "open_child_dir_helper() failed to get the attribute of the new child directory={child_dir_name:?}",
-        ))?;
-        debug_assert_eq!(SFlag::S_IFDIR, child_attr.kind);
+        let child_attr = {
+            // get new directory attribute
+            let child_attr = fs_util::load_attr(child_raw_fd).await.context(format!(
+                "open_child_dir_helper() failed to get the attribute of the new child directory={child_dir_name:?}",
+            ))?;
+            debug_assert_eq!(SFlag::S_IFDIR, child_attr.kind);
+            Arc::new(RwLock::new(child_attr))
+        };
 
         // insert new entry to parent directory
         // TODO: support thread-safe
         let previous_value = dir_data.insert(
             child_dir_name.to_owned(),
-            DirEntry::new(child_attr.ino, child_dir_name.to_owned(), SFlag::S_IFDIR),
+            DirEntry::new(child_dir_name.to_owned(), Arc::clone(&child_attr)),
         );
         debug_assert!(previous_value.is_none()); // double check creation race
 
@@ -965,7 +976,7 @@ impl Node for DefaultNode {
     async fn open_child_file(
         &self,
         child_file_name: &str,
-        _remote: Option<FileAttr>,
+        child_attr: Arc<RwLock<FileAttr>>,
         oflags: OFlag,
         global_cache: Arc<GlobalCache>,
     ) -> anyhow::Result<Self> {
@@ -982,11 +993,14 @@ impl Node for DefaultNode {
                 under parent ino={ino} with oflags={oflags:?} and mode={mode:?}",
         ))?;
 
-        // get new file attribute
-        let child_attr = fs_util::load_attr(child_fd)
-            .await
-            .context("open_child_file() failed to get the attribute of the new child")?;
-        debug_assert_eq!(SFlag::S_IFREG, child_attr.kind);
+        {
+            // get new file attribute
+            let child_attr_ = fs_util::load_attr(child_fd)
+                .await
+                .context("open_child_file() failed to get the attribute of the new child")?;
+            debug_assert_eq!(SFlag::S_IFREG, child_attr_.kind);
+            child_attr.write().clone_from(&child_attr_);
+        }
 
         let mut full_path = self.full_path().to_owned();
         full_path.push_str(child_file_name);
@@ -1029,17 +1043,20 @@ impl Node for DefaultNode {
                 under parent ino={ino} with oflags={oflags:?} and mode={mode:?}",
         ))?;
 
-        // get new file attribute
-        let child_attr = fs_util::load_attr(child_fd)
-            .await
-            .context("create_child_file() failed to get the attribute of the new child")?;
-        debug_assert_eq!(SFlag::S_IFREG, child_attr.kind);
+        let child_attr = {
+            // get new file attribute
+            let child_attr = fs_util::load_attr(child_fd)
+                .await
+                .context("create_child_file() failed to get the attribute of the new child")?;
+            debug_assert_eq!(SFlag::S_IFREG, child_attr.kind);
+            Arc::new(RwLock::new(child_attr))
+        };
 
         // insert new entry to parent directory
         // TODO: support thread-safe
         let previous_value = dir_data.insert(
             child_file_name.to_owned(),
-            DirEntry::new(child_attr.ino, child_file_name.to_owned(), SFlag::S_IFREG),
+            DirEntry::new(child_file_name.to_owned(), Arc::clone(&child_attr)),
         );
         debug_assert!(previous_value.is_none()); // double check creation race
 
@@ -1080,11 +1097,16 @@ impl Node for DefaultNode {
                 let new_len_tmp =
                     global_cache.round_up(offset.overflow_sub(aligned_offset).overflow_add(len));
 
-                let new_len = if new_len_tmp.overflow_add(aligned_offset) > self.attr.size.cast() {
-                    self.attr.size.cast::<usize>().overflow_sub(aligned_offset)
-                } else {
-                    new_len_tmp
-                };
+                let new_len =
+                    if new_len_tmp.overflow_add(aligned_offset) > self.attr.read().size.cast() {
+                        self.attr
+                            .read()
+                            .size
+                            .cast::<usize>()
+                            .overflow_sub(aligned_offset)
+                    } else {
+                        new_len_tmp
+                    };
 
                 let file_data_vec = fs_util::load_file_data(self.get_fd(), aligned_offset, new_len)
                     .await
@@ -1311,11 +1333,14 @@ impl Node for DefaultNode {
         }
 
         // update the attribute of the written file
-        self.attr.size = std::cmp::max(
-            self.attr.size,
-            (offset.cast::<u64>()).overflow_add(written_size.cast()),
-        );
-        debug!("file {:?} size = {:?}", self.name, self.attr.size);
+        {
+            let mut attr_write = self.attr.write();
+            attr_write.size = std::cmp::max(
+                attr_write.size,
+                (offset.cast::<u64>()).overflow_add(written_size.cast()),
+            );
+            debug!("file {:?} size = {:?}", self.name, attr_write.size);
+        }
         self.update_mtime_ctime_to_now();
 
         Ok(written_size)

--- a/src/async_fuse/memfs/s3_metadata.rs
+++ b/src/async_fuse/memfs/s3_metadata.rs
@@ -17,19 +17,19 @@ use crate::async_fuse::util;
 use crate::common::etcd_delegate::EtcdDelegate;
 use anyhow::Context;
 use async_trait::async_trait;
+use clippy_utilities::{Cast, OverflowArithmetic};
 use itertools::Itertools;
 use log::debug;
 use nix::errno::Errno;
 use nix::fcntl::OFlag;
 use nix::sys::stat::SFlag;
+use parking_lot::RwLock as SyncRwLock; // conflict with tokio RwLock
 use std::collections::BTreeMap;
 use std::os::unix::io::RawFd;
 use std::path::Path;
 use std::sync::{atomic::AtomicU32, Arc};
 use std::time::Duration;
 use tokio::sync::{Mutex, RwLock, RwLockWriteGuard};
-
-use clippy_utilities::{Cast, OverflowArithmetic};
 
 /// The time-to-live seconds of FUSE attributes
 const MY_TTL_SEC: u64 = 3600; // TODO: should be a long value, say 1 hour
@@ -343,8 +343,8 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
         child_name: &str,
     ) -> anyhow::Result<(Duration, FuseAttr, u64)> {
         let pre_check_res = self.lookup_pre_check(parent, child_name).await;
-        let (ino, child_type) = match pre_check_res {
-            Ok((ino, child_type)) => (ino, child_type),
+        let (ino, child_type, child_attr) = match pre_check_res {
+            Ok((ino, child_type, child_attr)) => (ino, child_type, child_attr),
             Err(e) => {
                 debug!(
                     "lookup() failed to pre-check, the error is: {}",
@@ -381,18 +381,6 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
                     and i-node of ino={} and name={:?}",
                 parent, ino, child_name,
             );
-            let child_path = {
-                let cache = self.cache.read().await;
-                let parent_node = cache.get(&parent).unwrap_or_else(|| {
-                    panic!(
-                        "lookup_helper() found fs is inconsistent, \
-                        parent i-node of ino={parent} should be in cache",
-                    );
-                });
-                parent_node.absolute_path_of_child(child_name, child_type)
-            };
-            let remote_attr = self.get_attr_remote(&child_path).await;
-
             let (mut child_node, parent_name) = {
                 let cache = self.cache.read().await;
                 let parent_node = cache.get(&parent).unwrap_or_else(|| {
@@ -404,7 +392,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
                 let parent_name = parent_node.get_name().to_owned();
                 let child_node = match child_type {
                     SFlag::S_IFDIR => parent_node
-                        .open_child_dir(child_name, remote_attr)
+                        .open_child_dir(child_name, child_attr)
                         .await
                         .context(format!(
                             "lookup_helper() failed to open sub-directory name={child_name:?} \
@@ -415,7 +403,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
                         parent_node
                             .open_child_file(
                                 child_name,
-                                remote_attr,
+                                child_attr,
                                 oflags,
                                 Arc::<GlobalCache>::clone(&self.data_cache),
                             )
@@ -426,7 +414,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
                         ))?
                     }
                     SFlag::S_IFLNK => parent_node
-                        .load_child_symlink(child_name, remote_attr)
+                        .load_child_symlink(child_name, child_attr)
                         .await
                         .context(format!(
                             "lookup_helper() failed to read child symlink name={child_name:?} \
@@ -671,7 +659,11 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
     }
 
     /// Lookup helper function to pre-check
-    async fn lookup_pre_check(&self, parent: INum, name: &str) -> anyhow::Result<(INum, SFlag)> {
+    async fn lookup_pre_check(
+        &self,
+        parent: INum,
+        name: &str,
+    ) -> anyhow::Result<(INum, SFlag, Arc<SyncRwLock<FileAttr>>)> {
         // lookup child ino and type first
         let cache = self.cache.read().await;
         let parent_node = cache.get(&parent).unwrap_or_else(|| {
@@ -683,7 +675,7 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
         if let Some(child_entry) = parent_node.get_entry(name) {
             let ino = child_entry.ino();
             let child_type = child_entry.entry_type();
-            Ok((ino, child_type))
+            Ok((ino, child_type, Arc::clone(child_entry.file_attr_arc_ref())))
         } else {
             debug!(
                 "lookup_helper() failed to find the file name={:?} \
@@ -810,9 +802,10 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
                 old_parent,
                 old_parent_node.get_name(),
             ),
-            Some(old_entry) => {
-                DirEntry::new(old_entry.ino(), new_name.to_owned(), old_entry.entry_type())
-            }
+            Some(old_entry) => DirEntry::new(
+                new_name.to_owned(),
+                Arc::clone(old_entry.file_attr_arc_ref()),
+            ),
         };
 
         s3_node::rename_fullpath_recursive(entry_to_move.ino(), new_parent, &mut cache).await;
@@ -866,11 +859,9 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
                 replaced_entry.ino(),
                 "rename_exchange_helper() replaced entry i-number not match"
             );
-            let exchange_entry = DirEntry::new(
-                new_entry_ino,
-                old_name.to_owned(),
-                replaced_entry.entry_type(),
-            );
+            let attr = Arc::clone(replaced_entry.file_attr_arc_ref());
+            attr.write().ino = new_entry_ino;
+            let exchange_entry = DirEntry::new(old_name.to_owned(), attr);
 
             let mut cache = self.cache.write().await;
             let old_parent_node = cache.get_mut(&old_parent).unwrap_or_else(|| {
@@ -1157,21 +1148,6 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
         .await
         {
             panic!("failed to sync dir to others, error: {e}");
-        }
-    }
-
-    /// Get attr from other nodes
-    async fn get_attr_remote(&self, path: &str) -> Option<FileAttr> {
-        match dist_client::get_attr(
-            Arc::<EtcdDelegate>::clone(&self.etcd_client),
-            &self.node_id,
-            &self.volume_info,
-            path,
-        )
-        .await
-        {
-            Err(e) => panic!("failed to sync attribute to others, error: {e}"),
-            Ok(res) => res,
         }
     }
 

--- a/src/async_fuse/memfs/serial.rs
+++ b/src/async_fuse/memfs/serial.rs
@@ -1,20 +1,18 @@
-use super::super::dir::DirEntry;
-use super::super::fs_util::FileAttr;
+use super::dir::DirEntry;
+use super::fs_util::FileAttr;
 use crate::async_fuse::fuse::protocol::INum;
-use libc::ino_t;
 use nix::sys::stat::SFlag;
+use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use std::time::SystemTime;
+use std::{sync::Arc, time::SystemTime};
 
 /// Serializable `DirEntry`
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SerialDirEntry {
-    /// The i-number of the entry
-    ino: ino_t,
-    /// The `SFlag` type of the entry
-    entry_type: SerialSFlag,
     /// The entry name
     name: String,
+    /// File attr
+    file_attr: SerialFileAttr,
 }
 
 /// Serializable `FileAttr`
@@ -86,9 +84,8 @@ pub const fn serial_to_entry_type(entry_type: &SerialSFlag) -> SFlag {
 #[must_use]
 pub fn dir_entry_to_serial(entry: &DirEntry) -> SerialDirEntry {
     SerialDirEntry {
-        ino: entry.ino(),
-        entry_type: { entry_type_to_serial(entry.entry_type()) },
         name: entry.entry_name().to_owned(),
+        file_attr: file_attr_to_serial(&entry.file_attr_arc_ref().read()),
     }
 }
 
@@ -96,9 +93,8 @@ pub fn dir_entry_to_serial(entry: &DirEntry) -> SerialDirEntry {
 #[must_use]
 pub fn serial_to_dir_entry(entry: &SerialDirEntry) -> DirEntry {
     DirEntry::new(
-        entry.ino,
         entry.name.clone(),
-        serial_to_entry_type(&entry.entry_type),
+        Arc::new(RwLock::new(serial_to_file_attr(&entry.file_attr))),
     )
 }
 


### PR DESCRIPTION
## effect
- parent dir and child file node can share a same reference and have agreement on it
- parent dir contains all children‘s file attr to accelerate the process of get child's attr , and we don't need to load attr from remote because each time lookup the parent dir with attrs is already in cache.