### PR TITLE
 Introduction of Utility Code for KV Rebuild Metadata Usage

### DIFF
--- a/src/async_fuse/memfs/inode.rs
+++ b/src/async_fuse/memfs/inode.rs
@@ -8,6 +8,8 @@ use std::ops::Add;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+use super::kv_engine::KVEngine;
+
 // Check the inode number management design at here ：https://github.com/datenlord/datenlord/issues/349
 
 /// Inode management related state.
@@ -104,7 +106,7 @@ impl InodeState {
     }
 }
 
-impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
+impl<S: S3BackEnd + Send + Sync + 'static, K: KVEngine + 'static> S3MetaData<S, K> {
     /// alloc global conflict free inum for a path
     #[inline]
     pub(crate) async fn inode_get_inum_by_fullpath(&self, fullpath: &str) -> (INum, bool) {

--- a/src/async_fuse/memfs/kv_engine.rs
+++ b/src/async_fuse/memfs/kv_engine.rs
@@ -28,12 +28,12 @@ impl ValueType {
     #[allow(dead_code)]
     /// Turn the `ValueType` into `SerialNode` then into `S3Node`.
     // Notice : If the value is not `ValueType::Node`, it will panic
-    pub fn into_s3_node<S: S3BackEnd + Send + Sync + 'static>(
+    pub async fn into_s3_node<S: S3BackEnd + Send + Sync + 'static>(
         self,
         meta: &S3MetaData<S>,
     ) -> S3Node<S> {
         match self {
-            ValueType::Node(node) => S3Node::from_serial_node(node, meta),
+            ValueType::Node(node) => S3Node::from_serial_node(node, meta).await,
             ValueType::DirEntry(_) | ValueType::INum(_) | ValueType::Attr(_) => {
                 panic!("expect ValueType::Node but get {self:?}");
             }

--- a/src/async_fuse/memfs/mod.rs
+++ b/src/async_fuse/memfs/mod.rs
@@ -8,7 +8,7 @@ mod fs_util;
 mod inode;
 /// The KV engine module
 #[macro_use]
-mod kv_engine;
+pub mod kv_engine;
 /// fs metadata module
 mod metadata;
 mod node;

--- a/src/async_fuse/memfs/s3_metadata.rs
+++ b/src/async_fuse/memfs/s3_metadata.rs
@@ -73,7 +73,7 @@ pub struct S3MetaData<S: S3BackEnd + Send + Sync + 'static> {
     /// Persist handle
     persist_handle: PersistHandle,
     /// KV engine
-    kv_engine: Arc<dyn KVEngine>,
+    pub(crate) kv_engine: Arc<dyn KVEngine>,
 }
 
 /// Parse S3 info

--- a/src/async_fuse/memfs/s3_metadata.rs
+++ b/src/async_fuse/memfs/s3_metadata.rs
@@ -5,6 +5,7 @@ use super::dist::etcd;
 use super::dist::server::CacheServer;
 use super::fs_util::{self, FileAttr};
 use super::inode::InodeState;
+use super::kv_engine::{EtcdKVEngine, KVEngine, KeyType, ValueType};
 use super::metadata::MetaData;
 use super::node::Node;
 use super::persist::PersistDirContent;
@@ -71,6 +72,8 @@ pub struct S3MetaData<S: S3BackEnd + Send + Sync + 'static> {
     fuse_fd: Mutex<RawFd>,
     /// Persist handle
     persist_handle: PersistHandle,
+    /// KV engine
+    kv_engine: Arc<dyn KVEngine>,
 }
 
 /// Parse S3 info
@@ -113,6 +116,8 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
             node_id,
         ));
 
+        let kv_engine = EtcdKVEngine::new_kv_engine(etcd_arc.get_inner_client_clone());
+
         let meta = Arc::new(Self {
             s3_backend: Arc::clone(&s3_backend),
             cache: RwLock::new(BTreeMap::new()),
@@ -125,6 +130,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
             path2inum: RwLock::new(BTreeMap::new()),
             fuse_fd: Mutex::new(-1_i32),
             persist_handle,
+            kv_engine,
         });
 
         let server = CacheServer::new(
@@ -579,6 +585,114 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
 }
 
 impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
