### PR TITLE
refactor: remove useless S3 interface wrapper

### DIFF
--- a/src/async_fuse/memfs/metadata.rs
+++ b/src/async_fuse/memfs/metadata.rs
@@ -980,23 +980,6 @@ impl MetaData for DefaultMetaData {
             });
             exchanged_node.set_parent_ino(old_parent);
             exchanged_node.set_name(old_name);
-            let exchanged_attr = exchanged_node
-                .load_attribute()
-                .await
-                .context(format!(
-                    "rename_exchange_helper() failed to load attribute of \
-                        to i-node of ino={new_entry_ino} and name={new_name:?} under parent directory",
-                ))
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "rename_exchange_helper() failed to load attributed of to i-node of ino={} and name={:?}, \
-                            the error is: {}",
-                        exchanged_node.get_ino(), exchanged_node.get_name(),
-                        crate::common::util::format_anyhow_error(&e),
-                    )
-                });
-            debug_assert_eq!(exchanged_attr.ino, exchanged_node.get_ino());
-            debug_assert_eq!(exchanged_attr.ino, new_entry_ino);
             panic!("rename2 system call has not been supported in libc to exchange two nodes yet!");
         } else {
             panic!(
@@ -1071,21 +1054,6 @@ impl MetaData for DefaultMetaData {
             });
             moved_node.set_parent_ino(new_parent);
             moved_node.set_name(&new_name);
-            let moved_attr = moved_node
-                .load_attribute()
-                .await
-                .context(format!(
-                    "rename_may_replace_helper() failed to \
-                    load attribute of old entry i-node of ino={old_entry_ino}",
-                ))
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "rename() failed, the error is: {}",
-                        crate::common::util::format_anyhow_error(&e)
-                    )
-                });
-            debug_assert_eq!(moved_attr.ino, moved_node.get_ino());
-            debug_assert_eq!(moved_attr.ino, old_entry_ino);
             debug!(
                 "rename_may_replace_helper() successfully moved the from i-node \
                 of ino={} and name={:?} under from parent ino={} to \

--- a/src/async_fuse/memfs/node.rs
+++ b/src/async_fuse/memfs/node.rs
@@ -64,8 +64,6 @@ pub trait Node: Sized {
     fn get_lookup_count(&self) -> i64;
     /// Decrease node lookup count
     fn dec_lookup_count_by(&self, nlookup: u64) -> i64;
-    /// Load node attr
-    async fn load_attribute(&mut self) -> DatenLordResult<FileAttr>;
     /// Flush node data
     async fn flush(&mut self, ino: INum, fh: u64);
     /// Duplicate fd
@@ -611,20 +609,6 @@ impl Node for DefaultNode {
     /// If node is marked as deferred deletion
     fn is_deferred_deletion(&self) -> bool {
         self.deferred_deletion.load(Ordering::Relaxed)
-    }
-
-    /// Load attribute
-    async fn load_attribute(&mut self) -> DatenLordResult<FileAttr> {
-        let attr = fs_util::load_attr(self.fd).await.context(format!(
-            "load_attribute() failed to get the attribute of the node ino={}",
-            self.get_ino(),
-        ))?;
-        match self.data {
-            DefaultNodeData::Directory(..) => debug_assert_eq!(SFlag::S_IFDIR, attr.kind),
-            DefaultNodeData::RegFile(..) => debug_assert_eq!(SFlag::S_IFREG, attr.kind),
-            DefaultNodeData::SymLink(..) => debug_assert_eq!(SFlag::S_IFLNK, attr.kind),
-        };
-        Ok(attr)
     }
 
     /// flush node data

--- a/src/async_fuse/memfs/s3_metadata.rs
+++ b/src/async_fuse/memfs/s3_metadata.rs
@@ -1423,23 +1423,6 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
             });
             exchanged_node.set_parent_ino(old_parent);
             exchanged_node.set_name(old_name);
-            let exchanged_attr = exchanged_node.
-                load_attribute()
-               .await
-               .context(format!(
-                    "rename_exchange_helper() failed to load attribute of \
-                        to i-node of ino={new_entry_ino} and name={new_name:?} under parent directory",
-                ))
-               .unwrap_or_else(|e| {
-                    panic!(
-                        "rename_exchange_helper() failed to load attributed of to i-node of ino={} and name={:?}, \
-                            the error is: {}",
-                        exchanged_node.get_ino(), exchanged_node.get_name(),
-                        crate::common::util::format_anyhow_error(&e),
-                    )
-                });
-            debug_assert_eq!(exchanged_attr.ino, exchanged_node.get_ino());
-            debug_assert_eq!(exchanged_attr.ino, new_entry_ino);
             panic!("rename2 system call has not been supported in libc to exchange two nodes yet!");
         } else {
             panic!(


### PR DESCRIPTION
As we've moved the metadata system to the kv storage, the metadata related S3 interface is useless. So let's remove it.