### PR TITLE
Refactor DatenLord Error Handling with DatenLordError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,18 @@ crossbeam-channel = "0.5.0"
 crossbeam-queue = "0.3.1"
 crossbeam-utils = "0.8.1"
 env_logger = "0.10.0"
-etcd-client = { git="https://github.com/datenlord/etcd-client", rev = "f697899"}
+etcd-client = { git = "https://github.com/datenlord/etcd-client", rev = "f697899" }
 event-listener = "2.5.1"
 flate2 = "1.0.16"
 futures = "0.3.5"
-grpcio = { version = "0.9.1", default-features = false, features = ["protobuf-codec"] }
+grpcio = { version = "0.9.1", default-features = false, features = [
+    "protobuf-codec",
+] }
 hyper = { version = "^0.14", features = ["server", "http1", "tcp"] }
 itertools = "0.10.0"
-k8s-openapi = { version = "0.15.0", default-features = false, features = ["v1_19"] }
+k8s-openapi = { version = "0.15.0", default-features = false, features = [
+    "v1_19",
+] }
 lazy_static = "^1.4"
 libc = "0.2.79"
 lockfree-cuckoohash = "0.1.0"
@@ -41,14 +45,16 @@ memchr = "2.3.4"
 nix = "0.23.1"
 once_cell = "1.7.2"
 parking_lot = "0.12.0"
-pin-project-lite ="0.2.0"
+pin-project-lite = "0.2.0"
 priority-queue = "1.1.0"
 prometheus = "0.13.0"
 protobuf = "2.16.2"
 rand = "0.8.3"
 ring-io = { git = "https://github.com/datenlord/ring-io", rev = "2f0506c" }
-rust-s3 = {git="https://github.com/rogercloud/rust-s3", rev = "c1fa1b9", features = ["with-async-std"], default-features = false}
-serde-xml-rs = "0.6" 
+rust-s3 = { git = "https://github.com/rogercloud/rust-s3", rev = "c1fa1b9", features = [
+    "with-async-std",
+], default-features = false }
+serde-xml-rs = "0.6"
 serde = "1.0.126"
 serde_json = "1.0.64"
 tar = "0.4.29"
@@ -65,7 +71,7 @@ protoc-grpcio = "3.0.0"
 mock-etcd = { git = "https://github.com/datenlord/etcd-client", rev = "f697899" }
 #  Create mock api for some interface like s3 that are independent service,
 #  We don't want to start up a real service for some api when doing unit test.
-mockall = "0.11.2"  
+mockall = "0.11.2"
 
 [[bin]]
 path = "src/bin/bind_mounter.rs"

--- a/src/async_fuse/memfs/s3_metadata.rs
+++ b/src/async_fuse/memfs/s3_metadata.rs
@@ -19,6 +19,7 @@ use crate::async_fuse::fuse::file_system::FsAsyncResultSender;
 use crate::async_fuse::fuse::fuse_reply::FuseDeleteNotification;
 use crate::async_fuse::fuse::protocol::{FuseAttr, INum, FUSE_ROOT_ID};
 use crate::async_fuse::util;
+use crate::common::error::{DatenLordError, DatenLordResult};
 use crate::common::etcd_delegate::EtcdDelegate;
 use anyhow::Context;
 use async_trait::async_trait;
@@ -202,7 +203,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
         mode: u32,
         node_type: SFlag,
         target_path: Option<&Path>,
-    ) -> anyhow::Result<(Duration, FuseAttr, u64)> {
+    ) -> DatenLordResult<(Duration, FuseAttr, u64)> {
         // pre-check
         let (parent_full_path, full_path, new_node_attr, fuse_attr) = {
             let mut cache = self.cache.write().await;
@@ -214,9 +215,9 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
             if !is_new {
                 // inum created by others or exist in remote cache
                 //todo delete parent node cache to update parent dir content
-                return Err(anyhow::anyhow!("create_node_helper() failed to create node, ino alloc failed, \
+                return Err(DatenLordError::from(anyhow::anyhow!("create_node_helper() failed to create node, ino alloc failed, \
                     the node of name={:?} already exists under parent directory of ino={} and name={:?}",
-                    node_name, parent, parent_node.get_name()));
+                    node_name, parent, parent_node.get_name())));
             }
 
             let parent_name = parent_node.get_name().to_owned();
@@ -350,7 +351,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
         parent: INum,
         node_name: &str,
         node_type: SFlag,
