### PR TITLE
test: add fio data verification test

### DIFF
--- a/scripts/perf/fio-perf-test.sh
+++ b/scripts/perf/fio-perf-test.sh
@@ -36,3 +36,7 @@ fio-plot -i ${BLOCK_SIZES_DIRS} -T "Different Block Size Read" -C --rw randread 
 bench-fio --target ${TEST_DIR} --type directory --size 5M --output ${OUTPUT_DIR} --iodepth 1 --block-size 4k --numjobs ${THREAD_NUMS} --engine sync --direct 1 --destructive
 fio-plot -i ${OUTPUT_SUBDIR}/4k/  -T "Different Thread Num Write" -N --rw randwrite -o ${OUTPUT_DIR}/4k_multithread_write.png
 fio-plot -i ${OUTPUT_SUBDIR}/4k/  -T "Different Thread Num Read" -N --rw randread -o ${OUTPUT_DIR}/4k_multithread_read.png
+
+# Test the correctness of the data
+export WRITE_AND_VERIFY_FILE=${TEST_DIR}/write_and_verify_file
+fio write_and_verify.fio

--- a/scripts/perf/write_and_verify.fio
+++ b/scripts/perf/write_and_verify.fio
@@ -1,0 +1,13 @@
+# The most basic form of data verification. Write the device randomly
+# in 4K chunks, then read it back and verify the contents.
+[write-and-verify]
+filename=${WRITE_AND_VERIFY_FILE}
+rw=randwrite
+bs=4k
+direct=1
+ioengine=libaio
+iodepth=16
+verify=crc32c
+size=128K
+do_verify=1
+exitall_on_error=1


### PR DESCRIPTION
Use crc32 to verify the correctness of the data.

Ref:
https://github.com/axboe/fio/blob/a142e0df6c1483a76d92ff7f9d8c07242af9910e/examples/basic-verify.fio