### PR TITLE
Improve Datenlord for fstest Compatibility

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,6 +42,8 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
         run: cargo llvm-cov --codecov --output-path codecov.info
+      - name: Print Integration Test Logs
+        run: cat datenlord.log
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ fuse_bench/*
 bench.log
 .vscode/*
 localtest.sh
+*.log

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,10 +59,10 @@ thiserror = "1.0.22"
 tiny_http = "0.10.0"
 uuid = { version = "1.1.1", features = ["v4"] }
 walkdir = "2.3.1"
-tokio = { version = "1.19.2", features = ["full"] }
+tokio = { version = "1.32.0", features = ["full"] }
 # The version of smol should be same as the etcd-client used
 smol = "1.2.4"
-etcd-client = "0.11.1"
+etcd-client = "0.11"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 

--- a/src/async_fuse/fuse/mount.rs
+++ b/src/async_fuse/fuse/mount.rs
@@ -174,7 +174,7 @@ async fn fuser_mount(mount_point: &Path) -> anyhow::Result<RawFd> {
             .arg("-o")
             // fusermount option allow_other only allowed if user_allow_other is set in
             // /etc/fuse.conf
-            .arg("nosuid,nodev,allow_other") // rw,async,noatime,noexec,auto_unmount,allow_other
+            .arg("nosuid,nodev,allow_other,default_permissions") // rw,async,noatime,noexec,auto_unmount,allow_other
             .arg(mount_path.as_os_str())
             .env("_FUSE_COMMFD", remote.to_string())
             .output()

--- a/src/async_fuse/memfs/fs_util.rs
+++ b/src/async_fuse/memfs/fs_util.rs
@@ -7,12 +7,16 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::Context;
 use clippy_utilities::Cast;
+use nix::errno::Errno;
 use nix::fcntl::{self, OFlag};
 use nix::sys::stat::{self, FileStat, Mode, SFlag};
 use tracing::debug;
 
 use super::dir::{Dir, DirEntry};
 use crate::async_fuse::fuse::protocol::{FuseAttr, INum};
+use crate::async_fuse::util::build_error_result_from_errno;
+use crate::common::error::DatenLordResult;
+use crate::common::util;
 
 /// File attributes
 #[derive(Copy, Clone, Debug)]
@@ -67,6 +71,62 @@ impl FileAttr {
             rdev: 0,
             flags: 0,
         }
+    }
+
+    /// ```
+    ///     File permissions in Unix/Linux systems are represented as a 12-bit structure, laid out as follows:
+    ///     ┌─────────────┬─────────┬─────────┬─────────┐
+    ///     │   Special   │  User   │  Group  │  Other  │
+    ///     ├─────────────┼─────────┼─────────┼─────────┤
+    ///     │2 Bits       │3 Bits   │3 Bits   │3 Bits   │
+    ///     ├─────────────┼─────────┼─────────┼─────────┤
+    ///     │suid |sgid   │r  w  x  │r  w  x  │r  w  x  │
+    ///     └──────┬──────┴───┬────┴───┬────┴───┬──────┘
+    ///            │          │        │        │
+    ///            │          │        │        └─ Other: Read, Write, Execute permissions for users
+    ///            |          |        |                   other than the owner or members of the group.
+    ///            │          │        └─ Group: Read, Write, Execute permissions for group members.
+    ///            │          └─ User: Read, Write, Execute permissions for the owner of the file.
+    ///            └─ Special: Set User ID (suid) and Set Group ID (sgid).
+    ///  The suid and sgid bits are beyond the scope of a simple permissions
+    ///  check and are not considered in this function.
+    /// ```
+    pub fn check_perm(&self, user_id: u32, group_id: u32, access_mode: u8) -> DatenLordResult<()> {
+        debug_assert!(
+            access_mode <= 0o7 && access_mode != 0,
+            "check_perm() found access_mode={access_mode} invalid",
+        );
+        if user_id == 0 {
+            return Ok(());
+        }
+
+        let file_mode = self.get_access_mode(user_id, group_id);
+        debug!(
+            "check_perm() got access_mode={access_mode} and file_mode={file_mode} \
+            from uid={user_id} gid={group_id}",
+        );
+        if file_mode & access_mode != access_mode {
+            return build_error_result_from_errno(
+                Errno::EACCES,
+                format!("check_perm() failed {user_id} {group_id} {file_mode}"),
+            );
+        }
+        Ok(())
+    }
+
+    /// For given uid and gid, get the access mode of the file
+    #[allow(clippy::default_numeric_fallback)]
+    #[allow(clippy::integer_arithmetic)]
+    fn get_access_mode(&self, user_id: u32, group_id: u32) -> u8 {
+        let perm = self.perm;
+        let mode = if user_id == self.uid {
+            (perm >> 6) & 0o7
+        } else if group_id == self.gid {
+            (perm >> 3) & 0o7
+        } else {
+            perm & 0o7
+        };
+        mode.cast()
     }
 }
 
@@ -255,7 +315,7 @@ pub fn time_from_system_time(system_time: &SystemTime) -> (u64, u32) {
                 "time_from_system_time() failed to convert SystemTime={:?} \
                 to timestamp(seconds, nano-seconds), the error is: {}",
                 system_time,
-                crate::common::util::format_anyhow_error(&e),
+                util::format_anyhow_error(&e),
             )
         });
     (duration.as_secs(), duration.subsec_nanos())
@@ -344,4 +404,57 @@ pub async fn load_file_data(fd: RawFd, offset: usize, len: usize) -> anyhow::Res
     .await??;
     debug_assert_eq!(file_data_vec.len(), len);
     Ok(file_data_vec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[allow(clippy::assertions_on_result_states)]
+    fn test_permission_check() {
+        let file = FileAttr {
+            ino: 0,
+            size: 0,
+            blocks: 0,
+            atime: SystemTime::now(),
+            mtime: SystemTime::now(),
+            ctime: SystemTime::now(),
+            crtime: SystemTime::now(),
+            kind: SFlag::S_IFREG,
+            perm: 0o741,
+            nlink: 0,
+            uid: 1000,
+            gid: 1000,
+            rdev: 0,
+            flags: 0,
+        };
+
+        // Owner permission checks
+        assert!(file.check_perm(1000, 1001, 7).is_ok());
+        assert!(file.check_perm(1000, 1001, 6).is_ok());
+        assert!(file.check_perm(1000, 1001, 5).is_ok());
+        assert!(file.check_perm(1000, 1001, 4).is_ok());
+        assert!(file.check_perm(1000, 1001, 3).is_ok());
+        assert!(file.check_perm(1000, 1001, 2).is_ok());
+        assert!(file.check_perm(1000, 1001, 1).is_ok());
+
+        // Group permission checks
+        assert!(file.check_perm(1001, 1000, 7).is_err());
+        assert!(file.check_perm(1001, 1000, 6).is_err());
+        assert!(file.check_perm(1001, 1000, 5).is_err());
+        assert!(file.check_perm(1001, 1000, 4).is_ok());
+        assert!(file.check_perm(1001, 1000, 3).is_err());
+        assert!(file.check_perm(1001, 1000, 2).is_err());
+        assert!(file.check_perm(1001, 1000, 1).is_err());
+
+        // Other permission checks
+        assert!(file.check_perm(1002, 1002, 7).is_err());
+        assert!(file.check_perm(1002, 1002, 6).is_err());
+        assert!(file.check_perm(1002, 1002, 5).is_err());
+        assert!(file.check_perm(1002, 1002, 4).is_err());
+        assert!(file.check_perm(1002, 1002, 3).is_err());
+        assert!(file.check_perm(1002, 1002, 2).is_err());
+        assert!(file.check_perm(1002, 1002, 1).is_ok());
+    }
 }

--- a/src/async_fuse/memfs/fs_util.rs
+++ b/src/async_fuse/memfs/fs_util.rs
@@ -105,7 +105,7 @@ impl FileAttr {
             "check_perm() got access_mode={access_mode} and file_mode={file_mode} \
             from uid={user_id} gid={group_id}",
         );
-        if file_mode & access_mode != access_mode {
+        if (file_mode & access_mode) != access_mode {
             return build_error_result_from_errno(
                 Errno::EACCES,
                 format!("check_perm() failed {user_id} {group_id} {file_mode}"),

--- a/src/async_fuse/memfs/fs_util.rs
+++ b/src/async_fuse/memfs/fs_util.rs
@@ -74,22 +74,22 @@ impl FileAttr {
     }
 
     /// ```
-    ///     File permissions in Unix/Linux systems are represented as a 12-bit structure, laid out as follows:
-    ///     ┌─────────────┬─────────┬─────────┬─────────┐
-    ///     │   Special   │  User   │  Group  │  Other  │
-    ///     ├─────────────┼─────────┼─────────┼─────────┤
-    ///     │2 Bits       │3 Bits   │3 Bits   │3 Bits   │
-    ///     ├─────────────┼─────────┼─────────┼─────────┤
-    ///     │suid |sgid   │r  w  x  │r  w  x  │r  w  x  │
-    ///     └──────┬──────┴───┬────┴───┬────┴───┬──────┘
-    ///            │          │        │        │
-    ///            │          │        │        └─ Other: Read, Write, Execute permissions for users
-    ///            |          |        |                   other than the owner or members of the group.
-    ///            │          │        └─ Group: Read, Write, Execute permissions for group members.
-    ///            │          └─ User: Read, Write, Execute permissions for the owner of the file.
-    ///            └─ Special: Set User ID (suid) and Set Group ID (sgid).
-    ///  The suid and sgid bits are beyond the scope of a simple permissions
-    ///  check and are not considered in this function.
+    /// File permissions in Unix/Linux systems are represented as a 12-bit structure,
+    /// laid out as follows:
+    /// ┌───────────────┬─────────┬─────────┬─────────┐
+    /// │   Special     │  User   │  Group  │  Other  │
+    /// ├───────────────┼─────────┼─────────┼─────────┤
+    /// │   3 Bits      │ 3 Bits  │ 3 Bits  │ 3 Bits  │
+    /// ├───────────────┼─────────┼─────────┼─────────┤
+    /// │ suid|sgid|stky│  r w x  │  r w x  │  r w x  │
+    /// └──────┬───────┴────┬────┴────┬────┴────┬────┘
+    ///        │             │         │         │
+    ///        │             │         │         └─ Other: Read, Write, Execute permissions for other users.
+    ///        │             │         └─ Group: Read, Write, Execute permissions for group members.
+    ///        │             └─ User:  Read, Write, Execute permissions for the owner of the file.
+    ///        └─ Special: Set User ID (suid), Set Group ID (sgid), and Sticky Bit (stky).
+    /// When Sticky Bit set on a directory, files in that directory may only be unlinked or -
+    /// renamed by root or the directory owner or the file owner.
     /// ```
     pub fn check_perm(&self, user_id: u32, group_id: u32, access_mode: u8) -> DatenLordResult<()> {
         debug_assert!(

--- a/src/async_fuse/memfs/kv_engine/mod.rs
+++ b/src/async_fuse/memfs/kv_engine/mod.rs
@@ -114,7 +114,6 @@ impl ValueType {
 /// If you want to add a new type of value, you need to add a new variant to the
 /// enum. And you need to add a new match arm to the `get_key` function , make
 /// sure the key is unique.
-#[allow(dead_code)]
 #[derive(Debug, Eq, PartialEq)]
 pub enum KeyType {
     /// INum -> SerailNode
@@ -127,8 +126,6 @@ pub enum KeyType {
     INum2Attr(INum),
     /// IdAllocator value key
     IdAllocatorValue(IdType),
-    /// Csi related key
-    Csi(String),
     /// Node ip and port info : node_id -> "{node_ipaddr}:{port}"
     /// The corresponding value type is ValueType::String
     NodeIpPort(String),
@@ -163,7 +160,6 @@ impl Display for KeyType {
             KeyType::IdAllocatorValue(ref id_type) => {
                 write!(f, "IdAllocatorValue{{unique_id: {id_type:?}}}")
             }
-            KeyType::Csi(ref s) => write!(f, "Csi{{s: {s}}}"),
             KeyType::NodeIpPort(ref s) => write!(f, "NodeIpPort{{s: {s}}}"),
             KeyType::VolumeInfo(ref s) => write!(f, "VolumeInfo{{s: {s}}}"),
             KeyType::FileNodeList(ref s) => write!(f, "FileNodeList{{s: {s:?}}}"),
@@ -212,7 +208,6 @@ impl KeyType {
             KeyType::Path2INum(ref p) => serialize_key(2, p),
             KeyType::INum2Attr(ref i) => serialize_key(3, i),
             KeyType::IdAllocatorValue(ref id_type) => serialize_key(4, &id_type.to_unique_id()),
-            KeyType::Csi(ref s) => serialize_key(5, s),
             KeyType::NodeIpPort(ref s) => serialize_key(6, s),
             KeyType::VolumeInfo(ref s) => serialize_key(8, s),
             KeyType::FileNodeList(ref s) => serialize_key(10, s),
@@ -238,7 +233,6 @@ impl LockKeyType {
 pub trait MetaTxn {
     /// Get the value by the key.
     /// Notice : do not get the same key twice in one transaction.
-    #[must_use]
     async fn get(&mut self, key: &KeyType) -> DatenLordResult<Option<ValueType>>;
     /// Set the value by the key.
     fn set(&mut self, key: &KeyType, value: &ValueType);

--- a/src/async_fuse/memfs/metadata.rs
+++ b/src/async_fuse/memfs/metadata.rs
@@ -36,6 +36,15 @@ const MY_TTL_SEC: u64 = 3600; // TODO: should be a long value, say 1 hour
 /// The generation ID of FUSE attributes
 const MY_GENERATION: u64 = 1; // TODO: find a proper way to set generation
 
+/// The context of a request contains the uid and gid
+#[derive(Debug, Clone)]
+pub struct ReqContext {
+    /// The uid of the user who sends the request
+    pub user_id: u32,
+    /// The gid of the user who sends the request
+    pub group_id: u32,
+}
+
 /// MetaData of fs
 #[async_trait]
 pub trait MetaData {
@@ -73,6 +82,7 @@ pub trait MetaData {
     /// Helper function to lookup
     async fn lookup_helper(
         &self,
+        context: ReqContext,
         parent: INum,
         name: &str,
     ) -> DatenLordResult<(Duration, FuseAttr, u64)>;
@@ -108,6 +118,7 @@ pub trait MetaData {
     /// Set Node's attribute
     async fn setattr_helper(
         &self,
+        context: ReqContext,
         ino: u64,
         param: SetAttrParam,
     ) -> DatenLordResult<(Duration, FuseAttr)>;
@@ -119,7 +130,7 @@ pub trait MetaData {
     async fn getattr(&self, ino: u64) -> DatenLordResult<(Duration, FuseAttr)>;
 
     /// Open a file or directory by ino and flags
-    async fn open(&self, ino: u64, flags: u32) -> DatenLordResult<RawFd>;
+    async fn open(&self, context: ReqContext, ino: u64, flags: u32) -> DatenLordResult<RawFd>;
 
     /// Forget a i-node by ino
     async fn forget(&self, ino: u64, nlookup: u64);
@@ -140,22 +151,23 @@ pub trait MetaData {
     async fn releasedir(&self, ino: u64, fh: u64);
 
     /// Statfs helper
-    async fn statfs(&self, ino: u64) -> DatenLordResult<StatFsParam>;
+    async fn statfs(&self, context: ReqContext, ino: u64) -> DatenLordResult<StatFsParam>;
 
     /// Helper function to readlink
     async fn readlink(&self, ino: u64) -> Vec<u8>;
 
     /// Helper function to opendir
-    async fn opendir(&self, ino: u64, flags: u32) -> DatenLordResult<RawFd>;
+    async fn opendir(&self, context: ReqContext, ino: u64, flags: u32) -> DatenLordResult<RawFd>;
 
     /// Helper function to readdir
     async fn readdir(
         &self,
+        context: ReqContext,
         ino: u64,
         fh: u64,
         offset: i64,
-        reply: ReplyDirectory,
-    ) -> nix::Result<usize>;
+        reply: &mut ReplyDirectory,
+    ) -> DatenLordResult<()>;
 
     /// Helper function to release
     async fn release(&self, ino: u64, fh: u64, flags: u32, lock_owner: u64, flush: bool);
@@ -204,11 +216,12 @@ impl MetaData for DefaultMetaData {
 
     async fn readdir(
         &self,
+        _context: ReqContext,
         ino: u64,
         _fh: u64,
         offset: i64,
-        mut reply: ReplyDirectory,
-    ) -> nix::Result<usize> {
+        reply: &mut ReplyDirectory,
+    ) -> DatenLordResult<()> {
         let mut readdir_helper = |data: &BTreeMap<String, DirEntry>| -> usize {
             let mut num_child_entries = 0;
             for (i, (child_name, child_entry)) in data.iter().enumerate().skip(offset.cast()) {
@@ -242,17 +255,7 @@ impl MetaData for DefaultMetaData {
             );
         });
         if inode.need_load_dir_data() {
-            let load_res = inode.load_data(0_usize, 0_usize).await;
-            if let Err(e) = load_res {
-                debug!(
-                    "readdir() failed to load the data for directory of ino={} and name={:?}, \
-                        the error is: {:?}",
-                    ino,
-                    inode.get_name(),
-                    e
-                );
-                return reply.error(e).await;
-            }
+            inode.load_data(0_usize, 0_usize).await?;
         }
         let num_child_entries = inode.read_dir(&mut readdir_helper);
         debug!(
@@ -262,10 +265,10 @@ impl MetaData for DefaultMetaData {
             ino,
             inode.get_name(),
         );
-        reply.ok().await
+        Ok(())
     }
 
-    async fn opendir(&self, ino: u64, flags: u32) -> DatenLordResult<RawFd> {
+    async fn opendir(&self, context: ReqContext, ino: u64, flags: u32) -> DatenLordResult<RawFd> {
         let cache = self.cache().read().await;
         let node = cache.get(&ino).unwrap_or_else(|| {
             panic!(
@@ -273,6 +276,8 @@ impl MetaData for DefaultMetaData {
                     the i-node of ino={ino} should be in cache",
             );
         });
+        node.get_attr()
+            .check_perm(context.user_id, context.group_id, 1)?;
         let o_flags = fs_util::parse_oflag(flags);
         node.dup_fd(o_flags).await
     }
@@ -288,7 +293,7 @@ impl MetaData for DefaultMetaData {
         node.get_symlink_target().as_os_str().to_owned().into_vec()
     }
 
-    async fn statfs(&self, ino: u64) -> DatenLordResult<StatFsParam> {
+    async fn statfs(&self, _context: ReqContext, ino: u64) -> DatenLordResult<StatFsParam> {
         let cache = self.cache().read().await;
         let node = cache.get(&ino).unwrap_or_else(|| {
             panic!(
@@ -363,7 +368,7 @@ impl MetaData for DefaultMetaData {
         return Ok(inode.get_file_data(offset.cast(), size.cast()).await);
     }
 
-    async fn open(&self, ino: u64, flags: u32) -> DatenLordResult<RawFd> {
+    async fn open(&self, _context: ReqContext, ino: u64, flags: u32) -> DatenLordResult<RawFd> {
         let cache = self.cache().read().await;
         let node = cache.get(&ino).unwrap_or_else(|| {
             panic!(
@@ -434,6 +439,7 @@ impl MetaData for DefaultMetaData {
 
     async fn setattr_helper(
         &self,
+        context: ReqContext,
         ino: u64,
         param: SetAttrParam,
     ) -> DatenLordResult<(Duration, FuseAttr)> {
@@ -446,7 +452,10 @@ impl MetaData for DefaultMetaData {
             );
         });
 
-        match inode.setattr_precheck(param).await {
+        match inode
+            .setattr_precheck(param, context.user_id, context.group_id)
+            .await
+        {
             Ok((attr_changed, file_attr)) => {
                 if attr_changed {
                     inode.set_attr(file_attr);
@@ -792,6 +801,7 @@ impl MetaData for DefaultMetaData {
     /// Helper function to lookup
     async fn lookup_helper(
         &self,
+        _context: ReqContext,
         parent: INum,
         child_name: &str,
     ) -> DatenLordResult<(Duration, FuseAttr, u64)> {

--- a/src/async_fuse/memfs/metadata.rs
+++ b/src/async_fuse/memfs/metadata.rs
@@ -526,7 +526,6 @@ impl MetaData for DefaultMetaData {
             .canonicalize()
             .with_context(|| format!("failed to canonicalize the mount path={root_path:?}"))
             .unwrap_or_else(|e| panic!("{}", e));
-
         let root_path = root_path
             .as_os_str()
             .to_str()

--- a/src/async_fuse/memfs/metadata.rs
+++ b/src/async_fuse/memfs/metadata.rs
@@ -74,6 +74,7 @@ pub trait MetaData {
     /// Helper function to remove node
     async fn remove_node_helper(
         &self,
+        context: ReqContext,
         parent: INum,
         node_name: &str,
         node_type: SFlag,
@@ -88,10 +89,18 @@ pub trait MetaData {
     ) -> DatenLordResult<(Duration, FuseAttr, u64)>;
 
     /// Rename helper to exchange on disk
-    async fn rename_exchange_helper(&self, param: RenameParam) -> DatenLordResult<()>;
+    async fn rename_exchange_helper(
+        &self,
+        context: ReqContext,
+        param: RenameParam,
+    ) -> DatenLordResult<()>;
 
     /// Rename helper to move on disk, it may replace destination entry
-    async fn rename_may_replace_helper(&self, param: RenameParam) -> DatenLordResult<()>;
+    async fn rename_may_replace_helper(
+        &self,
+        context: ReqContext,
+        param: RenameParam,
+    ) -> DatenLordResult<()>;
 
     /// Helper function of fsync
     async fn fsync_helper(&self, ino: u64, fh: u64, datasync: bool) -> DatenLordResult<()>;
@@ -124,7 +133,7 @@ pub trait MetaData {
     ) -> DatenLordResult<(Duration, FuseAttr)>;
 
     /// Helper function to unlink
-    async fn unlink(&self, parent: INum, name: &str) -> DatenLordResult<()>;
+    async fn unlink(&self, context: ReqContext, parent: INum, name: &str) -> DatenLordResult<()>;
 
     /// Get attribute of i-node by ino
     async fn getattr(&self, ino: u64) -> DatenLordResult<(Duration, FuseAttr)>;
@@ -484,7 +493,7 @@ impl MetaData for DefaultMetaData {
         }
     }
 
-    async fn unlink(&self, parent: INum, name: &str) -> DatenLordResult<()> {
+    async fn unlink(&self, _context: ReqContext, parent: INum, name: &str) -> DatenLordResult<()> {
         let entry_type = {
             let cache = self.cache().read().await;
             let parent_node = cache.get(&parent).unwrap_or_else(|| {
@@ -508,7 +517,8 @@ impl MetaData for DefaultMetaData {
             entry_type
         };
 
-        self.remove_node_helper(parent, name, entry_type).await
+        self.remove_node_helper(_context, parent, name, entry_type)
+            .await
     }
 
     async fn new(
@@ -704,6 +714,7 @@ impl MetaData for DefaultMetaData {
     /// Helper function to remove node
     async fn remove_node_helper(
         &self,
+        _context: ReqContext,
         parent: INum,
         node_name: &str,
         node_type: SFlag,
@@ -894,7 +905,11 @@ impl MetaData for DefaultMetaData {
     }
 
     /// Rename helper to exchange on disk
-    async fn rename_exchange_helper(&self, param: RenameParam) -> DatenLordResult<()> {
+    async fn rename_exchange_helper(
+        &self,
+        _context: ReqContext,
+        param: RenameParam,
+    ) -> DatenLordResult<()> {
         let old_parent = param.old_parent;
         let old_name = param.old_name.as_str();
         let new_parent = param.new_parent;
@@ -992,7 +1007,11 @@ impl MetaData for DefaultMetaData {
     }
 
     /// Rename helper to move on disk, it may replace destination entry
-    async fn rename_may_replace_helper(&self, param: RenameParam) -> DatenLordResult<()> {
+    async fn rename_may_replace_helper(
+        &self,
+        _context: ReqContext,
+        param: RenameParam,
+    ) -> DatenLordResult<()> {
         let old_parent = param.old_parent;
         let old_name = param.old_name;
         let new_parent = param.new_parent;

--- a/src/async_fuse/memfs/mod.rs
+++ b/src/async_fuse/memfs/mod.rs
@@ -245,14 +245,14 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         reply: ReplyEntry,
     ) -> nix::Result<usize> {
         debug!("lookup(parent={}, name={:?}, req={:?})", parent, name, req,);
-        let context = ReqContext {
-            user_id: req.uid(),
-            group_id: req.gid(),
-        };
         // check the dir_name is valid
         if let Err(e) = check_name_length(name) {
             return reply.error(e).await;
         }
+        let context = ReqContext {
+            user_id: req.uid(),
+            group_id: req.gid(),
+        };
         let lookup_res = self.metadata.lookup_helper(context, parent, name).await;
         match lookup_res {
             Ok((ttl, fuse_attr, generation)) => {

--- a/src/async_fuse/memfs/node.rs
+++ b/src/async_fuse/memfs/node.rs
@@ -103,8 +103,8 @@ pub trait Node: Sized {
         inum: INum,
         child_dir_name: &str,
         mode: Mode,
-        uid: u32,
-        gid: u32,
+        user_id: u32,
+        group_id: u32,
     ) -> DatenLordResult<Self>;
     /// Open file in a directory
     async fn open_child_file(
@@ -114,8 +114,8 @@ pub trait Node: Sized {
         oflags: OFlag,
         global_cache: Arc<GlobalCache>,
     ) -> DatenLordResult<Self>;
-    /// Create file in a directory
     #[allow(clippy::too_many_arguments)]
+    /// Create file in a directory
     async fn create_child_file(
         &mut self,
         inum: INum,
@@ -156,7 +156,12 @@ pub trait Node: Sized {
     /// Close dir
     async fn closedir(&self, ino: INum, fh: u64);
     /// Precheck before set attr
-    async fn setattr_precheck(&self, param: SetAttrParam) -> DatenLordResult<(bool, FileAttr)>;
+    async fn setattr_precheck(
+        &self,
+        param: SetAttrParam,
+        uid: u32,
+        gid: u32,
+    ) -> DatenLordResult<(bool, FileAttr)>;
     /// Mark as deferred deletion
     fn mark_deferred_deletion(&self);
     /// If node is marked as deferred deletion
@@ -1420,7 +1425,12 @@ impl Node for DefaultNode {
 
     /// Precheck before set attr
     #[allow(clippy::too_many_lines)]
-    async fn setattr_precheck(&self, param: SetAttrParam) -> DatenLordResult<(bool, FileAttr)> {
+    async fn setattr_precheck(
+        &self,
+        param: SetAttrParam,
+        _uid: u32,
+        _gid: u32,
+    ) -> DatenLordResult<(bool, FileAttr)> {
         let fd = self.get_fd();
         let mut attr = self.get_attr();
 

--- a/src/async_fuse/memfs/s3_node.rs
+++ b/src/async_fuse/memfs/s3_node.rs
@@ -14,6 +14,7 @@ use futures::future::{BoxFuture, FutureExt};
 use nix::errno::Errno;
 use nix::fcntl::OFlag;
 use nix::sys::stat::{Mode, SFlag};
+use nix::unistd;
 use parking_lot::RwLock;
 use tracing::debug;
 
@@ -438,6 +439,8 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3Node<S> {
                     ctime: now,
                     crtime: now,
                     kind: SFlag::S_IFDIR,
+                    uid: unistd::getuid().as_raw(),
+                    gid: unistd::getgid().as_raw(),
                     ..FileAttr::default()
                 }));
 


### PR DESCRIPTION
This pull request consists of a series of commits designed to enhance the compatibility of the entire project with the fstest test suite. The focus is on resolving issues and adding features that allow the project to pass fstest, excluding tests related to unsupported file types.

Key Changes
**Add File Permission Check**: Implemented a feature to validate file permissions across the project.
**Add default_permission Mount Option**: Incorporated the default_permission mount option globally.
**Fix Node Update Bug**: Addressed an issue where nodes were not updated after lookup.
**Set Current User as Owner During Mount**:  Set the current user as the owner when mounting any filesystem.
Issues Resolved
#400 
#397 