### PR TITLE
Fix: Remove Excessive Usage of `panic!` in memfs Metadata Files

### DIFF
--- a/src/async_fuse/memfs/kv_engine/mod.rs
+++ b/src/async_fuse/memfs/kv_engine/mod.rs
@@ -51,7 +51,7 @@ impl ValueType {
     pub async fn into_s3_node<S: S3BackEnd + Send + Sync + 'static>(
         self,
         meta: &S3MetaData<S>,
-    ) -> S3Node<S> {
+    ) -> DatenLordResult<S3Node<S>> {
         match self {
             ValueType::Node(node) => S3Node::from_serial_node(node, meta).await,
             _ => {

--- a/src/async_fuse/memfs/metadata.rs
+++ b/src/async_fuse/memfs/metadata.rs
@@ -24,6 +24,44 @@ pub struct ReqContext {
     pub group_id: u32,
 }
 
+
+pub(crate) mod error {
+    //! A module containing helper functions to build errors.
+
+    use super::{INum, SFlag};
+    use crate::common::error::DatenLordError;
+
+    /// A helper function to build [`DatenLordError::InconsistentFS`] with default context.
+    pub(crate) fn build_inconsistent_fs(ino: INum, fn_name: &str) -> DatenLordError {
+        DatenLordError::InconsistentFS {
+            context: vec![format!(
+                "{ino}() found fs is inconsistent, the inode ino={fn_name} is not in cache.",
+            )],
+        }
+    }
+
+    /// A helper function to build [`DatenLordError::InconsistentFS`] with custom context.
+    pub(crate) fn build_inconsistent_fs_with_context(
+        fn_name: &str,
+        context: &str,
+    ) -> DatenLordError {
+        DatenLordError::InconsistentFS {
+            context: vec![format!("{fn_name}() found fs is inconsistent: {context}",)],
+        }
+    }
+
+    /// A helper function to build [`DatenLordError::UnsupportedINodeType`].
+    pub(crate) fn build_unsupported_inode_type(
+        node_type: SFlag,
+        context: String,
+    ) -> DatenLordError {
+        DatenLordError::UnsupportedINodeType {
+            node_type,
+            context: vec![context],
+        }
+    }
+}
+
 /// MetaData of fs
 #[async_trait]
 pub trait MetaData {

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -251,7 +251,7 @@ pub enum DatenLordError {
         context: Vec<String>,
     },
     /// An i-node type is not supported by the executing operation.
-    #[error("Unsuported i-node type={:?}, context id {:#?}.", .node_type, .context)]
+    #[error("Unsupported i-node type={:?}, context id {:#?}.", .node_type, .context)]
     UnsupportedINodeType {
         /// Type of the node
         node_type: SFlag,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@
     clippy::module_name_repetitions, // repeation of module name in a struct name is not big deal
     clippy::multiple_crate_versions, // multi-version dependency crates is not able to fix
     clippy::panic, // allow debug_assert, panic in production code
+    clippy::unreachable,  // Use `unreachable!` instead of `panic!` when impossible cases occurs
     // clippy::panic_in_result_fn,
     clippy::separated_literal_suffix, // conflict with unseparated_literal_suffix
     clippy::shadow_unrelated, //it’s a common pattern in Rust code

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@
     clippy::module_name_repetitions, // repeation of module name in a struct name is not big deal
     clippy::multiple_crate_versions, // multi-version dependency crates is not able to fix
     clippy::panic, // allow debug_assert, panic in production code
+    clippy::unreachable,  // Use `unreachable!` instead of `panic!` when impossible cases occurs
     // clippy::panic_in_result_fn,
     clippy::missing_errors_doc, // TODO: add error docs
     clippy::exhaustive_structs,


### PR DESCRIPTION
This PR aims to fix a problem of excessive usage of `panic!` in `async_fuse/memfs/s3_metadata.rs`, raised by #376 .