### PR TITLE
Replace etcd_client mod with more robust lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ crossbeam-channel = "0.5.0"
 crossbeam-queue = "0.3.1"
 crossbeam-utils = "0.8.1"
 env_logger = "0.10.0"
-etcd-client = { git = "https://github.com/datenlord/etcd-client", rev = "216ca33" }
 event-listener = "2.5.1"
 flate2 = "1.0.16"
 futures = "0.3.5"
@@ -64,7 +63,8 @@ uuid = { version = "1.1.1", features = ["v4"] }
 walkdir = "2.3.1"
 tokio = { version = "1.19.2", features = ["full"] }
 # The version of smol should be same as the etcd-client used
-smol = "1.2.4" 
+smol = "1.2.4"
+etcd-client = "0.11.1"
 
 [build-dependencies]
 protoc-grpcio = "3.0.0"

--- a/src/common/async_fuse_error.rs
+++ b/src/common/async_fuse_error.rs
@@ -1,0 +1,10 @@
+//! `DatenLord` async fuse error of different mod
+use thiserror::Error;
+
+/// Error caused by `async_fuse::memfs::kv_engine`
+#[derive(Error, Debug)]
+pub enum KVEngineError {
+    /// Error caused by std::io::Error
+    #[error("Timeout arg in kv operation is <= 0")]
+    WrongTimeoutArg,
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,5 +1,6 @@
 //! Common library
 
+pub mod async_fuse_error;
 pub mod error;
 pub mod etcd_delegate;
 /// Utility module


### PR DESCRIPTION
The old etcd client has a cache layer which is not needed and there's some bugs and unlmplemented features, which takes too much effort from the main project. But the mock etcd is still kept for unit test.