### PR TITLE
feat: implement exchange rename and remove some dead code

### DIFF
--- a/.github/workflows/ci-7-23.yml
+++ b/.github/workflows/ci-7-23.yml
@@ -1,0 +1,85 @@
+name: CI-7-23
+on:
+    pull_request:
+        branches: [master]
+
+env:
+    CI_RUST_TOOLCHAIN: 1.67.1
+    CONTROLLER_SOCKET_FILE: /tmp/controller.sock
+    BIND_MOUNTER: target/debug/bind_mounter
+    ETCD_CONTAINER_NAME: etcd
+    ETCD_IMAGE: gcr.io/etcd-development/etcd:v3.4.13
+    NODE_SOCKET_FILE: /tmp/node.sock
+    RUST_BACKTRACE: full
+    RUST_LOG: debug
+    DATENLORD_LOCAL_BIND_DIR: /tmp/datenlord_data_dir
+
+jobs:
+    check:
+        name: Check
+        runs-on: ubuntu-latest
+        steps:
+          - name: Install CSI dependencies
+            run: |
+              sudo apt update
+              sudo apt install -y cmake g++ libprotobuf-dev protobuf-compiler
+          - uses: actions/checkout@v2
+          - uses: actions-rs/toolchain@v1
+            with:
+              profile: minimal
+              toolchain: ${{ env.CI_RUST_TOOLCHAIN }}
+              override: true
+          - uses: Swatinem/rust-cache@v2
+          - uses: actions-rs/cargo@v1
+            with:
+              command: check
+              args: -F abi-7-23
+  
+    fstest:
+      needs: ["check"]
+      name: fstest
+      runs-on: ubuntu-latest
+      steps:
+        - name: Install CSI dependencies
+          run: |
+            sudo apt update
+            sudo apt install -y cmake g++ libprotobuf-dev protobuf-compiler
+        - name: Set up Docker
+          id: buildx
+          uses: docker/setup-buildx-action@v1
+          with:
+            version: latest
+        - name: Check out code
+          uses: actions/checkout@v2
+        - name: Prepare Rust environment
+          uses: actions-rs/toolchain@v1
+          with:
+            profile: minimal
+            toolchain: ${{ env.CI_RUST_TOOLCHAIN }}
+            override: true
+        - uses: Swatinem/rust-cache@v2
+        - name: Cargo build
+          uses: actions-rs/cargo@v1
+          with:
+            command: build
+            args: -F abi-7-23
+        - name: Enable bind_mounter permission
+          run: |
+            sudo chown root:root $BIND_MOUNTER
+            sudo chmod u+s $BIND_MOUNTER
+            ls -lsh $BIND_MOUNTER
+            export ETCD_END_POINT=127.0.0.1:2379
+            export BIND_MOUNTER=`realpath $BIND_MOUNTER`
+        - name: Modify fuse.conf
+          run: sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
+        - name: Run Datenlord in the background locally.
+          run: |
+            ./scripts/setup/start_local_node.sh "-F abi-7-23" &
+        - name: Build fstest
+          run: |
+            cd /home/runner/work/datenlord/datenlord/tests/fstest_dir/
+            make
+        - name: Run fstest
+          run: |
+            cd $DATENLORD_LOCAL_BIND_DIR
+            sudo prove -rv /home/runner/work/datenlord/datenlord/tests/fstest_dir/tests/

--- a/scripts/setup/start_local_node.sh
+++ b/scripts/setup/start_local_node.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+# scripts/setup/start_local_node.sh [build_flags]
+#
+# The parameter `build_flags` will be passed to `cargo build` in this scripts
+# when building DatenLord. You should put all options in quotes.
+#
+# For example, run `scripts/setup/start_local_node.sh`, this script will just simply run `cargo build` without any option.
+# But run `scripts/setup/start_local_node.sh "-F abi-7-23"`, this script will run `cargo build -F abi-7-23` to build DatenLord.
+
 export CONTROLLER_SOCKET_FILE=/tmp/controller.sock
 export BIND_MOUNTER=../target/debug/bind_mounter
 export NODE_SOCKET_FILE=/tmp/node.sock
@@ -8,6 +16,9 @@ export RUST_LOG=debug
 export RUST_BACKTRACE=1
 export ETCD_END_POINT=127.0.0.1:2379
 export BIND_MOUNTER=`realpath $BIND_MOUNTER`
+
+# build flags with `cargo build`
+BUILD_FLAGS=$1
 
 . scripts/setup/config.sh
 . scripts/setup/setup_etcd.sh