-    ) -> anyhow::Result<()> {
+    ) -> DatenLordResult<()> {
         debug!(
             "remove_node_helper() about to remove parent ino={:?}, \
             child_name={:?}, child_type={:?}",
@@ -369,15 +370,12 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
         &self,
         parent: INum,
         child_name: &str,
-    ) -> anyhow::Result<(Duration, FuseAttr, u64)> {
+    ) -> DatenLordResult<(Duration, FuseAttr, u64)> {
         let pre_check_res = self.lookup_pre_check(parent, child_name).await;
         let (ino, child_type, child_attr) = match pre_check_res {
             Ok((ino, child_type, child_attr)) => (ino, child_type, child_attr),
             Err(e) => {
-                debug!(
-                    "lookup() failed to pre-check, the error is: {}",
-                    crate::common::util::format_anyhow_error(&e),
-                );
+                debug!("lookup() failed to pre-check, the error is: {}", e);
                 return Err(e);
             }
         };
@@ -476,7 +474,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
     }
 
     /// Rename helper to exchange on disk
-    async fn rename_exchange_helper(&self, param: RenameParam) -> anyhow::Result<()> {
+    async fn rename_exchange_helper(&self, param: RenameParam) -> DatenLordResult<()> {
         let old = param.old_parent;
         let new = param.new_parent;
         self.rename_exchange_local(&param).await?;
@@ -487,7 +485,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
     }
 
     /// Rename helper to move on disk, it may replace destination entry
-    async fn rename_may_replace_helper(&self, param: RenameParam) -> anyhow::Result<()> {
+    async fn rename_may_replace_helper(&self, param: RenameParam) -> DatenLordResult<()> {
         let old = param.old_parent;
         let new = param.new_parent;
         self.rename_may_replace_local(&param, false).await?;
@@ -504,7 +502,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
         fh: u64,
         _datasync: bool,
         // reply: ReplyEmpty,
-    ) -> anyhow::Result<()> {
+    ) -> DatenLordResult<()> {
         let mut cache = self.cache().write().await;
         let inode = cache.get_mut(&ino).unwrap_or_else(|| {
             panic!(
@@ -526,7 +524,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
         offset: i64,
         data: Vec<u8>,
         flags: u32,
-    ) -> anyhow::Result<usize> {
+    ) -> DatenLordResult<usize> {
         let data_len = data.len();
         let (result, full_path, parent_ino) = {
             let mut cache = self.cache().write().await;
@@ -606,7 +604,7 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
         parent: INum,
         node_name: &str,
         cache: &'b mut RwLockWriteGuard<BTreeMap<INum, <Self as MetaData>::N>>,
-    ) -> anyhow::Result<&'b mut <Self as MetaData>::N> {
+    ) -> DatenLordResult<&'b mut <Self as MetaData>::N> {
         let parent_node = cache.get_mut(&parent).unwrap_or_else(|| {
             panic!(
                 "create_node_pre_check() found fs is inconsistent, \
@@ -654,7 +652,7 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
         &self,
         ino: INum,
         from_remote: bool,
-    ) -> anyhow::Result<()> {
+    ) -> DatenLordResult<()> {
         // remove entry from parent i-node
         let mut cache = self.cache.write().await;
         let inode = cache.get(&ino).unwrap_or_else(|| {
@@ -741,7 +739,7 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
         &self,
         parent: INum,
         name: &str,
-    ) -> anyhow::Result<(INum, SFlag, Arc<SyncRwLock<FileAttr>>)> {
+    ) -> DatenLordResult<(INum, SFlag, Arc<SyncRwLock<FileAttr>>)> {
         // lookup child ino and type first
         let cache = self.cache.read().await;
         let parent_node = cache.get(&parent).unwrap_or_else(|| {
@@ -784,7 +782,7 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
         new_parent: INum,
         new_name: &str,
         no_replace: bool,
-    ) -> anyhow::Result<(RawFd, INum, RawFd, Option<INum>)> {
+    ) -> DatenLordResult<(RawFd, INum, RawFd, Option<INum>)> {
         let cache = self.cache.read().await;
         let old_parent_node = cache.get(&old_parent).unwrap_or_else(|| {
             panic!(
@@ -897,7 +895,7 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
     }
 
     /// Rename exchange on local node
-    async fn rename_exchange_local(&self, param: &RenameParam) -> anyhow::Result<()> {
+    async fn rename_exchange_local(&self, param: &RenameParam) -> DatenLordResult<()> {
         let old_parent = param.old_parent;
         let old_name = param.old_name.as_str();
         let new_parent = param.new_parent;
@@ -917,10 +915,7 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
                 (old_parent_fd, old_entry_ino, new_parent_fd, new_entry_ino)
             }
             Err(e) => {
-                debug!(
-                    "rename() pre-check failed, the error is: {}",
-                    crate::common::util::format_anyhow_error(&e)
-                );
+                debug!("rename() pre-check failed, the error is: {}", e);
                 return Err(e);
             }
         };
@@ -996,7 +991,7 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
         &self,
         param: &RenameParam,
         from_remote: bool,
-    ) -> anyhow::Result<()> {
+    ) -> DatenLordResult<()> {
         let old_parent = param.old_parent;
         let old_name = &param.old_name;
         let new_parent = param.new_parent;
@@ -1016,10 +1011,7 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
                 (old_parent_fd, old_entry_ino, new_parent_fd, new_entry_ino)
             }
             Err(e) => {
-                debug!(
-                    "rename() pre-check failed, the error is: {}",
-                    crate::common::util::format_anyhow_error(&e)
-                );
+                debug!("rename() pre-check failed, the error is: {}", e);
                 return Err(e);
             }
         };
@@ -1081,7 +1073,7 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
         node_name: &str,
         node_type: SFlag,
         from_remote: bool,
-    ) -> anyhow::Result<()> {
+    ) -> DatenLordResult<()> {
         debug!(
             "remove_node_local() about to remove parent ino={:?}, \
             child_name={:?}, child_type={:?}",

--- a/src/async_fuse/memfs/s3_node.rs
+++ b/src/async_fuse/memfs/s3_node.rs
@@ -12,7 +12,9 @@ use super::SetAttrParam;
 use crate::async_fuse::fuse::fuse_reply::{AsIoVec, StatFsParam};
 use crate::async_fuse::fuse::protocol::INum;
 use crate::async_fuse::metrics;
+use crate::common::error::{DatenLordError, DatenLordResult};
 use crate::common::etcd_delegate::EtcdDelegate;
+use anyhow::anyhow;
 use async_trait::async_trait;
 use clippy_utilities::{Cast, OverflowArithmetic};
 use log::debug;
@@ -270,7 +272,7 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3Node<S> {
         name: &str,
         s3_backend: Arc<S>,
         meta: Arc<S3MetaData<S>>,
-    ) -> anyhow::Result<Self> {
+    ) -> DatenLordResult<Self> {
         match persist::read_persisted_dir(&s3_backend, "/".to_owned()).await {
             Err(e) => {
                 //todo: handle different type of error, key not exist, net err, etc.
@@ -314,14 +316,14 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3Node<S> {
                 }
                 Err(e) => {
                     log::error!("Root node persist lack of attr info {e}.");
-                    Err(e)
+                    Err(DatenLordError::from(e))
                 }
             },
         }
     }
 
     /// flush all data of a node
-    async fn flush_all_data(&mut self) -> anyhow::Result<()> {
+    async fn flush_all_data(&mut self) -> DatenLordResult<()> {
         if self.is_deferred_deletion() {
             return Ok(());
         }
@@ -340,20 +342,31 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3Node<S> {
                 debug!(
                     "failed to load data for file {} while flushing data, the error is: {}",
                     self.get_name(),
-                    crate::common::util::format_anyhow_error(&e),
+                    e,
                 );
                 return Err(e);
             }
         }
 
-        self.s3_backend
+        let put_result = self
+            .s3_backend
             .put_data_vec(
                 &self.full_path,
                 data_cache.get_file_cache(self.full_path.as_bytes(), 0, size.cast()),
             )
-            .await?;
+            .await;
 
-        Ok(())
+        match put_result {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                debug!(
+                    "flush_all_data() failed to flush data for file {}, the error is: {}",
+                    self.get_name(),
+                    e,
+                );
+                Err(DatenLordError::from(anyhow!(e)))
+            }
+        }
     }
 }
 
@@ -531,7 +544,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> Node for S3Node<S> {
     }
 
     /// Load attribute
-    async fn load_attribute(&mut self) -> anyhow::Result<FileAttr> {
+    async fn load_attribute(&mut self) -> DatenLordResult<FileAttr> {
         let (content_len, last_modified) = self
             .s3_backend
             .get_meta(&self.full_path)
@@ -569,7 +582,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> Node for S3Node<S> {
     }
 
     /// Duplicate fd
-    async fn dup_fd(&self, _oflags: OFlag) -> anyhow::Result<RawFd> {
+    async fn dup_fd(&self, _oflags: OFlag) -> DatenLordResult<RawFd> {
         self.inc_open_count();
         Ok(self.new_fd().cast())
     }
@@ -636,7 +649,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> Node for S3Node<S> {
         inum: INum,
         child_symlink_name: &str,
         target_path: PathBuf,
-    ) -> anyhow::Result<Self> {
+    ) -> DatenLordResult<Self> {
         let absolute_path = self.absolute_path_with_child(child_symlink_name);
         let dir_data = self.get_dir_data();
         debug_assert!(
@@ -704,7 +717,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> Node for S3Node<S> {
         &self,
         child_symlink_name: &str,
         child_attr: Arc<RwLock<FileAttr>>,
-    ) -> anyhow::Result<Self> {
+    ) -> DatenLordResult<Self> {
         let absolute_path = self.absolute_path_with_child(child_symlink_name);
 
         let target_path = PathBuf::from(
@@ -737,7 +750,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> Node for S3Node<S> {
         &self,
         child_dir_name: &str,
         child_attr: Arc<RwLock<FileAttr>>,
-    ) -> anyhow::Result<Self> {
+    ) -> DatenLordResult<Self> {
         // lookup count and open count are increased to 1 by creation
         let full_path = format!("{}{}/", self.full_path, child_dir_name);
         let dirdata = match persist::read_persisted_dir(&self.s3_backend, full_path.clone()).await {
@@ -767,7 +780,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> Node for S3Node<S> {
         inum: INum,
         child_dir_name: &str,
         mode: Mode,
-    ) -> anyhow::Result<Self> {
+    ) -> DatenLordResult<Self> {
         let absolute_path = self.absolute_dir_with_child(child_dir_name);
         let dir_data = self.get_dir_data();
         // TODO return error
@@ -819,7 +832,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> Node for S3Node<S> {
         child_attr: Arc<RwLock<FileAttr>>,
         _oflags: OFlag,
         global_cache: Arc<GlobalCache>,
-    ) -> anyhow::Result<Self> {
+    ) -> DatenLordResult<Self> {
         Ok(Self::new(
             self.get_ino(),
             child_file_name,
@@ -839,7 +852,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> Node for S3Node<S> {
         oflags: OFlag,
         mode: Mode,
         global_cache: Arc<GlobalCache>,
-    ) -> anyhow::Result<Self> {
+    ) -> DatenLordResult<Self> {
         let absolute_path = self.absolute_path_with_child(child_file_name);
         let dir_data = self.get_dir_data();
         debug_assert!(
@@ -888,7 +901,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> Node for S3Node<S> {
 
     /// Load data from directory, file or symlink target.
     /// The `offset` and `len` is used for regular file
-    async fn load_data(&mut self, offset: usize, len: usize) -> anyhow::Result<usize> {
+    async fn load_data(&mut self, offset: usize, len: usize) -> DatenLordResult<usize> {
         match self.data {
             S3NodeData::Directory(..) => {
                 // TODO: really read dir from S3
@@ -948,8 +961,10 @@ impl<S: S3BackEnd + Sync + Send + 'static> Node for S3Node<S> {
                             Ok(a) => a,
                             Err(e) => {
                                 let anyhow_err: anyhow::Error = e.into();
-                                return Err(anyhow_err
-                                    .context("load_data() failed to load file content data"));
+                                return Err(DatenLordError::from(
+                                    anyhow_err
+                                        .context("load_data() failed to load file content data"),
+                                ));
                             }
                         }
                     }
@@ -1004,7 +1019,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> Node for S3Node<S> {
     }
 
     /// Unlink directory entry from both cache and disk
-    async fn unlink_entry(&mut self, child_name: &str) -> anyhow::Result<DirEntry> {
+    async fn unlink_entry(&mut self, child_name: &str) -> DatenLordResult<DirEntry> {
         let dir_data = self.get_dir_data_mut();
         let removed_entry = dir_data.remove(child_name).unwrap_or_else(|| {
             panic!(
@@ -1057,7 +1072,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> Node for S3Node<S> {
 
     /// Fake data for statefs
     /// TODO: handle some important data from S3 storage
-    async fn statefs(&self) -> anyhow::Result<StatFsParam> {
+    async fn statefs(&self) -> DatenLordResult<StatFsParam> {
         Ok(StatFsParam {
             blocks: 10_000_000_000,
             bfree: 10_000_000_000,
@@ -1090,7 +1105,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> Node for S3Node<S> {
         data: Vec<u8>,
         _oflags: OFlag,
         _write_to_disk: bool,
-    ) -> anyhow::Result<usize> {
+    ) -> DatenLordResult<usize> {
         let this: &Self = self;
 
         let ino = this.get_ino();
@@ -1101,7 +1116,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> Node for S3Node<S> {
                     "read() failed to load file data of ino={} and name={:?}, the error is: {}",
                     ino,
                     self.get_name(),
-                    crate::common::util::format_anyhow_error(&e),
+                    e,
                 );
                 return Err(e);
             }
@@ -1157,7 +1172,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> Node for S3Node<S> {
         self.dec_open_count();
     }
 
-    async fn setattr_precheck(&self, param: SetAttrParam) -> anyhow::Result<(bool, FileAttr)> {
+    async fn setattr_precheck(&self, param: SetAttrParam) -> DatenLordResult<(bool, FileAttr)> {
         let mut attr = self.get_attr();
 
         let st_now = SystemTime::now();

--- a/src/async_fuse/util.rs
+++ b/src/async_fuse/util.rs
@@ -6,7 +6,7 @@ use std::mem::MaybeUninit;
 use std::os::raw::{c_char, c_int};
 use std::{io, ptr, slice};
 
-use anyhow::Context;
+use crate::common::error::{DatenLordError, DatenLordResult};
 use memchr::memchr;
 use nix::errno::Errno;
 use nix::sys::stat::SFlag;
@@ -23,8 +23,10 @@ pub fn format_nix_error(error: nix::Error) -> String {
 /// # Errors
 ///
 /// Return the built `Err(anyhow::Error(..))`
-pub fn build_error_result_from_errno<T>(error_code: Errno, err_msg: String) -> anyhow::Result<T> {
-    Err(error_code).context(err_msg)
+pub fn build_error_result_from_errno<T>(error_code: Errno, err_msg: String) -> DatenLordResult<T> {
+    Err(DatenLordError::from(
+        anyhow::Error::new(error_code).context(err_msg),
+    ))
 }
 
 /// Convert `nix::errno::Errno` to `c_int`

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -200,6 +200,15 @@ pub enum DatenLordError {
         context: Vec<String>,
     },
 
+    /// Error caused by datenlord's internal logic
+    #[error("InternalErr, the error is {:?} context is {:#?}", .source,.context)]
+    InternalErr {
+        /// Error srouce
+        source: anyhow::Error,
+        /// Context of the error
+        context: Vec<String>,
+    },
+
     /// API is not implemented
     #[error("Not implemented, context is {:#?}", .context)]
     Unimplemented {
@@ -294,6 +303,7 @@ impl DatenLordError {
                 SerdeJsonErr,
                 JoinErr,
                 TransactionRetryLimitExceededErr,
+                InternalErr,
                 Unimplemented
             ]
         );
@@ -335,6 +345,7 @@ implement_from!(std::time::SystemTimeError, SystemTimeErr);
 implement_from!(grpcio::Error, GrpcioErr);
 implement_from!(serde_json::Error, SerdeJsonErr);
 implement_from!(tokio::task::JoinError, JoinErr);
+implement_from!(anyhow::Error, InternalErr);
 
 impl From<DatenLordError> for RpcStatusCode {
     #[inline]
@@ -351,6 +362,7 @@ impl From<DatenLordError> for RpcStatusCode {
             | DatenLordError::SerdeJsonErr { .. }
             | DatenLordError::WalkdirErr { .. }
             | DatenLordError::TransactionRetryLimitExceededErr { .. }
+            | DatenLordError::InternalErr { .. }
             | DatenLordError::JoinErr { .. } => Self::INTERNAL,
             DatenLordError::GrpcioErr { source, .. } => match source {
                 grpcio::Error::RpcFailure(ref s) => s.code(),


### PR DESCRIPTION
# Description:
This pull request refactors the error handling of the DatenLord to align with the general error handling approach of the project.
Previously, the MetaData trait was returning results of type anyhow::Result, while other parts of the codebase were returning DatenLordResult, leading to an interface mismatch and increased complexity. Additionally, using anyhow::Result provided no error type information, making it difficult to discern the exact nature of the error.
We've added a new error type, InternalErr, under DatenLordError. This new error type contains the source anyhow::Error and its context Vec<String>, effectively encapsulating the original anyhow::Error.
# Changes:
- Refactored  functions that were returning anyhow::Result to now return DatenLordResult with the appropriate error type.
- Added InternalErr under DatenLordError to encapsulate anyhow::Error and its context.
- Updated all relevant error handling and propagation logic to match the new error handling approach.
Please review these changes and provide any feedback you may have. We're happy to make further adjustments as necessary.