### PR TITLE
Refactor S3Node and add serialization/deserialization support

### DIFF
--- a/src/async_fuse/memfs/dist/server.rs
+++ b/src/async_fuse/memfs/dist/server.rs
@@ -237,6 +237,7 @@ async fn update_dir<S: S3BackEnd + Send + Sync + 'static>(
                 &args.child_name,
                 Arc::clone(&child_attr),
                 args.target_path,
+                &meta.data_cache,
             );
 
             let child_ino = child_node.get_ino();

--- a/src/async_fuse/memfs/inode.rs
+++ b/src/async_fuse/memfs/inode.rs
@@ -111,8 +111,8 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
         self.inode_state
             .inode_get_inum_by_fullpath(
                 fullpath,
-                self.node_id.as_str(),
-                self.volume_info.as_str(),
+                &self.node_id,
+                &self.volume_info,
                 &self.etcd_client,
             )
             .await

--- a/src/async_fuse/memfs/mod.rs
+++ b/src/async_fuse/memfs/mod.rs
@@ -7,6 +7,7 @@ mod fs_util;
 /// manage inode related, inum allocation and recycle
 mod inode;
 /// The KV engine module
+#[macro_use]
 mod kv_engine;
 /// fs metadata module
 mod metadata;

--- a/src/async_fuse/memfs/s3_node.rs
+++ b/src/async_fuse/memfs/s3_node.rs
@@ -146,9 +146,7 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3Node<S> {
             name: name.to_owned(),
             attr: Arc::new(RwLock::new(serial_to_file_attr(attr))),
             data: data.deserialize_s3(Arc::clone(&arg.data_cache)),
-            // open count set to 0 by creation
             open_count: AtomicI64::new(open_count),
-            // lookup count set to 1 by creation
             lookup_count: AtomicI64::new(lookup_count),
             deferred_deletion: AtomicBool::new(deferred_deletion),
             etcd_client: Arc::clone(&arg.etcd_client),

--- a/src/async_fuse/memfs/serial.rs
+++ b/src/async_fuse/memfs/serial.rs
@@ -2,9 +2,7 @@ use super::cache::GlobalCache;
 use super::dir::DirEntry;
 use super::fs_util::FileAttr;
 use super::s3_node::S3NodeData;
-use super::s3_wrapper::S3BackEnd;
 use crate::async_fuse::fuse::protocol::INum;
-use crate::common::etcd_delegate::EtcdDelegate;
 use nix::sys::stat::SFlag;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
@@ -79,7 +77,7 @@ pub enum SerialNodeData {
 
 impl SerialNodeData {
     /// Deserializes the node data
-    pub fn deserialize_s3(self, data_cache: Arc<GlobalCache>) -> S3NodeData {
+    pub fn into_s3_nodedata(self, data_cache: Arc<GlobalCache>) -> S3NodeData {
         match self {
             SerialNodeData::Directory(dir) => {
                 let mut dir_entry_map = BTreeMap::new();
@@ -113,22 +111,6 @@ pub struct SerialNode {
     pub(crate) lookup_count: i64,
     /// If S3Node has been marked as deferred deletion
     pub(crate) deferred_deletion: bool,
-}
-
-#[allow(dead_code)]
-#[derive(Debug)]
-/// Deserializable 'Node' arguments
-pub struct DeserialS3NodeArgs<S: S3BackEnd + Sync + Send + 'static> {
-    /// The s3 backend
-    pub(crate) s3_backend: Arc<S>,
-    /// The etcd client
-    pub(crate) etcd_client: Arc<EtcdDelegate>,
-    /// The k8s node id
-    pub(crate) k8s_node_id: String,
-    /// The k8s volume info
-    pub(crate) k8s_volume_info: String,
-    /// The global cache(for file data)
-    pub(crate) data_cache: Arc<GlobalCache>,
 }
 
 /// Convert `SFlag` to `SerialSFlag`


### PR DESCRIPTION
**Problem:**

The `S3Node` struct currently holds an `Arc<S3Meta<S>>`, which simplifies many operations. However, this design is not friendly for serialization and deserialization of the `S3Node`. The majority of usages of `Arc<S3Meta<S>>`  in `S3Node` involve the `etcd_client`, `node_id`, and `volume_info` data members.

**Solution:**

This pull request refactors the `S3Node` by replacing the `Arc<S3Meta<S>>` with the three aforementioned data members (`etcd_client`, `node_id`, and `volume_info`). Additionally, serialization and deserialization support for the `S3Node` has been implemented.

**Changes:**

1. Remove the `Arc<S3Meta<S>>` data member from the `S3Node` struct,add `etcd_client`, `node_id`, and `volume_info` data members to the `S3Node` struct.
2. Update the `S3Node` constructor to initialize the new data members.
3. Refactor any methods in the `S3Node` that previously used `Arc<S3Meta<S>>` to now use the new data members.
4. Implement serialization and deserialization for the `S3Node`, handling the new data members.
5. Add test cases for the serialization and deserialization functionality.