### PR TITLE
feat: Introduce `EvictPolicy`, `Storage` and related utilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ smol = "1.2.4"
 etcd-client = "0.11"
 tracing = "0.1"
 tracing-subscriber = "0.3"
+hashlink = "0.8.4"
 
 [build-dependencies]
 protoc-grpcio = "3.0.0"

--- a/src/async_fuse/memfs/cache/block.rs
+++ b/src/async_fuse/memfs/cache/block.rs
@@ -1,0 +1,320 @@
+//! Utilities for blocks.
+
+use std::{fmt::Formatter, sync::Arc};
+
+use aligned_utils::bytes::AlignedBytes;
+use clippy_utilities::OverflowArithmetic;
+use nix::sys::uio::IoVec;
+
+use crate::async_fuse::fuse::fuse_reply::{AsIoVec, CouldBeAsIoVecList};
+use crate::async_fuse::fuse::protocol::INum;
+
+/// Page Size
+const PAGE_SIZE: usize = 4096;
+
+/// A common coordinate to locate a block.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct BlockCoordinate(pub INum, pub usize);
+
+/// Make a partial slice of `u8` slice for debugging.
+fn make_partial_u8_slice(src: &[u8], start: usize, len: usize) -> String {
+    let end = start.overflow_add(len).min(src.len());
+    let show_length = end.overflow_sub(start);
+    let slice = src.get(start..end).unwrap_or(&[]);
+
+    let mut result = String::from("[");
+
+    for (i, &ch) in slice.iter().enumerate() {
+        result.push_str(format!("{ch}").as_str());
+        if i != show_length.overflow_sub(1) {
+            result.push_str(", ");
+        }
+    }
+
+    if end != src.len() {
+        result.push_str(", ...");
+    }
+
+    result.push(']');
+
+    result
+}
+
+/// The minimum unit of data in the storage layers.
+#[derive(Clone)]
+pub struct Block {
+    /// The underlying data of a block. Shared with `Arc`.
+    inner: Arc<AlignedBytes>,
+    /// A flag that if this block is dirty.
+    dirty: bool,
+}
+
+impl std::fmt::Debug for Block {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let inner_slice = make_partial_u8_slice(self.inner.as_ref(), 0, 8);
+
+        let result = format!("Block {{ inner: {inner_slice}, dirty: {} }}", self.dirty());
+
+        write!(f, "{result}")
+    }
+}
+
+impl Block {
+    /// Create a block with `capacity`, which usually equals the `block_size` of storage manager.
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        Block {
+            inner: Arc::new(AlignedBytes::new_zeroed(capacity, PAGE_SIZE)),
+            dirty: false,
+        }
+    }
+
+    /// Returns the length of the block, which usually equals the `block_size` of storage manager.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Check if the block is with size of 0.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Get a mutable slice of the underlying data, copy them if there are other blocks hold the same data with `Arc`.
+    /// See also [`Arc::make_mut`](fn@std::sync::Arc::make_mut).
+    pub fn make_mut(&mut self) -> &mut [u8] {
+        Arc::make_mut(&mut self.inner).as_mut()
+    }
+
+    /// Checks if the block is dirty.
+    #[must_use]
+    pub fn dirty(&self) -> bool {
+        self.dirty
+    }
+
+    /// Sets the block to be dirty.
+    pub fn set_dirty(&mut self) {
+        self.dirty = true;
+    }
+}
+
+/// A wrapper for `IoBlock`, which is used for I/O operations
+#[derive(Clone)]
+pub struct IoBlock {
+    /// The inner `Block` that contains data
+    inner: Block,
+    /// The offset for this `Block`
+    offset: usize,
+    /// The end offset for this `Block`
+    end: usize,
+}
+
+impl std::fmt::Debug for IoBlock {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let inner_slice = make_partial_u8_slice(self.as_slice(), 0, 8);
+
+        let result = format!(
+            "IoBlock {{ inner: {inner_slice}, offset: {}, end: {}, dirty: {} }}",
+            self.offset,
+            self.end,
+            self.dirty()
+        );
+
+        write!(f, "{result}")
+    }
+}
+
+impl IoBlock {
+    /// The constructor of `IoBlock`
+    #[must_use]
+    pub fn new(inner: Block, offset: usize, end: usize) -> Self {
+        debug_assert!(offset <= end);
+        debug_assert!(
+            end <= inner.len(),
+            "The end {end} of slice is out of range of the inner block."
+        );
+        Self { inner, offset, end }
+    }
+
+    /// The inner block
+    #[must_use]
+    pub fn block(&self) -> &Block {
+        &self.inner
+    }
+
+    /// The offset of valid bytes of the inner block
+    #[must_use]
+    pub const fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// The end offset of valid bytes of the inner block
+    #[must_use]
+    pub const fn end(&self) -> usize {
+        self.end
+    }
+
+    /// Turn `IoBlock` into slice
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        self.inner
+            .inner
+            .get(self.offset..self.end)
+            .unwrap_or_else(|| {
+                unreachable!(
+                    "`{}..{}` is checked not to be out of range of inner block.",
+                    self.offset, self.end,
+                )
+            })
+    }
+
+    /// Checks if the inner block is dirty.
+    #[must_use]
+    pub fn dirty(&self) -> bool {
+        self.inner.dirty
+    }
+
+    /// Sets the inner block to be dirty.
+    pub fn set_dirty(&mut self) {
+        self.inner.dirty = true;
+    }
+}
+
+#[cfg(test)]
+impl From<Block> for IoBlock {
+    fn from(block: Block) -> Self {
+        let len = block.len();
+        IoBlock::new(block, 0, len)
+    }
+}
+
+impl CouldBeAsIoVecList for IoBlock {}
+
+impl AsIoVec for IoBlock {
+    fn as_io_vec(&self) -> IoVec<&[u8]> {
+        IoVec::from_slice(self.as_slice())
+    }
+
+    fn can_convert(&self) -> bool {
+        true
+    }
+
+    fn len(&self) -> usize {
+        self.end.overflow_sub(self.offset)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clippy_utilities::OverflowArithmetic;
+
+    use crate::async_fuse::fuse::fuse_reply::AsIoVec;
+
+    use super::{Arc, Block, IoBlock};
+
+    const BLOCK_SIZE_IN_BYTES: usize = 8;
+    const BLOCK_CONTENT: &[u8; BLOCK_SIZE_IN_BYTES] = b"foo bar ";
+
+    #[test]
+    fn test_block() {
+        let mut block = Block::new(BLOCK_SIZE_IN_BYTES);
+        assert_eq!(block.len(), BLOCK_SIZE_IN_BYTES);
+        assert!(!block.is_empty());
+
+        block.make_mut().copy_from_slice(BLOCK_CONTENT);
+        assert_eq!(block.inner.get(..), Some(BLOCK_CONTENT.as_slice()));
+
+        let _another_block = block.clone();
+        assert_eq!(Arc::strong_count(&block.inner), 2);
+
+        assert_eq!(
+            format!("{block:?}"),
+            "Block { inner: [102, 111, 111, 32, 98, 97, 114, 32], dirty: false }"
+        );
+    }
+
+    #[test]
+    fn test_small_block() {
+        let mut block = Block::new(4);
+        assert_eq!(block.len(), 4);
+
+        block.make_mut().copy_from_slice(&BLOCK_CONTENT[..4]);
+        assert_eq!(block.inner.get(..), Some(&BLOCK_CONTENT[..4]));
+
+        assert_eq!(
+            format!("{block:?}"),
+            "Block { inner: [102, 111, 111, 32], dirty: false }"
+        );
+    }
+
+    #[test]
+    fn test_large_block() {
+        let mut block = Block::new(BLOCK_SIZE_IN_BYTES.overflow_mul(2));
+        assert_eq!(block.len(), BLOCK_SIZE_IN_BYTES.overflow_mul(2));
+
+        block
+            .make_mut()
+            .copy_from_slice(BLOCK_CONTENT.repeat(2).as_slice());
+
+        assert_eq!(
+            format!("{block:?}"),
+            "Block { inner: [102, 111, 111, 32, 98, 97, 114, 32, ...], dirty: false }"
+        );
+    }
+
+    #[test]
+    fn test_io_block() {
+        let mut block = Block::new(BLOCK_SIZE_IN_BYTES.overflow_mul(2));
+        block
+            .make_mut()
+            .copy_from_slice(BLOCK_CONTENT.repeat(2).as_slice());
+
+        let mut io_block = IoBlock::from(block);
+        assert_eq!(io_block.len(), BLOCK_SIZE_IN_BYTES.overflow_mul(2));
+        assert_eq!(io_block.as_slice(), BLOCK_CONTENT.repeat(2).as_slice());
+
+        io_block.offset = 1;
+        io_block.end = 5;
+        assert_eq!(io_block.len(), 4);
+        assert_eq!(io_block.as_slice(), b"oo b");
+
+        assert_eq!(
+            format!("{io_block:?}"),
+            "IoBlock { inner: [111, 111, 32, 98], offset: 1, end: 5, dirty: false }"
+        );
+
+        io_block.offset = 0;
+        io_block.end = BLOCK_SIZE_IN_BYTES.overflow_mul(2);
+        assert_eq!(
+            format!("{io_block:?}"),
+            "IoBlock { inner: [102, 111, 111, 32, 98, 97, 114, 32, ...], offset: 0, end: 16, dirty: false }"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "out of range")]
+    fn test_io_block_out_of_range() {
+        let io_block = IoBlock::new(Block::new(8), 0, 16);
+        let _: &[u8] = io_block.as_slice();
+    }
+
+    #[test]
+    fn test_dirty_block() {
+        let mut block = Block::new(8);
+        assert!(!block.dirty());
+        block.set_dirty();
+        assert!(block.dirty());
+
+        let io_block = IoBlock::from(block);
+        assert!(io_block.dirty());
+
+        let mut io_block = IoBlock::new(Block::new(8), 0, 8);
+        assert!(!io_block.dirty());
+        io_block.set_dirty();
+        assert!(io_block.dirty());
+    }
+}

--- a/src/async_fuse/memfs/cache/mock.rs
+++ b/src/async_fuse/memfs/cache/mock.rs
@@ -1,0 +1,262 @@
+//! Mock storages for test and local nodes.
+
+use std::collections::{HashMap, HashSet};
+
+use async_trait::async_trait;
+use clippy_utilities::OverflowArithmetic;
+use parking_lot::Mutex;
+
+use crate::async_fuse::fuse::protocol::INum;
+
+use super::{Block, BlockCoordinate, IoBlock, Storage};
+
+/// A "persistent" storage layer in memory.
+#[derive(Debug, Default)]
+pub struct MemoryStorage {
+    /// The inner map of this storage
+    inner: Mutex<HashMap<INum, HashMap<usize, Block>>>,
+    /// Records of the flushed files
+    flushed: Mutex<HashSet<INum>>,
+    /// The size of block
+    block_size: usize,
+}
+
+impl MemoryStorage {
+    /// Creates a memory storage with block size.
+    #[must_use]
+    pub fn new(block_size: usize) -> Self {
+        Self {
+            block_size,
+            ..Default::default()
+        }
+    }
+
+    /// Tests if the storage contains the block of `(ino, block_id)`
+    pub fn contains(&self, ino: INum, block_id: usize) -> bool {
+        self.inner
+            .lock()
+            .get(&ino)
+            .map_or(false, |file| file.contains_key(&block_id))
+    }
+
+    /// Tests if the file is flushed,
+    /// and after being tested, the flushed status of the file will be set to `false` again.
+    pub fn flushed(&self, ino: INum) -> bool {
+        self.flushed.lock().remove(&ino)
+    }
+}
+
+#[async_trait]
+impl Storage for MemoryStorage {
+    async fn load_from_self(&self, ino: INum, block_id: usize) -> Option<Block> {
+        self.inner
+            .lock()
+            .get(&ino)
+            .and_then(|file| file.get(&block_id).cloned())
+    }
+
+    async fn load_from_backend(&self, _: INum, _: usize) -> Option<Block> {
+        None
+    }
+
+    async fn cache_block_from_backend(
+        &self,
+        _: INum,
+        _: usize,
+        _: Block,
+    ) -> Option<(BlockCoordinate, Block)> {
+        unreachable!("`MemoryStorage` does not have a backend.");
+    }
+
+    async fn on_evict(&self, _: INum, _: usize, _: Block) {
+        unreachable!("No block will be evicted from `MemoryStorage`.");
+    }
+
+    async fn store(&self, ino: INum, block_id: usize, block: IoBlock) {
+        let start = block.offset();
+        let end = block.end();
+
+        self.inner
+            .lock()
+            .entry(ino)
+            .or_default()
+            .entry(block_id)
+            .or_insert_with(|| Block::new(self.block_size))
+            .make_mut()
+            .get_mut(start..end)
+            .unwrap_or_else(|| panic!("Out of range"))
+            .copy_from_slice(block.as_slice());
+    }
+
+    async fn remove(&self, ino: INum) {
+        self.inner.lock().remove(&ino);
+    }
+
+    async fn invalidate(&self, _: INum) {}
+
+    async fn flush(&self, ino: INum) {
+        self.flushed.lock().insert(ino);
+    }
+
+    async fn flush_all(&self) {
+        let inner = self.inner.lock();
+        self.flushed.lock().extend(inner.keys());
+    }
+
+    async fn truncate(&self, ino: INum, from_block: usize, to_block: usize, fill_start: usize) {
+        debug_assert!(from_block >= to_block);
+
+        if let Some(file_cache) = self.inner.lock().get_mut(&ino) {
+            for block_id in to_block..from_block {
+                file_cache.remove(&block_id);
+            }
+
+            if to_block > 0 && fill_start < self.block_size {
+                let fill_block_id = to_block.overflow_sub(1);
+                if let Some(block) = file_cache.get_mut(&fill_block_id) {
+                    let fill_len = self.block_size.overflow_sub(fill_start);
+                    let fill_content = vec![0; fill_len];
+                    block
+                        .make_mut()
+                        .get_mut(fill_start..)
+                        .unwrap_or_else(|| {
+                            unreachable!("`fill_start` is checked to be less than block size.")
+                        })
+                        .copy_from_slice(&fill_content);
+                    block.set_dirty();
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use clippy_utilities::OverflowArithmetic;
+
+    use crate::async_fuse::memfs::cache::{Block, IoBlock};
+
+    use super::{MemoryStorage, Storage};
+
+    const BLOCK_SIZE_IN_BYTES: usize = 8;
+    const BLOCK_CONTENT: &[u8; BLOCK_SIZE_IN_BYTES] = b"foo bar ";
+
+    #[tokio::test]
+    async fn test_read_write() {
+        let ino = 0;
+        let block_id = 0;
+        let mut block = Block::new(BLOCK_SIZE_IN_BYTES);
+        block.make_mut().copy_from_slice(BLOCK_CONTENT.as_slice());
+        let io_block = IoBlock::new(block, 0, BLOCK_SIZE_IN_BYTES);
+        let storage = MemoryStorage::new(BLOCK_SIZE_IN_BYTES);
+        storage.store(ino, block_id, io_block).await;
+
+        assert!(storage.contains(ino, block_id));
+        let block = storage
+            .load(ino, block_id)
+            .await
+            .map(IoBlock::from)
+            .unwrap();
+        assert_eq!(block.as_slice(), BLOCK_CONTENT);
+
+        assert!(!storage.contains(ino, 1));
+        let block = storage.load(ino, 1).await;
+        assert!(block.is_none());
+
+        assert!(!storage.contains(1, 1));
+        let block = storage.load(1, 1).await;
+        assert!(block.is_none());
+
+        storage.remove(ino).await;
+        assert!(!storage.contains(ino, block_id));
+        let block = storage.load(ino, block_id).await;
+        assert!(block.is_none());
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "Out of range")]
+    async fn test_ioblock_out_of_range() {
+        let storage = MemoryStorage::new(BLOCK_SIZE_IN_BYTES);
+        let block = Block::new(BLOCK_SIZE_IN_BYTES.overflow_mul(2));
+        let io_block = IoBlock::new(block, 0, BLOCK_SIZE_IN_BYTES.overflow_mul(2));
+
+        storage.store(0, 0, io_block).await;
+    }
+
+    #[tokio::test]
+    async fn test_flush() {
+        let storage = MemoryStorage::new(BLOCK_SIZE_IN_BYTES);
+        storage.flush(0).await;
+        assert!(storage.flushed(0));
+        assert!(!storage.flushed(0));
+
+        storage
+            .store(0, 0, Block::new(BLOCK_SIZE_IN_BYTES).into())
+            .await;
+        storage.flush_all().await;
+        assert!(storage.flushed(0));
+        assert!(!storage.flushed(0));
+    }
+
+    #[tokio::test]
+    async fn test_invalid() {
+        let storage = MemoryStorage::new(BLOCK_SIZE_IN_BYTES);
+        storage.invalidate(0).await;
+    }
+
+    #[tokio::test]
+    async fn test_truncate_whole_blocks() {
+        let storage = MemoryStorage::new(BLOCK_SIZE_IN_BYTES);
+        for block_id in 0..8 {
+            storage
+                .store(0, block_id, Block::new(BLOCK_SIZE_IN_BYTES).into())
+                .await;
+            assert!(storage.contains(0, block_id));
+        }
+
+        storage.truncate(0, 8, 4, BLOCK_SIZE_IN_BYTES).await;
+        for block_id in 0..4 {
+            assert!(storage.contains(0, block_id));
+        }
+        for block_id in 4..8 {
+            assert!(!storage.contains(0, block_id));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_truncate_may_fill() {
+        let storage = MemoryStorage::new(BLOCK_SIZE_IN_BYTES);
+        for block_id in 0..8 {
+            storage
+                .store(0, block_id, Block::new(BLOCK_SIZE_IN_BYTES).into())
+                .await;
+            assert!(storage.contains(0, block_id));
+        }
+
+        let mut block = Block::new(BLOCK_SIZE_IN_BYTES);
+        block.make_mut().copy_from_slice(b"foo bar ");
+        let io_block = IoBlock::new(block, 0, BLOCK_SIZE_IN_BYTES);
+
+        storage.store(0, 3, io_block).await;
+        storage.truncate(0, 8, 4, 4).await;
+
+        let loaded = storage.load(0, 3).await.map(IoBlock::from).unwrap();
+        assert_eq!(loaded.as_slice(), b"foo \0\0\0\0");
+    }
+
+    #[tokio::test]
+    async fn test_truncate_in_the_same_block() {
+        let storage = MemoryStorage::new(BLOCK_SIZE_IN_BYTES);
+
+        let mut block = Block::new(BLOCK_SIZE_IN_BYTES);
+        block.make_mut().copy_from_slice(b"foo bar ");
+        let io_block = IoBlock::new(block, 0, BLOCK_SIZE_IN_BYTES);
+
+        storage.store(0, 0, io_block).await;
+        storage.truncate(0, 1, 1, 4).await;
+
+        let loaded = storage.load(0, 0).await.map(IoBlock::from).unwrap();
+        assert_eq!(loaded.as_slice(), b"foo \0\0\0\0");
+    }
+}

--- a/src/async_fuse/memfs/cache/mod.rs
+++ b/src/async_fuse/memfs/cache/mod.rs
@@ -3,7 +3,9 @@
 // TODO: Remove this after the storage is ready for product env.
 #![allow(dead_code)]
 
+mod block;
 mod global_cache;
 pub mod policy;
 
+pub use block::{Block, BlockCoordinate, IoBlock};
 pub use global_cache::*;

--- a/src/async_fuse/memfs/cache/mod.rs
+++ b/src/async_fuse/memfs/cache/mod.rs
@@ -5,7 +5,35 @@
 
 mod block;
 mod global_cache;
+mod storage;
+
 pub mod policy;
 
 pub use block::{Block, BlockCoordinate, IoBlock};
 pub use global_cache::*;
+pub use storage::Storage;
+
+/// The number of bytes in one KiB.
+pub const KB_SIZE: usize = 1024;
+
+/// The number of bytes in one MiB.
+pub const MB_SIZE: usize = 1024 * KB_SIZE;
+
+/// The number of bytes in one GiB.
+pub const GB_SIZE: usize = 1024 * MB_SIZE;
+
+/// The size of a block.
+pub const BLOCK_SIZE_IN_BYTES: usize = 512 * KB_SIZE;
+
+/// The capacity of `InMemoryCache` in bytes.
+pub const MEMORY_CACHE_CAPACITY_IN_BYTES: usize = 8 * GB_SIZE;
+
+/// The capacity of `InMemoryCache` in blocks.
+pub const MEMORY_CACHE_CAPACITY_IN_BLOCKS: usize =
+    MEMORY_CACHE_CAPACITY_IN_BYTES.wrapping_div(BLOCK_SIZE_IN_BYTES);
+
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+pub use mock::MemoryStorage;

--- a/src/async_fuse/memfs/cache/mod.rs
+++ b/src/async_fuse/memfs/cache/mod.rs
@@ -1,5 +1,9 @@
-//! This is the cache implementation for the memfs
+//! This is the storage managing mechanism implementation for the memfs
+
+// TODO: Remove this after the storage is ready for product env.
+#![allow(dead_code)]
 
 mod global_cache;
+pub mod policy;
 
 pub use global_cache::*;

--- a/src/async_fuse/memfs/cache/policy/lru.rs
+++ b/src/async_fuse/memfs/cache/policy/lru.rs
@@ -1,0 +1,117 @@
+//! The LRU policy implementation.
+
+use super::EvictPolicy;
+use hashlink::LruCache;
+use parking_lot::Mutex;
+use std::hash::Hash;
+
+/// The evict policy based on LRU.
+#[derive(Debug)]
+pub struct LruPolicy<K> {
+    /// The inner hashlink
+    inner: Mutex<LruCache<K, ()>>,
+    /// The capacity of this policy
+    capacity: usize,
+}
+
+impl<K: Hash + Eq> LruPolicy<K> {
+    /// Create a new `LruPolicy` with `capacity`.
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        LruPolicy {
+            inner: Mutex::new(LruCache::new(capacity)),
+            capacity,
+        }
+    }
+}
+
+impl<K: Hash + Eq> EvictPolicy<K> for LruPolicy<K> {
+    fn put(&self, key: K) -> Option<K> {
+        let mut lru = self.inner.lock();
+        let len = lru.len();
+
+        let evicted = if !lru.contains_key(&key) && len == self.capacity {
+            lru.remove_lru()
+        } else {
+            None
+        };
+
+        lru.insert(key, ());
+        evicted.map(|(k, ())| k)
+    }
+
+    fn touch(&self, key: &K) {
+        let _: Option<&()> = self.inner.lock().get(key);
+    }
+
+    fn remove(&self, key: &K) {
+        let _: Option<()> = self.inner.lock().remove(key);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::default_numeric_fallback)]
+mod tests {
+    use super::{EvictPolicy, LruPolicy};
+
+    /// Create a `LruPolicy` of `i32`, with keys `1 -> 2 -> 3`.
+    fn create_lru() -> LruPolicy<i32> {
+        let cache = LruPolicy::<i32>::new(3);
+
+        let mut res;
+        res = cache.put(1);
+        assert_eq!(res, None);
+        res = cache.put(2);
+        assert_eq!(res, None);
+        res = cache.put(3);
+        assert_eq!(res, None);
+
+        cache
+    }
+
+    #[test]
+    fn test_evict() {
+        let cache = create_lru();
+
+        // 1 -> 2 -> 3
+        let res = cache.put(4);
+        assert_eq!(res, Some(1));
+    }
+
+    #[test]
+    fn test_touch() {
+        let cache = create_lru();
+
+        cache.touch(&1);
+
+        // 2 -> 3 -> 1
+        let res = cache.put(4);
+        assert_eq!(res, Some(2));
+    }
+
+    #[test]
+    fn test_touch_by_put() {
+        let cache = create_lru();
+
+        let res = cache.put(1);
+        assert_eq!(res, None);
+
+        // 2 -> 3 -> 1
+        let res = cache.put(4);
+        assert_eq!(res, Some(2));
+    }
+
+    #[test]
+    fn test_remove() {
+        let cache = create_lru();
+
+        cache.remove(&1);
+
+        // 2 -> 3
+        assert_eq!(cache.inner.lock().len(), 2);
+        let res = cache.put(4);
+        assert_eq!(res, None);
+        let res = cache.put(5);
+        assert_eq!(res, Some(2));
+    }
+}

--- a/src/async_fuse/memfs/cache/policy/mod.rs
+++ b/src/async_fuse/memfs/cache/policy/mod.rs
@@ -1,0 +1,22 @@
+//! Evict policies for cache.
+
+mod lru;
+
+pub use lru::LruPolicy;
+
+/// The evict policy trait.
+/// A policy records and maintains cache keys.
+pub trait EvictPolicy<K> {
+    /// Put a key into the policy.
+    ///
+    /// If a key is to be evicted, returns it; otherwise, returns `None`.
+    fn put(&self, key: K) -> Option<K>;
+
+    /// Touch a key, as it's accessed.
+    ///
+    /// This may make no differences in some policy, such as FIFO.
+    fn touch(&self, key: &K);
+
+    /// Remove a key from the policy.
+    fn remove(&self, key: &K);
+}

--- a/src/async_fuse/memfs/cache/storage.rs
+++ b/src/async_fuse/memfs/cache/storage.rs
@@ -1,0 +1,136 @@
+//! The storage trait, as a abstraction of the storage layers.
+
+use std::sync::Arc;
+
+use crate::async_fuse::fuse::protocol::INum;
+use async_trait::async_trait;
+
+use super::{Block, BlockCoordinate, IoBlock};
+
+/// The `Storage` trait. It handles blocks with storage such as in-memory cache, in-disk cache and `S3Backend`.
+#[async_trait]
+pub trait Storage {
+    // Required methods
+
+    /// Loads a block from `self` but not from its backend.
+    async fn load_from_self(&self, ino: INum, block_id: usize) -> Option<Block>;
+
+    /// Loads a block from the `backend`.
+    async fn load_from_backend(&self, ino: INum, block_id: usize) -> Option<Block>;
+
+    /// Caches a block that is just loaded from the backend.
+    ///
+    /// An evicted block may be returned.
+    async fn cache_block_from_backend(
+        &self,
+        ino: INum,
+        block_id: usize,
+        block: Block,
+    ) -> Option<(BlockCoordinate, Block)>;
+
+    /// A callback to handle the eviction.
+    async fn on_evict(&self, ino: INum, block_id: usize, evicted: Block);
+
+    /// Store a block to the storage.
+    async fn store(&self, ino: INum, block_id: usize, block: IoBlock);
+
+    /// Remove a file from storage.
+    async fn remove(&self, ino: INum);
+
+    /// Invalidate caches of a file, if the storage contains caches.
+    async fn invalidate(&self, ino: INum);
+
+    /// Flush a file
+    async fn flush(&self, ino: INum);
+
+    /// Flush all files
+    async fn flush_all(&self);
+
+    /// Truncate a file from the block id of `from` to a lower one, and fill zeros in the end of the last block.
+    /// Both `from` and `to` are in blocks, and are the next id to the last valid block of a file.
+    /// If `fill_start` is set to block size, this method should not fill any zero.
+    /// After the truncating, the block range of the file is
+    /// `[0, to_block)`.
+    async fn truncate(&self, ino: INum, from_block: usize, to_block: usize, fill_start: usize);
+
+    // Provided methods
+
+    /// Load a block from the storage.
+    async fn load(&self, ino: INum, block_id: usize) -> Option<Block> {
+        if let Some(block_in_cache) = self.load_from_self(ino, block_id).await {
+            Some(block_in_cache)
+        } else {
+            let res = self.load_from_backend(ino, block_id).await;
+            if let Some(block) = res {
+                let evicted = self
+                    .cache_block_from_backend(ino, block_id, block.clone())
+                    .await;
+                if let Some((BlockCoordinate(ino, block_id), evicted)) = evicted {
+                    self.on_evict(ino, block_id, evicted).await;
+                }
+                Some(block)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl<T> Storage for Arc<T>
+where
+    T: Storage + Send + Sync,
+{
+    async fn load_from_self(&self, ino: INum, block_id: usize) -> Option<Block> {
+        self.as_ref().load_from_self(ino, block_id).await
+    }
+
+    async fn load_from_backend(&self, ino: INum, block_id: usize) -> Option<Block> {
+        self.as_ref().load_from_backend(ino, block_id).await
+    }
+
+    async fn cache_block_from_backend(
+        &self,
+        ino: INum,
+        block_id: usize,
+        block: Block,
+    ) -> Option<(BlockCoordinate, Block)> {
+        self.as_ref()
+            .cache_block_from_backend(ino, block_id, block)
+            .await
+    }
+
+    async fn on_evict(&self, ino: INum, block_id: usize, evicted: Block) {
+        self.as_ref().on_evict(ino, block_id, evicted).await;
+    }
+
+    async fn load(&self, ino: INum, block_id: usize) -> Option<Block> {
+        self.as_ref().load(ino, block_id).await
+    }
+
+    async fn store(&self, ino: INum, block_id: usize, block: IoBlock) {
+        self.as_ref().store(ino, block_id, block).await;
+    }
+
+    async fn remove(&self, ino: INum) {
+        self.as_ref().remove(ino).await;
+    }
+
+    async fn invalidate(&self, ino: INum) {
+        self.as_ref().invalidate(ino).await;
+    }
+
+    async fn flush(&self, ino: INum) {
+        self.as_ref().flush(ino).await;
+    }
+
+    async fn flush_all(&self) {
+        self.as_ref().flush_all().await;
+    }
+
+    async fn truncate(&self, ino: INum, from_block: usize, to_block: usize, fill_start: usize) {
+        self.as_ref()
+            .truncate(ino, from_block, to_block, fill_start)
+            .await;
+    }
+}


### PR DESCRIPTION
This PR aims at implementing `StorageManager` as a new storage managing mechanism, introducing some trait and utilities for it, and implementing the `InMemoryCache`, which is plugged into the new mechanism, as a replacement of the old `GlobalCache`.

All targets in this PR are listed below:

- [x] Introduce `EvictPolicy` trait and implement `LruPolicy`
- [x] Implement `StorageManager`
- [x] Implement `InMemoryCache`
- [x] Test `InMemoryCache`
- [x] Plug `InMemoryCache` into `StorageManager` and test the manager
- [x] Find the best way to write a block

When #432 is merged, clippy lints should be fixed:

- [x] Fix clippy lints.

Because the patches are too large, thus the `InMemoryCache` and `StorageManager` have been moved to #442.