+    #[allow(dead_code)]
+    #[allow(clippy::unwrap_used)]
+    /// Get a node from kv engine by inum
+    pub async fn get_node_from_kv_engine(&self, inum: INum) -> Option<S3Node<S>> {
+        let inum_key = KeyType::INum2Node(inum).get_key();
+        let raw_data = self.kv_engine.get(&inum_key).await.unwrap_or_else(|e| {
+            panic!(
+                "get_node_from_kv_engine() failed to get node of ino={inum} from kv engine, \
+                        error={e:?}"
+            );
+        });
+        let raw_data = raw_data.as_ref()?;
+        // deserialize node
+        Some(
+            serde_json::from_slice::<ValueType>(raw_data)
+                .unwrap_or_else(|e| {
+                    panic!(
+                "get_node_from_kv_engine() failed to deserialize node of ino={inum} from kv engine, \
+                        error={e:?}"
+            );
+                })
+                .into_s3_node(self),
+        )
+    }
+
+    #[allow(dead_code)]
+    /// Set node to kv engine use inum
+    pub async fn set_node_to_kv_engine(&self, inum: INum, node: S3Node<S>) {
+        let inum_key = KeyType::INum2Node(inum).get_key();
+        let node_value = serde_json::to_vec::<ValueType>(&ValueType::Node(node.into_serial_node()))
+            .unwrap_or_else(|e| {
+                panic!(
+                    "set_node_to_kv_engine() failed to serialize node of ino={inum} to kv engine, \
+                        error={e:?}"
+                );
+            });
+        self.kv_engine
+            .set(&inum_key, &node_value)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "set_node_to_kv_engine() failed to set node of ino={inum} to kv engine, \
+                        error={e:?}"
+                );
+            });
+    }
+
+    /// Remove node from kv engine use inum
+    pub async fn remove_node_from_kv_engine(&self, inum: INum) {
+        let inum_key = KeyType::INum2Node(inum).get_key();
+        self.kv_engine.delete(&inum_key).await.unwrap_or_else(|e| {
+            panic!(
+                "remove_node_from_kv_engine() failed to remove node of ino={inum} from kv engine, \
+                        error={e:?}"
+            );
+        });
+    }
+
+    #[allow(dead_code)]
+    #[allow(clippy::unwrap_used)]
+    /// Get inum from kv engine use full path
+    pub async fn get_inum_from_kv_engine(&self, full_path: &str) -> Option<INum> {
+        let full_path_key = KeyType::Path2INum(full_path.to_owned()).get_key();
+        let raw_data = self
+            .kv_engine
+            .get(&full_path_key)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "get_inum_from_kv_engine() failed to get inum of full_path={full_path} from kv engine, \
+                    error={e:?}"
+                );
+            });
+        let raw_data = raw_data.as_ref()?;
+        // deserialize inum
+        Some(
+            serde_json::from_slice::<ValueType>(raw_data).unwrap_or_else(|e| {
+                panic!(
+                    "get_inum_from_kv_engine() failed to deserialize inum of full_path={full_path} from kv engine, \
+                        error={e:?}"
+                );
+            }).into_inum()
+        )
+    }
+
+    #[allow(dead_code)]
+    /// Set inum to kv engine use full path
+    async fn set_inum_to_kv_engine(&self, full_path: &str, inum: INum) {
+        let full_path_key = KeyType::Path2INum(full_path.to_owned()).get_key();
+        let inum_value = serde_json::to_vec::<ValueType>(&ValueType::INum(inum)).unwrap_or_else(
+            |e| {
+                panic!(
+                    "set_inum_to_kv_engine() failed to serialize inum of full_path={full_path} to kv engine, \
+                        error={e:?}"
+                );
+            },
+        );
+        self.kv_engine
+            .set(&full_path_key, &inum_value)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "set_inum_to_kv_engine() failed to set inum of full_path={full_path} to kv engine, \
+                        error={e:?}"
+                );
+            });
+    }
+
     /// Get parent content from cache and do the persist operation.
     /// This function will try to get the lock, so make sure there's no deadlock.
     async fn load_parent_from_cache_and_mark_dirty(&self, parent: INum) {

--- a/src/async_fuse/memfs/serial.rs
+++ b/src/async_fuse/memfs/serial.rs
@@ -20,6 +20,8 @@ pub struct SerialDirEntry {
 }
 
 impl SerialDirEntry {
+    #[must_use]
+    /// Get the child inode number
     pub fn get_child_ino(&self) -> INum {
         self.file_attr.get_ino()
     }
@@ -59,6 +61,8 @@ pub struct SerialFileAttr {
 }
 
 impl SerialFileAttr {
+    #[must_use]
+    /// Get the inode number
     pub fn get_ino(&self) -> INum {
         self.ino
     }

--- a/src/async_fuse/memfs/serial.rs
+++ b/src/async_fuse/memfs/serial.rs
@@ -16,7 +16,13 @@ pub struct SerialDirEntry {
     /// The entry name
     name: String,
     /// File attr
-    file_attr: SerialFileAttr,
+    pub(crate) file_attr: SerialFileAttr,
+}
+
+impl SerialDirEntry {
+    pub fn get_child_ino(&self) -> INum {
+        self.file_attr.get_ino()
+    }
 }
 
 /// Serializable `FileAttr`
@@ -50,6 +56,12 @@ pub struct SerialFileAttr {
     rdev: u32,
     /// Flags (macOS only, see chflags(2))
     flags: u32,
+}
+
+impl SerialFileAttr {
+    pub fn get_ino(&self) -> INum {
+        self.ino
+    }
 }
 
 /// Serializable `SFlag`

--- a/src/async_fuse/mod.rs
+++ b/src/async_fuse/mod.rs
@@ -13,6 +13,8 @@ pub mod metrics;
 pub mod proactor;
 pub mod util;
 
+use memfs::kv_engine::EtcdKVEngine;
+
 /// Start async-fuse
 pub async fn start_async_fuse(
     etcd_delegate: EtcdDelegate,
@@ -48,7 +50,7 @@ pub async fn start_async_fuse(
         }
         VolumeType::S3 => {
             let (fs, fs_controller): (
-                memfs::MemFs<memfs::S3MetaData<S3BackEndImpl>>,
+                memfs::MemFs<memfs::S3MetaData<S3BackEndImpl, EtcdKVEngine>>,
                 FsController,
             ) = memfs::MemFs::new(
                 &args.volume_info,
@@ -66,7 +68,7 @@ pub async fn start_async_fuse(
         }
         VolumeType::None => {
             let (fs, fs_controller): (
-                memfs::MemFs<memfs::S3MetaData<DoNothingImpl>>,
+                memfs::MemFs<memfs::S3MetaData<DoNothingImpl, EtcdKVEngine>>,
                 FsController,
             ) = memfs::MemFs::new(
                 &args.volume_info,

--- a/src/async_fuse/test/test_util.rs
+++ b/src/async_fuse/test/test_util.rs
@@ -1,4 +1,5 @@
 use crate::async_fuse::fuse::{file_system, session};
+use crate::async_fuse::memfs::kv_engine::EtcdKVEngine;
 use crate::common::etcd_delegate::EtcdDelegate;
 use log::{debug, info}; // warn, error
 use std::fs;
@@ -43,7 +44,7 @@ pub async fn setup(mount_dir: &Path, is_s3: bool) -> anyhow::Result<tokio::task:
             let etcd_delegate = EtcdDelegate::new(vec![TEST_ETCD_ENDPOINT.to_owned()]).await?;
             if is_s3 {
                 let (fs, fs_ctrl): (
-                    memfs::MemFs<memfs::S3MetaData<DoNothingImpl>>,
+                    memfs::MemFs<memfs::S3MetaData<DoNothingImpl, EtcdKVEngine>>,
                     file_system::FsController,
                 ) = memfs::MemFs::new(
                     TEST_VOLUME_INFO,
@@ -59,7 +60,7 @@ pub async fn setup(mount_dir: &Path, is_s3: bool) -> anyhow::Result<tokio::task:
                 ss.run().await?;
             } else {
                 let (fs, fs_ctrl): (
-                    memfs::MemFs<memfs::S3MetaData<DoNothingImpl>>,
+                    memfs::MemFs<memfs::S3MetaData<DoNothingImpl, EtcdKVEngine>>,
                     file_system::FsController,
                 ) = memfs::MemFs::new(
                     mount_point

--- a/src/common/etcd_delegate.rs
+++ b/src/common/etcd_delegate.rs
@@ -409,4 +409,11 @@ impl EtcdDelegate {
             .add_context("failed to delete all data from etcd")?;
         Ok(())
     }
+
+    /// Get the inner etcd client's clone
+    #[must_use]
+    #[inline]
+    pub fn get_inner_client_clone(&self) -> etcd_client::Client {
+        self.etcd_rs_client.clone()
+    }
 }


### PR DESCRIPTION
This Pull Request introduces some utility code to facilitate future usage of kv rebuild metadata. Here are the specific changes:

* Added traversal get and set functions for metadata. These are designed to replace the two BTreeMaps previously held by metadata.

* Modified the process for deserializing directories. Now, during deserialization, we will scan through the FillAttr of its child nodes.

* Introduced an `S3NodeWrap` structure. This is intended for handling synchronization of modifications after a node is fetched remotely.
