### PR TITLE
Replace KVEngine generics with KVEngineType

### DIFF
--- a/src/async_fuse/memfs/kv_engine.rs
+++ b/src/async_fuse/memfs/kv_engine.rs
@@ -8,6 +8,10 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::{fmt, time::Duration};
 
+/// The `KVEngineType` is used to provide support for metadata.
+/// We use this alias to avoid tem
+pub type KVEngineType = EtcdKVEngine;
+
 use std::sync::Arc;
 
 use super::serial::{SerialDirEntry, SerialFileAttr, SerialNode};
@@ -32,9 +36,9 @@ impl ValueType {
     /// Turn the `ValueType` into `SerialNode` then into `S3Node`.
     /// # Panics
     /// Panics if `ValueType` is not `ValueType::Node`.
-    pub async fn into_s3_node<S: S3BackEnd + Send + Sync + 'static, K: KVEngine + 'static>(
+    pub async fn into_s3_node<S: S3BackEnd + Send + Sync + 'static>(
         self,
-        meta: &S3MetaData<S, K>,
+        meta: &S3MetaData<S>,
     ) -> S3Node<S> {
         match self {
             ValueType::Node(node) => S3Node::from_serial_node(node, meta).await,

--- a/src/async_fuse/mod.rs
+++ b/src/async_fuse/mod.rs
@@ -13,8 +13,6 @@ pub mod metrics;
 pub mod proactor;
 pub mod util;
 
-use memfs::kv_engine::EtcdKVEngine;
-
 /// Start async-fuse
 pub async fn start_async_fuse(
     etcd_delegate: EtcdDelegate,
@@ -50,7 +48,7 @@ pub async fn start_async_fuse(
         }
         VolumeType::S3 => {
             let (fs, fs_controller): (
-                memfs::MemFs<memfs::S3MetaData<S3BackEndImpl, EtcdKVEngine>>,
+                memfs::MemFs<memfs::S3MetaData<S3BackEndImpl>>,
                 FsController,
             ) = memfs::MemFs::new(
                 &args.volume_info,
@@ -68,7 +66,7 @@ pub async fn start_async_fuse(
         }
         VolumeType::None => {
             let (fs, fs_controller): (
-                memfs::MemFs<memfs::S3MetaData<DoNothingImpl, EtcdKVEngine>>,
+                memfs::MemFs<memfs::S3MetaData<DoNothingImpl>>,
                 FsController,
             ) = memfs::MemFs::new(
                 &args.volume_info,

--- a/src/async_fuse/test/test_util.rs
+++ b/src/async_fuse/test/test_util.rs
@@ -1,5 +1,4 @@
 use crate::async_fuse::fuse::{file_system, session};
-use crate::async_fuse::memfs::kv_engine::EtcdKVEngine;
 use crate::common::etcd_delegate::EtcdDelegate;
 use log::{debug, info}; // warn, error
 use std::fs;
@@ -44,7 +43,7 @@ pub async fn setup(mount_dir: &Path, is_s3: bool) -> anyhow::Result<tokio::task:
             let etcd_delegate = EtcdDelegate::new(vec![TEST_ETCD_ENDPOINT.to_owned()]).await?;
             if is_s3 {
                 let (fs, fs_ctrl): (
-                    memfs::MemFs<memfs::S3MetaData<DoNothingImpl, EtcdKVEngine>>,
+                    memfs::MemFs<memfs::S3MetaData<DoNothingImpl>>,
                     file_system::FsController,
                 ) = memfs::MemFs::new(
                     TEST_VOLUME_INFO,
@@ -60,7 +59,7 @@ pub async fn setup(mount_dir: &Path, is_s3: bool) -> anyhow::Result<tokio::task:
                 ss.run().await?;
             } else {
                 let (fs, fs_ctrl): (
-                    memfs::MemFs<memfs::S3MetaData<DoNothingImpl, EtcdKVEngine>>,
+                    memfs::MemFs<memfs::S3MetaData<DoNothingImpl>>,
                     file_system::FsController,
                 ) = memfs::MemFs::new(
                     mount_point


### PR DESCRIPTION
After `datenlord` is launched, there is only one possibility for `KVEngine`, which means it is fixed. We use type aliases to fix it and avoid using generics. If we want to replace it later, we only need to replace this type alias, which is similar to manually instantiating a generic.