### PR TITLE
Refactor : removing the concurrency safety guarantee of `Node`

### DIFF
--- a/src/async_fuse/memfs/dist/server.rs
+++ b/src/async_fuse/memfs/dist/server.rs
@@ -12,7 +12,6 @@ use super::tcp;
 use crate::async_fuse::memfs::s3_wrapper::S3BackEnd;
 use crate::async_fuse::memfs::RenameParam;
 use log::debug;
-use parking_lot::RwLock;
 use std::fmt::{self, Debug};
 use std::sync::Arc;
 use tokio::net::TcpStream;
@@ -231,11 +230,11 @@ async fn update_dir<S: S3BackEnd + Send + Sync + 'static>(
     if let Some(parent_inum) = path2inum.get(&args.parent_path) {
         if let Some(parent_node) = cache.get_mut(parent_inum) {
             let child_attr_serial = args.child_attr;
-            let child_attr = Arc::new(RwLock::new(serial::serial_to_file_attr(&child_attr_serial)));
+            let child_attr = serial::serial_to_file_attr(&child_attr_serial);
             let child_node = S3Node::new_child_node_of_parent(
                 parent_node,
                 &args.child_name,
-                Arc::clone(&child_attr),
+                child_attr,
                 args.target_path,
             );
 

--- a/src/async_fuse/memfs/node.rs
+++ b/src/async_fuse/memfs/node.rs
@@ -87,13 +87,13 @@ pub trait Node: Sized {
     async fn load_child_symlink(
         &self,
         child_symlink_name: &str,
-        child_attr: Arc<RwLock<FileAttr>>,
+        child_attr: FileAttr,
     ) -> anyhow::Result<Self>;
     /// Open sub-directory in a directory
     async fn open_child_dir(
         &self,
         child_dir_name: &str,
-        child_attr: Arc<RwLock<FileAttr>>,
+        child_attr: FileAttr,
     ) -> anyhow::Result<Self>;
     /// Create sub-directory in a directory
     async fn create_child_dir(
@@ -106,7 +106,7 @@ pub trait Node: Sized {
     async fn open_child_file(
         &self,
         child_file_name: &str,
-        child_attr: Arc<RwLock<FileAttr>>,
+        child_attr: FileAttr,
         oflags: OFlag,
         global_cache: Arc<GlobalCache>,
     ) -> anyhow::Result<Self>;
@@ -178,17 +178,17 @@ pub struct DefaultNode {
     /// Full abstract path
     full_path: String,
     /// DefaultNode attribute
-    attr: Arc<RwLock<FileAttr>>,
+    attr: FileAttr,
     /// DefaultNode data
     data: DefaultNodeData,
     /// DefaultNode fd
     fd: RawFd,
     /// DefaultNode open counter
-    open_count: AtomicI64,
+    open_count: i64,
     /// DefaultNode lookup counter
-    lookup_count: AtomicI64,
+    lookup_count: i64,
     /// If DefaultNode has been marked as deferred deletion
-    deferred_deletion: AtomicBool,
+    deferred_deletion: bool,
     /// Shared metadata
     meta: Arc<DefaultMetaData>,
 }

--- a/src/async_fuse/memfs/persist.rs
+++ b/src/async_fuse/memfs/persist.rs
@@ -108,10 +108,7 @@ impl PersistDirContent {
                 file_map: files
                     .iter()
                     .map(|(fname, entry)| {
-                        (
-                            fname.clone(),
-                            file_attr_to_serial(&entry.file_attr_arc_ref().read()),
-                        )
+                        (fname.clone(), file_attr_to_serial(&entry.file_attr_ref()))
                     })
                     .collect(),
                 root_attr,
@@ -129,10 +126,7 @@ impl PersistDirContent {
             .map(|(name, fattr)| {
                 (
                     name.clone(),
-                    DirEntry::new(
-                        name.clone(),
-                        Arc::new(RwLock::new(serial::serial_to_file_attr(fattr))),
-                    ),
+                    DirEntry::new(name.clone(), serial::serial_to_file_attr(fattr)),
                 )
             })
             .collect();

--- a/src/async_fuse/memfs/serial.rs
+++ b/src/async_fuse/memfs/serial.rs
@@ -2,9 +2,8 @@ use super::dir::DirEntry;
 use super::fs_util::FileAttr;
 use crate::async_fuse::fuse::protocol::INum;
 use nix::sys::stat::SFlag;
-use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use std::{sync::Arc, time::SystemTime};
+use std::time::SystemTime;
 
 /// Serializable `DirEntry`
 #[derive(Serialize, Deserialize, Debug)]
@@ -85,17 +84,14 @@ pub const fn serial_to_entry_type(entry_type: &SerialSFlag) -> SFlag {
 pub fn dir_entry_to_serial(entry: &DirEntry) -> SerialDirEntry {
     SerialDirEntry {
         name: entry.entry_name().to_owned(),
-        file_attr: file_attr_to_serial(&entry.file_attr_arc_ref().read()),
+        file_attr: file_attr_to_serial(&entry.file_attr_ref()),
     }
 }
 
 /// Convert `SerialDirEntry` to `DirEntry`
 #[must_use]
 pub fn serial_to_dir_entry(entry: &SerialDirEntry) -> DirEntry {
-    DirEntry::new(
-        entry.name.clone(),
-        Arc::new(RwLock::new(serial_to_file_attr(&entry.file_attr))),
-    )
+    DirEntry::new(entry.name.clone(), serial_to_file_attr(&entry.file_attr))
 }
 
 /// Convert `FileAttr` to `SerialFileAttr`


### PR DESCRIPTION
Removing the concurrency safety guarantee of `Node`
Although the changes made in this pull request can pass compilation, we cannot guarantee the correctness of the logic, including passing the tests. The reason for this is that the changes involve a significant amount of code modifications in the kv_engine meta layer. To facilitate the code review process, we have split the changes into smaller pull requests for submission. This approach will enable each pull request's changes to be more easily reviewed and tested, ensuring the overall code quality