@@ -32,7 +43,7 @@ fi
 
 echo "==> Start to deploy datenlord locally"
 echo "==> Building datenlord"
-cargo build
+cargo build $BUILD_FLAGS
 if [ $? -ne 0 ]; then
   echo "Failed to build datenlord."
   exit 1

--- a/src/async_fuse/fuse/abi_marker.rs
+++ b/src/async_fuse/fuse/abi_marker.rs
@@ -171,7 +171,7 @@ mark_sized_types! {@kernel size_check: check_abi_7_21,
     FuseDirEntPlus,
 }
 
-// #[cfg(feature = "abi-7-23")]
+#[cfg(feature = "abi-7-23")]
 mark_sized_types! {@kernel size_check: check_abi_7_23,
     FuseRename2In,
 }

--- a/src/async_fuse/fuse/protocol.rs
+++ b/src/async_fuse/fuse/protocol.rs
@@ -557,7 +557,7 @@ pub enum FuseOpCode {
     // #[cfg(feature = "abi-7-21")]
     FUSE_READDIRPLUS = 44,
     /// Rename2
-    // #[cfg(feature = "abi-7-23")]
+    #[cfg(feature = "abi-7-23")]
     FUSE_RENAME2 = 45,
     /// Find next data or hole after the specified offset
     // #[cfg(feature = "abi-7-24")]
@@ -784,7 +784,13 @@ pub struct FuseRenameIn {
 }
 
 /// FUSE rename2 request input `fuse_rename2_in`
-// #[cfg(feature = "abi-7-23")]
+///
+/// Available when the protocol version is greater than 7.22.
+/// This is checked by the kernel so that the app won't receive such a request.
+///
+/// See [here](https://github.com/torvalds/linux/blob/8f6f76a6a29f36d2f3e4510d0bde5046672f6924/fs/fuse/dir.c#L1077C2-L1088C3)
+/// for the source code of checking.
+#[cfg(feature = "abi-7-23")]
 #[derive(Debug)]
 #[repr(C)]
 pub struct FuseRename2In {

--- a/src/async_fuse/fuse/session.rs
+++ b/src/async_fuse/fuse/session.rs
@@ -817,7 +817,7 @@ async fn dispatch<'a>(
             error!("ReadDirPlus not implemented, arg={:?}", arg);
             not_implement_helper(req, fd).await
         }
-        // #[cfg(feature = "abi-7-23")]
+        #[cfg(feature = "abi-7-23")]
         Operation::Rename2 {
             arg,
             oldname,

--- a/src/async_fuse/memfs/kv_engine/etcd_impl.rs
+++ b/src/async_fuse/memfs/kv_engine/etcd_impl.rs
@@ -368,7 +368,7 @@ mod test {
             .await
             .unwrap();
         // insert a key , and then get it , and then delete it, and then get it again
-        let key = KeyType::Path2INum("test_key".to_owned());
+        let key = KeyType::String("test_key".to_owned());
         let value = ValueType::INum(123);
         client.set(&key, &value, None).await.unwrap();
         let get_value = client.get(&key).await.unwrap().unwrap();
@@ -390,9 +390,9 @@ mod test {
             .await
             .unwrap();
         let mut first_txn = client.new_meta_txn().await;
-        let key1 = KeyType::Path2INum(String::from("test_commit key1"));
+        let key1 = KeyType::String(String::from("test_commit key1"));
         let value1 = ValueType::INum(12);
-        let key2 = KeyType::Path2INum(String::from("test_commit key2"));
+        let key2 = KeyType::String(String::from("test_commit key2"));
         let value2 = ValueType::INum(13);
         first_txn.set(&key1, &value1);
         first_txn.set(&key2, &value2);
@@ -408,7 +408,7 @@ mod test {
                     .await
                     .unwrap();
                 let mut second_txn = client.new_meta_txn().await;
-                let key1 = KeyType::Path2INum(String::from("test_commit key1"));
+                let key1 = KeyType::String(String::from("test_commit key1"));
                 let value1 = second_txn.get(&key1).await.unwrap();
                 assert!(value1.is_some());
                 if let Some(ValueType::INum(num)) = value1 {
@@ -420,7 +420,7 @@ mod test {
                 first_step_tx.send(()).await.unwrap();
                 // wait for the third txn to set the key
                 second_step_rx.recv().await.unwrap();
-                let key2 = KeyType::Path2INum(String::from("test_commit key2"));
+                let key2 = KeyType::String(String::from("test_commit key2"));
                 let value2 = second_txn.get(&key2).await.unwrap();
                 assert!(value2.is_some());
                 if let Some(ValueType::INum(num)) = value2 {
@@ -444,7 +444,7 @@ mod test {
             let mut third_txn = client.new_meta_txn().await;
             // wait for the second read first key and send the signal
             first_step_rx.recv().await.unwrap();
-            let key1 = KeyType::Path2INum(String::from("test_commit key1"));
+            let key1 = KeyType::String(String::from("test_commit key1"));
             let value1 = ValueType::INum(14);
             third_txn.set(&key1, &value1);
             third_txn.commit().await.unwrap();
@@ -462,7 +462,7 @@ mod test {
                 .await
                 .unwrap();
             let mut txn = client.new_meta_txn().await;
-            let key = KeyType::Path2INum(String::from("/"));
+            let key = KeyType::String(String::from("/"));
             let _ = txn.get(&key).await.unwrap();
             (txn.commit().await, ())
         });

--- a/src/async_fuse/memfs/kv_engine/mod.rs
+++ b/src/async_fuse/memfs/kv_engine/mod.rs
@@ -25,6 +25,9 @@ pub mod etcd_impl;
 pub mod kv_utils;
 
 /// The `ValueType` is used to provide support for metadata.
+///
+/// The variants `DirEntry`, `INum` and `Attr` are not used currently,
+/// but preserved for the future.
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub enum ValueType {
     /// SerialNode
@@ -120,8 +123,6 @@ pub enum KeyType {
     INum2Node(INum),
     /// INum -> DirEntry
     INum2DirEntry(INum),
-    /// Path -> Inum
-    Path2INum(String),
     /// INum -> SerialFileAttr
     INum2Attr(INum),
     /// IdAllocator value key
@@ -135,6 +136,9 @@ pub enum KeyType {
     /// Node list
     /// The corresponding value type is ValueType::RawData
     FileNodeList(INum),
+    /// Just a string key for testing the KVEngine.
+    #[cfg(test)]
+    String(String),
 }
 
 // ::<KeyType>::get() -> ValueType
@@ -155,7 +159,8 @@ impl Display for KeyType {
         match *self {
             KeyType::INum2Node(ref i) => write!(f, "INum2Node{{i: {i}}}"),
             KeyType::INum2DirEntry(ref i) => write!(f, "INum2DirEntry{{i: {i}}}"),
-            KeyType::Path2INum(ref p) => write!(f, "Path2INum{{p: {p}}}"),
+            #[cfg(test)]
+            KeyType::String(ref s) => write!(f, "String{{s: {s}}}"),
             KeyType::INum2Attr(ref i) => write!(f, "INum2Attr{{i: {i}}}"),
             KeyType::IdAllocatorValue(ref id_type) => {
                 write!(f, "IdAllocatorValue{{unique_id: {id_type:?}}}")
@@ -205,7 +210,8 @@ impl KeyType {
         match *self {
             KeyType::INum2Node(ref i) => serialize_key(0, i),
             KeyType::INum2DirEntry(ref i) => serialize_key(1, i),
-            KeyType::Path2INum(ref p) => serialize_key(2, p),
+            #[cfg(test)]
+            KeyType::String(ref s) => serialize_key(2, s),
             KeyType::INum2Attr(ref i) => serialize_key(3, i),
             KeyType::IdAllocatorValue(ref id_type) => serialize_key(4, &id_type.to_unique_id()),
             KeyType::NodeIpPort(ref s) => serialize_key(6, s),

--- a/src/async_fuse/memfs/metadata.rs
+++ b/src/async_fuse/memfs/metadata.rs
@@ -106,6 +106,7 @@ pub trait MetaData {
     ) -> DatenLordResult<(Duration, FuseAttr, u64)>;
 
     /// Rename helper to exchange on disk
+    #[cfg(feature = "abi-7-23")]
     async fn rename_exchange_helper(
         &self,
         context: ReqContext,

--- a/src/async_fuse/memfs/node.rs
+++ b/src/async_fuse/memfs/node.rs
@@ -33,8 +33,6 @@ pub trait Node: Sized {
     fn set_parent_ino(&mut self, parent: u64) -> INum;
     /// Get node name
     fn get_name(&self) -> &str;
-    /// Get node full path
-    fn get_full_path(&self) -> &str;
     /// Set node name
     fn set_name(&mut self, name: &str);
     /// Get node type

--- a/src/async_fuse/memfs/s3_metadata.rs
+++ b/src/async_fuse/memfs/s3_metadata.rs
@@ -23,7 +23,9 @@ use super::dist::client as dist_client;
 use super::dist::server::CacheServer;
 use super::fs_util::{self, FileAttr};
 use super::id_alloc_used::INumAllocator;
-use super::kv_engine::{KVEngine, KVEngineType, KeyType, MetaTxn, ValueType};
+#[cfg(feature = "abi-7-23")]
+use super::kv_engine::MetaTxn;
+use super::kv_engine::{KVEngine, KVEngineType, KeyType, ValueType};
 use super::metadata::error;
 use super::metadata::{MetaData, ReqContext};
 use super::node::Node;
@@ -673,8 +675,9 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
         Ok((ttl, fuse_attr, MY_GENERATION))
     }
 
-    #[instrument(skip(self), err, ret)]
     /// Rename helper for exchange rename
+    #[instrument(skip(self), err, ret)]
+    #[cfg(feature = "abi-7-23")]
     async fn rename_exchange_helper(
         &self,
         context: ReqContext,
@@ -1092,6 +1095,7 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
     /// - The ino of new entry
     ///
     /// Otherwise, it returns an `Err`.
+    #[cfg(feature = "abi-7-23")]
     async fn exchange_pre_check<T: MetaTxn + ?Sized>(
         &self,
         txn: &mut T,

--- a/src/async_fuse/memfs/s3_node.rs
+++ b/src/async_fuse/memfs/s3_node.rs
@@ -952,9 +952,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> Node for S3Node<S> {
             SFlag::S_IFDIR | SFlag::S_IFREG | SFlag::S_IFLNK => {
                 let ino = removed_entry.ino();
                 if let Err(e) = self.s3_backend.delete_data(ino).await {
-                    panic!(
-                        "failed to delete data of {ino} from s3 backend, error is {e:?}"
-                    );
+                    panic!("failed to delete data of {ino} from s3 backend, error is {e:?}");
                 }
             }
             _ => panic!(

--- a/src/async_fuse/memfs/serial.rs
+++ b/src/async_fuse/memfs/serial.rs
@@ -119,8 +119,6 @@ pub struct SerialNode {
     pub(crate) parent: u64,
     /// S3Node name
     pub(crate) name: String,
-    /// Full path of S3Node
-    pub(crate) full_path: String,
     /// Node attribute
     pub(crate) attr: SerialFileAttr,
     /// Node data

--- a/src/async_fuse/test/integration_tests.rs
+++ b/src/async_fuse/test/integration_tests.rs
@@ -297,6 +297,7 @@ fn test_rename_file_replace(mount_dir: &Path) -> anyhow::Result<()> {
 }
 
 #[cfg(test)]
+#[cfg(feature = "abi-7-23")]
 fn test_rename_exchange(mount_dir: &Path) -> anyhow::Result<()> {
     use nix::{fcntl::RenameFlags, sys::stat};
 
@@ -322,7 +323,7 @@ fn test_rename_exchange(mount_dir: &Path) -> anyhow::Result<()> {
         fs::write(&file_left, "a")?;
         fs::write(file_b_txt, "b")?;
 
-        /* Tree: 
+        /* Tree:
          * exchange
          * |- a.txt
          * |
@@ -342,7 +343,7 @@ fn test_rename_exchange(mount_dir: &Path) -> anyhow::Result<()> {
             rename_flag,
         )?;
 
-        /* Tree: 
+        /* Tree:
          * exchange
          * |- dir (former a.txt)
          * |
@@ -673,6 +674,7 @@ async fn _run_test(mount_dir_str: &str, is_s3: bool) -> anyhow::Result<()> {
     test_bind_mount(mount_dir).context("test_bind_mount() failed")?;
     test_deferred_deletion(mount_dir).context("test_deferred_deletion() failed")?;
     test_rename_file_replace(mount_dir).context("test_rename_file_replace() failed")?;
+    #[cfg(feature = "abi-7-23")]
     test_rename_exchange(mount_dir).context("test_rename_exchange() failed")?;
     test_rename_file(mount_dir).context("test_rename_file() failed")?;
     test_rename_dir(mount_dir).context("test_rename_dir() failed")?;


### PR DESCRIPTION
As "exchange rename" has not yet been implemented, this PR implements it.

There are 3 main proposes in this PR:
1. Remove some dead code about `full_path` from `S3Node`, `S3Metadata` and etcd. 
2. Implement "exchange rename", which can exchange 2 files (may be in different types) atomically, and write an integration test case for it.
3. Mark codes related to FUSE request `Rename2` with feature `abi-7-23`, as `Rename2` is not supported in protocol version lower than 7.23.

Besides, this PR introduces a CI workflow for protocol version 7.23.