### PR TITLE
chore: bump Rust version to 1.74.0

### DIFF
--- a/.github/workflows/ci-7-23.yml
+++ b/.github/workflows/ci-7-23.yml
@@ -4,7 +4,7 @@ on:
         branches: [master]
 
 env:
-    CI_RUST_TOOLCHAIN: 1.67.1
+    CI_RUST_TOOLCHAIN: 1.74.0
     CONTROLLER_SOCKET_FILE: /tmp/controller.sock
     BIND_MOUNTER: target/debug/bind_mounter
     ETCD_CONTAINER_NAME: etcd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
     branches: [master]
 
 env:
-  CI_RUST_TOOLCHAIN: 1.67.1
+  CI_RUST_TOOLCHAIN: 1.74.0
   CONTROLLER_SOCKET_FILE: /tmp/controller.sock
   BIND_MOUNTER: target/debug/bind_mounter
   ETCD_CONTAINER_NAME: etcd

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ on:
     branches: [master]
 
 env:
-  CI_RUST_TOOLCHAIN: 1.67.1
+  CI_RUST_TOOLCHAIN: 1.74.0
   ETCD_CONTAINER_NAME: etcd
   ETCD_IMAGE: gcr.io/etcd-development/etcd:v3.4.13
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
 
 env:
-  RUST_VERSION: 1.67.1
+  RUST_VERSION: 1.74.0
 jobs:
 
   build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ once_cell = "1.7.2"
 parking_lot = "0.12.0"
 pin-project-lite = "0.2.0"
 priority-queue = "1.1.0"
-prometheus = "0.13.0"
+prometheus = "0.13.3"
 protobuf = "2.16.2"
 rand = "0.8.3"
 ring-io = { git = "https://github.com/datenlord/ring-io", rev = "2f0506c" }

--- a/macro-utils/src/lib.rs
+++ b/macro-utils/src/lib.rs
@@ -79,7 +79,6 @@
     clippy::shadow_reuse, //it’s a common pattern in Rust code
     clippy::shadow_same, //it’s a common pattern in Rust code
     clippy::arithmetic_side_effects,  // An error is raised when calling `quote::quote!`
-    clippy::arithmetic_side_effects  // As same as above
 )]
 
 use proc_macro::TokenStream;

--- a/macro-utils/src/lib.rs
+++ b/macro-utils/src/lib.rs
@@ -78,7 +78,7 @@
     clippy::shadow_unrelated, //it’s a common pattern in Rust code
     clippy::shadow_reuse, //it’s a common pattern in Rust code
     clippy::shadow_same, //it’s a common pattern in Rust code
-    clippy::integer_arithmetic,  // An error is raised when calling `quote::quote!`
+    clippy::arithmetic_side_effects,  // An error is raised when calling `quote::quote!`
     clippy::arithmetic_side_effects  // As same as above
 )]
 

--- a/scripts/setup/config.sh
+++ b/scripts/setup/config.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export RUST_VERSION=1.67.1
+export RUST_VERSION=1.74.0
 export BUSYBOX_IMAGE=busybox:1.35.0
 export CONFIG_DOCKERHUB=datenlord-deploy.yaml
 export CONFIG_KIND=scripts/setup/datenlord.yaml

--- a/src/async_fuse/fuse/de.rs
+++ b/src/async_fuse/fuse/de.rs
@@ -178,7 +178,7 @@ impl<'b> Deserializer<'b> {
     ///
     /// `slice::len` is always O(1)
     pub fn fetch_c_str(&mut self) -> Result<&'b [u8], DeserializeError> {
-        let strlen: usize = memchr(0, self.bytes)
+        let strlen = memchr(0, self.bytes)
             .ok_or_else(|| {
                 trace!("no trailing zero in bytes, cannot fetch c-string");
                 DeserializeError::NotEnough
@@ -264,6 +264,8 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::semicolon_outside_block)]
+    #[allow(clippy::host_endian_bytes)]
     fn fetch_ref() {
         // this buffer contains two `u32` or one `u64`
         // so it is aligned to 8 bytes
@@ -293,6 +295,8 @@ mod tests {
     #[test]
     #[allow(clippy::unwrap_used)]
     #[cfg(feature = "abi-7-16")]
+    #[allow(clippy::host_endian_bytes)]
+    #[allow(clippy::semicolon_outside_block)]
     fn fetch_all_as_slice() {
         // this buffer contains two `u32`
         // so it can be aligned to 4 bytes

--- a/src/async_fuse/fuse/de.rs
+++ b/src/async_fuse/fuse/de.rs
@@ -233,6 +233,7 @@ impl<'b> Deserializer<'b> {
 }
 
 #[cfg(test)]
+#[allow(clippy::host_endian_bytes)] // For test only
 mod tests {
     use aligned_utils::stack::Align8;
 
@@ -264,8 +265,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::semicolon_outside_block)]
-    #[allow(clippy::host_endian_bytes)]
     fn fetch_ref() {
         // this buffer contains two `u32` or one `u64`
         // so it is aligned to 8 bytes
@@ -295,8 +294,6 @@ mod tests {
     #[test]
     #[allow(clippy::unwrap_used)]
     #[cfg(feature = "abi-7-16")]
-    #[allow(clippy::host_endian_bytes)]
-    #[allow(clippy::semicolon_outside_block)]
     fn fetch_all_as_slice() {
         // this buffer contains two `u32`
         // so it can be aligned to 4 bytes

--- a/src/async_fuse/fuse/fuse_reply.rs
+++ b/src/async_fuse/fuse/fuse_reply.rs
@@ -24,7 +24,7 @@ use super::protocol::{
 #[cfg(feature = "abi-7-18")]
 use super::protocol::{FuseNotifyCode::FUSE_NOTIFY_DELETE, FuseNotifyDeleteOut};
 
-/// This trait describes a type that can be converted to Vec<IoVec<&[u8]>>
+/// This trait describes a type that can be converted to Vec<`IoVec`<&[u8]>>
 pub trait AsIoVecList {
     /// Convert the type to a Vec of `IoVec`
     fn as_io_vec_list(&self) -> Vec<IoVec<&[u8]>>;
@@ -35,7 +35,7 @@ pub trait AsIoVecList {
 }
 
 /// Any type implement the `AsIoVec` trait, its Vec can be automatically for
-/// Vec<IoVec<&[u8]>>.
+/// Vec<`IoVec`<&[u8]>>.
 impl<T> AsIoVecList for Vec<T>
 where
     T: AsIoVec,

--- a/src/async_fuse/fuse/fuse_request.rs
+++ b/src/async_fuse/fuse/fuse_request.rs
@@ -1117,7 +1117,6 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::semicolon_outside_block)]
     fn mknod() {
         let req = Request::new(&MKNOD_REQUEST[..], PROTO_VERSION)
             .unwrap_or_else(|err| panic!("failed to build FUSE request, the error is: {err}"));
@@ -1385,7 +1384,6 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::semicolon_outside_block)]
     fn write() {
         #[cfg(feature = "abi-7-9")]
         use super::super::protocol::{FOPEN_KEEP_CACHE, FUSE_WRITE_CACHE, FUSE_WRITE_LOCKOWNER};
@@ -2223,7 +2221,6 @@ mod test {
 
     #[test]
     #[cfg(feature = "abi-7-16")]
-    #[allow(clippy::missing_asserts_for_indexing)]
     fn batch_forget() {
         let req = Request::new(&BATCH_FORGET_REQUEST[..], PROTO_VERSION)
             .unwrap_or_else(|err| panic!("failed to build FUSE request, the error is: {err}"));
@@ -2235,6 +2232,7 @@ mod test {
         match *req.operation() {
             Operation::BatchForget { arg, nodes } => {
                 assert_eq!(arg.count, 2);
+                assert!(nodes.len() >= 2);
                 assert_eq!(nodes[0].nodeid, 1);
                 assert_eq!(nodes[0].nlookup, 5);
                 assert_eq!(nodes[1].nodeid, 2);

--- a/src/async_fuse/fuse/fuse_request.rs
+++ b/src/async_fuse/fuse/fuse_request.rs
@@ -1117,6 +1117,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::semicolon_outside_block)]
     fn mknod() {
         let req = Request::new(&MKNOD_REQUEST[..], PROTO_VERSION)
             .unwrap_or_else(|err| panic!("failed to build FUSE request, the error is: {err}"));
@@ -1384,6 +1385,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::semicolon_outside_block)]
     fn write() {
         #[cfg(feature = "abi-7-9")]
         use super::super::protocol::{FOPEN_KEEP_CACHE, FUSE_WRITE_CACHE, FUSE_WRITE_LOCKOWNER};
@@ -2221,6 +2223,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "abi-7-16")]
+    #[allow(clippy::missing_asserts_for_indexing)]
     fn batch_forget() {
         let req = Request::new(&BATCH_FORGET_REQUEST[..], PROTO_VERSION)
             .unwrap_or_else(|err| panic!("failed to build FUSE request, the error is: {err}"));

--- a/src/async_fuse/fuse/mod.rs
+++ b/src/async_fuse/fuse/mod.rs
@@ -1,5 +1,6 @@
 //! Implementation of FUSE library
 
+#[allow(clippy::tests_outside_test_module)]
 mod abi_marker;
 mod context;
 mod de;
@@ -7,12 +8,12 @@ mod de;
 pub mod file_system;
 
 // ioctl_read!() macro involves inter arithmetic
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 pub mod channel;
 pub mod fuse_reply;
 pub mod fuse_request;
 pub mod mount;
 // ioctl_read!() macro involves inter arithmetic
-#[allow(clippy::integer_arithmetic)]
+#[allow(clippy::arithmetic_side_effects)]
 pub mod protocol;
 pub mod session;

--- a/src/async_fuse/fuse/mount.rs
+++ b/src/async_fuse/fuse/mount.rs
@@ -119,7 +119,7 @@ async fn fuser_mount(mount_point: &Path) -> anyhow::Result<RawFd> {
         let mut buf = [0_u8; 5];
         let iov = [IoVec::from_mut_slice(&mut buf[..])];
 
-        #[allow(clippy::integer_arithmetic)]
+        #[allow(clippy::arithmetic_side_effects)]
         let mut cmsgspace = cmsg_space!([RawFd; 1]);
         let msg = socket::recvmsg(local, &iov, Some(&mut cmsgspace), MsgFlags::empty())
             .context("failed to receive from fusermount")?;

--- a/src/async_fuse/fuse/session.rs
+++ b/src/async_fuse/fuse/session.rs
@@ -148,7 +148,7 @@ impl<F: FileSystem + Send + Sync + 'static> Session<F> {
 
     /// Run the FUSE session
     #[allow(clippy::wildcard_enum_match_arm)] // nix::Errno is marked as non_exhaustive
-    #[allow(clippy::integer_arithmetic)] // The `select` macro will generate code that goes against this rule.
+    #[allow(clippy::arithmetic_side_effects)] // The `select` macro will generate code that goes against this rule.
     pub async fn run(mut self) -> anyhow::Result<()> {
         // For recycling the buffers used by process_fuse_request.
         let (pool_sender, pool_receiver) = self

--- a/src/async_fuse/memfs/cache/mod.rs
+++ b/src/async_fuse/memfs/cache/mod.rs
@@ -495,7 +495,7 @@ impl GlobalCache {
 
         let mut have_read: usize = 0;
         let mut grow_memory: usize = 0;
-        let mut is_first_block: bool = true;
+        let mut is_first_block = true;
         let mut copy_fn = |b: &mut Option<MemBlock>| {
             if b.is_some() && !overwrite {
                 return;
@@ -740,6 +740,7 @@ pub struct IoMemBlock {
     end: usize,
 }
 
+#[allow(clippy::missing_fields_in_debug)]
 impl Debug for IoMemBlock {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IoMemBlock")

--- a/src/async_fuse/memfs/dir.rs
+++ b/src/async_fuse/memfs/dir.rs
@@ -3,6 +3,7 @@
 #[cfg(not(all(target_os = "linux", target_pointer_width = "64")))]
 compile_error!("async-fuse does not support this target now");
 
+use std::ffi::c_int;
 use std::io;
 use std::iter::FusedIterator;
 use std::os::unix::ffi::OsStrExt;
@@ -66,7 +67,7 @@ impl Dir {
         let dirp = libc::fdopendir(fd);
         if dirp.is_null() {
             let err = io::Error::last_os_error();
-            let _ = libc::close(fd);
+            let _: c_int = libc::close(fd);
             return Err(err);
         }
         Ok(Self(NonNull::new_unchecked(dirp)))

--- a/src/async_fuse/memfs/dist/server.rs
+++ b/src/async_fuse/memfs/dist/server.rs
@@ -20,6 +20,7 @@ pub struct CacheServer {
     listener_join_handler: JoinHandle<()>,
 }
 
+#[allow(clippy::missing_fields_in_debug)]
 impl Debug for CacheServer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CacheServer")

--- a/src/async_fuse/memfs/dist/tcp.rs
+++ b/src/async_fuse/memfs/dist/tcp.rs
@@ -6,6 +6,7 @@ use crate::async_fuse::fuse::fuse_reply::AsIoVec;
 use crate::async_fuse::memfs::cache::IoMemBlock;
 
 /// Read message from tcp stream
+#[allow(clippy::big_endian_bytes)]
 pub async fn read_message(stream: &mut TcpStream, buf: &mut Vec<u8>) -> anyhow::Result<usize> {
     let mut local_buf: [u8; 8] = [0; 8];
     stream.read_exact(&mut local_buf).await?;
@@ -17,6 +18,7 @@ pub async fn read_message(stream: &mut TcpStream, buf: &mut Vec<u8>) -> anyhow::
     Ok(len.cast())
 }
 
+#[allow(clippy::big_endian_bytes)]
 /// Write message to tcp stream
 pub async fn write_message(stream: &mut TcpStream, buf: &[u8]) -> anyhow::Result<usize> {
     let len: u64 = buf.len().cast();
@@ -27,6 +29,7 @@ pub async fn write_message(stream: &mut TcpStream, buf: &[u8]) -> anyhow::Result
     Ok(len.cast())
 }
 
+#[allow(clippy::big_endian_bytes)]
 /// Write message vector to tcp stream
 pub async fn write_message_vector(
     stream: &mut TcpStream,
@@ -41,22 +44,4 @@ pub async fn write_message_vector(
     }
 
     Ok(len.cast())
-}
-
-/// Write u32 to tcp stream
-#[allow(dead_code)]
-pub async fn write_u32(stream: &mut TcpStream, num: u32) -> anyhow::Result<()> {
-    let num_buf = num.to_be_bytes();
-    stream.write_all(&num_buf).await?;
-
-    Ok(())
-}
-
-/// Read u32 from tcp stream
-#[allow(dead_code)]
-pub async fn read_u32(stream: &mut TcpStream) -> anyhow::Result<u32> {
-    let mut local_buf: [u8; 4] = [0; 4];
-    stream.read_exact(&mut local_buf).await?;
-
-    Ok(u32::from_be_bytes(local_buf))
 }

--- a/src/async_fuse/memfs/fs_util.rs
+++ b/src/async_fuse/memfs/fs_util.rs
@@ -127,7 +127,7 @@ impl FileAttr {
 
     /// For given uid and gid, get the access mode of the file
     #[allow(clippy::default_numeric_fallback)]
-    #[allow(clippy::integer_arithmetic)]
+    #[allow(clippy::arithmetic_side_effects)]
     fn get_access_mode(&self, user_id: u32, group_id: u32) -> u8 {
         let perm = self.perm;
         let mode = if user_id == self.uid {

--- a/src/async_fuse/memfs/kv_engine/etcd_impl.rs
+++ b/src/async_fuse/memfs/kv_engine/etcd_impl.rs
@@ -42,7 +42,6 @@ impl EtcdKVEngine {
 
 #[async_trait]
 impl KVEngine for EtcdKVEngine {
-    #[must_use]
     async fn new(end_points: Vec<String>) -> DatenLordResult<Self> {
         let client = etcd_client::Client::connect(end_points, None).await?;
         Ok(Self { client })
@@ -334,7 +333,7 @@ mod test {
         let client = EtcdKVEngine::new_for_local_test(vec![ETCD_ADDRESS.to_owned()])
             .await
             .unwrap();
-        let key: LockKeyType = LockKeyType::FileNodeListLock(test_key);
+        let key = LockKeyType::FileNodeListLock(test_key);
         let lock_key = client.lock(&key, Duration::from_secs(9999)).await.unwrap();
         // start a new thread to lock the same key
         // to check that lock the same key will be blocked

--- a/src/async_fuse/memfs/kv_engine/etcd_impl.rs
+++ b/src/async_fuse/memfs/kv_engine/etcd_impl.rs
@@ -462,7 +462,7 @@ mod test {
                 .unwrap();
             let mut txn = client.new_meta_txn().await;
             let key = KeyType::String(String::from("/"));
-            let _ = txn.get(&key).await.unwrap();
+            let _: Option<ValueType> = txn.get(&key).await.unwrap();
             (txn.commit().await, ())
         });
         result.unwrap();

--- a/src/async_fuse/memfs/mod.rs
+++ b/src/async_fuse/memfs/mod.rs
@@ -816,7 +816,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
             .readdir(context, ino, fh, offset, &mut reply)
             .await
         {
-            Ok(_) => reply.ok().await,
+            Ok(()) => reply.ok().await,
             Err(e) => {
                 debug!("readdir() failed, the error is: {:?}", e);
                 reply.error(e).await

--- a/src/async_fuse/memfs/s3_node.rs
+++ b/src/async_fuse/memfs/s3_node.rs
@@ -409,7 +409,7 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3Node<S> {
             .await;
 
         match put_result {
-            Ok(_) => Ok(()),
+            Ok(()) => Ok(()),
             Err(e) => {
                 debug!(
                     "flush_all_data() failed to flush data for file {}, the error is: {}",

--- a/src/async_fuse/memfs/s3_wrapper.rs
+++ b/src/async_fuse/memfs/s3_wrapper.rs
@@ -29,7 +29,7 @@ pub enum S3Error {
 pub type S3Result<T> = Result<T, S3Error>;
 
 /// S3 backend
-#[allow(clippy::integer_arithmetic, clippy::indexing_slicing)]
+#[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
 #[cfg_attr(test, automock)]
 #[async_trait]
 pub trait S3BackEnd {

--- a/src/async_fuse/memfs/serial.rs
+++ b/src/async_fuse/memfs/serial.rs
@@ -79,7 +79,7 @@ pub enum SerialSFlag {
 }
 
 /// In order to derive Serialize and Deserialize,
-/// Replace the 'BTreeMap<String, `DirEntry`>' with 'HashMap<String,
+/// Replace the `BTreeMap`<String, `DirEntry`>' with `HashMap`<String,
 /// `SerialDirEntry`>'
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub enum SerialNodeData {
@@ -320,7 +320,7 @@ mod test {
         let test_name = String::from("test_a_really_long_name");
         let test_file_attr = create_file_attr();
         let direntry = DirEntry::new(test_name.clone(), Arc::new(RwLock::new(test_file_attr)));
-        let serial_direntry: SerialDirEntry = dir_entry_to_serial(&direntry);
+        let serial_direntry = dir_entry_to_serial(&direntry);
         assert_eq!(test_name, serial_direntry.name);
         let direntry_after = serial_to_dir_entry(&serial_direntry);
         assert_eq!(test_name, direntry_after.entry_name());

--- a/src/async_fuse/mod.rs
+++ b/src/async_fuse/mod.rs
@@ -12,6 +12,7 @@ use crate::{AsyncFuseArgs, VolumeType};
 pub mod fuse;
 pub mod memfs;
 /// Datenlord metrics
+// Caused by prometheus macros
 #[allow(clippy::ignored_unit_patterns)]
 pub mod metrics;
 pub mod proactor;

--- a/src/async_fuse/mod.rs
+++ b/src/async_fuse/mod.rs
@@ -12,6 +12,7 @@ use crate::{AsyncFuseArgs, VolumeType};
 pub mod fuse;
 pub mod memfs;
 /// Datenlord metrics
+#[allow(clippy::ignored_unit_patterns)]
 pub mod metrics;
 pub mod proactor;
 pub mod util;

--- a/src/async_fuse/proactor/global.rs
+++ b/src/async_fuse/proactor/global.rs
@@ -277,6 +277,7 @@ impl Proactor {
     }
 
     /// Starts the submitter task and completer thread.
+    #[allow(clippy::semicolon_inside_block)]
     fn start_driver() -> io::Result<Self> {
         let ring_entries = 32;
         let available = 64;
@@ -288,7 +289,7 @@ impl Proactor {
 
         let (mut sq, mut cq, _) = ring.split();
 
-        let (tx, mut rx): _ = mpsc::channel(u32_to_usize(available));
+        let (tx, mut rx) = mpsc::channel(u32_to_usize(available));
 
         let inner = Arc::new(ProactorInner {
             chan: tx,

--- a/src/async_fuse/test/integration_tests.rs
+++ b/src/async_fuse/test/integration_tests.rs
@@ -301,7 +301,6 @@ fn test_rename_file_replace(mount_dir: &Path) -> anyhow::Result<()> {
 
 #[cfg(test)]
 #[cfg(feature = "abi-7-23")]
-#[allow(clippy::semicolon_outside_block)]
 fn test_rename_exchange(mount_dir: &Path) -> anyhow::Result<()> {
     use nix::fcntl::RenameFlags;
     use nix::sys::stat;

--- a/src/async_fuse/test/integration_tests.rs
+++ b/src/async_fuse/test/integration_tests.rs
@@ -66,7 +66,7 @@ fn test_name_too_long(mount_dir: &Path) -> anyhow::Result<()> {
     info!("try to create a dir with name too long");
     let result = fs::create_dir_all(&file_path);
     match result {
-        Ok(_) => panic!("Directory creation should have failed with ENAMETOOLONG"),
+        Ok(()) => panic!("Directory creation should have failed with ENAMETOOLONG"),
         Err(ref e) if e.raw_os_error() == Some(libc::ENAMETOOLONG) => {} // expected this error
         Err(e) => return Err(e.into()),
     }
@@ -74,7 +74,7 @@ fn test_name_too_long(mount_dir: &Path) -> anyhow::Result<()> {
     info!("try to create a symlink with name too long");
     let result = std::os::unix::fs::symlink(mount_dir, &file_path);
     match result {
-        Ok(_) => panic!("Symlink creation should have failed with ENAMETOOLONG"),
+        Ok(()) => panic!("Symlink creation should have failed with ENAMETOOLONG"),
         Err(ref e) if e.raw_os_error() == Some(libc::ENAMETOOLONG) => {} // expected this error
         Err(e) => return Err(e.into()),
     }
@@ -170,7 +170,7 @@ fn test_deferred_deletion(mount_dir: &Path) -> anyhow::Result<()> {
         read_size,
         FILE_CONTENT.len().overflow_mul(repeat_times),
     );
-    let str_content: String = FILE_CONTENT.repeat(repeat_times);
+    let str_content = FILE_CONTENT.repeat(repeat_times);
     assert_eq!(
         content, str_content,
         "the file read result is not the same as the expected content",
@@ -301,6 +301,7 @@ fn test_rename_file_replace(mount_dir: &Path) -> anyhow::Result<()> {
 
 #[cfg(test)]
 #[cfg(feature = "abi-7-23")]
+#[allow(clippy::semicolon_outside_block)]
 fn test_rename_exchange(mount_dir: &Path) -> anyhow::Result<()> {
     use nix::fcntl::RenameFlags;
     use nix::sys::stat;

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -396,7 +396,6 @@ implement_from!(anyhow::Error, InternalErr);
 
 impl From<DatenLordError> for RpcStatusCode {
     #[inline]
-    #[allow(clippy::ref_patterns)]
     fn from(error: DatenLordError) -> Self {
         match error {
             DatenLordError::IoErr { .. }

--- a/src/common/etcd_delegate.rs
+++ b/src/common/etcd_delegate.rs
@@ -475,7 +475,6 @@ impl EtcdDelegate {
 
     /// Write key value pair to etcd, if key exists, update it
     #[inline]
-    #[allow(clippy::multiple_unsafe_ops_per_block)]
     pub async fn write_or_update_kv<
         T: DeserializeOwned + Serialize + Clone + Debug + Send + Sync,
         K: Into<Vec<u8>> + Debug + Clone + Send,
@@ -502,7 +501,6 @@ impl EtcdDelegate {
     /// it
     /// - `expire`: auto delete after expire
     #[inline]
-    #[allow(clippy::multiple_unsafe_ops_per_block)]
     pub async fn write_or_update_kv_with_timeout<
         T: DeserializeOwned + Serialize + Clone + Debug + Send + Sync,
         K: Into<Vec<u8>> + Debug + Clone + Send,
@@ -531,7 +529,6 @@ impl EtcdDelegate {
     /// Write or update key only when matching the previous version.
     /// - `expire`: auto delete after expire
     #[inline]
-    #[allow(clippy::multiple_unsafe_ops_per_block)]
     pub async fn write_or_update_kv_with_version<
         T: DeserializeOwned + Serialize + Clone + Debug + Send + Sync,
         K: Into<Vec<u8>> + Debug + Clone + Send,
@@ -555,7 +552,6 @@ impl EtcdDelegate {
     ///
     /// Will panic if it doesn't delete one value from etcd
     #[inline]
-    #[allow(clippy::multiple_unsafe_ops_per_block)]
     pub async fn delete_exact_one_value_return_with_version<
         T: DeserializeOwned + Clone + Debug + Send + Sync,
     >(
@@ -584,7 +580,6 @@ impl EtcdDelegate {
     ///
     /// Will panic if it doesn't delete one value from etcd
     #[inline]
-    #[allow(clippy::multiple_unsafe_ops_per_block)]
     pub async fn delete_exact_one_value<T: DeserializeOwned + Clone + Debug + Send + Sync>(
         &self,
         key: &str,
@@ -603,7 +598,6 @@ impl EtcdDelegate {
     ///
     /// Will panic if it deletes more than one value from etcd
     #[inline]
-    #[allow(clippy::multiple_unsafe_ops_per_block)]
     pub async fn delete_one_value_return_with_version<
         T: DeserializeOwned + Clone + Debug + Send + Sync,
     >(
@@ -627,7 +621,6 @@ impl EtcdDelegate {
     ///
     /// Will panic if it deletes more than one value from etcd
     #[inline]
-    #[allow(clippy::multiple_unsafe_ops_per_block)]
     pub async fn delete_one_value<T: DeserializeOwned + Clone + Debug + Send + Sync>(
         &self,
         key: &str,
@@ -642,7 +635,6 @@ impl EtcdDelegate {
 
     /// Delete all key value pairs from etcd
     #[allow(dead_code)]
-    #[allow(clippy::multiple_unsafe_ops_per_block)]
     #[inline]
     pub async fn delete_all(&self) -> DatenLordResult<()> {
         self.etcd_rs_client
@@ -664,9 +656,8 @@ impl EtcdDelegate {
     /// This function will return when watch closed or there's etcd error.
     /// Timeout
     #[inline]
-    #[allow(clippy::arithmetic_side_effects, clippy::arithmetic_side_effects)] // for the auto generate code from tokio select!
-    #[allow(clippy::multiple_unsafe_ops_per_block)]
-    #[allow(clippy::pattern_type_mismatch)]
+    #[allow(clippy::arithmetic_side_effects)] // for the auto generate code from tokio select!
+    #[allow(clippy::pattern_type_mismatch)] // for tokio::select!
     pub async fn wait_key_delete(&self, name: &str) -> DatenLordResult<()> {
         let mut etcd_rs_client = self.etcd_rs_client.clone();
         let res = etcd_rs_client.watch(name, None).await;

--- a/src/common/logger.rs
+++ b/src/common/logger.rs
@@ -6,7 +6,6 @@ use tracing_subscriber::prelude::*;
 /// Initialize the logger with the default settings.
 /// The log file is located at `./datenlord.log`.
 #[allow(clippy::let_underscore_must_use)]
-#[allow(clippy::let_underscore_untyped)]
 #[inline]
 pub fn init_logger() {
     let filter = filter::Targets::new()
@@ -32,7 +31,8 @@ pub fn init_logger() {
     let subscriber = tracing_subscriber::Registry::default().with(layer);
 
     if cfg!(test) {
-        let _ = tracing::subscriber::set_global_default(subscriber);
+        let _: Result<(), tracing::subscriber::SetGlobalDefaultError> =
+            tracing::subscriber::set_global_default(subscriber);
     } else {
         tracing::subscriber::set_global_default(subscriber)
             .unwrap_or_else(|error| panic!("Could not set logger ,err {error}"));

--- a/src/common/logger.rs
+++ b/src/common/logger.rs
@@ -6,6 +6,7 @@ use tracing_subscriber::prelude::*;
 /// Initialize the logger with the default settings.
 /// The log file is located at `./datenlord.log`.
 #[allow(clippy::let_underscore_must_use)]
+#[allow(clippy::let_underscore_untyped)]
 #[inline]
 pub fn init_logger() {
     let filter = filter::Targets::new()
@@ -20,7 +21,7 @@ pub fn init_logger() {
         .write(true)
         .truncate(true)
         .open("./datenlord.log")
-        .unwrap_or_else(|e| panic!("Failed to open log file ,err {e}"));
+        .unwrap_or_else(|err| panic!("Failed to open log file ,err {err}"));
 
     let layer = tracing_subscriber::fmt::layer()
         .with_ansi(false)
@@ -34,6 +35,6 @@ pub fn init_logger() {
         let _ = tracing::subscriber::set_global_default(subscriber);
     } else {
         tracing::subscriber::set_global_default(subscriber)
-            .unwrap_or_else(|e| panic!("Could not set logger ,err {e}"));
+            .unwrap_or_else(|error| panic!("Could not set logger ,err {error}"));
     }
 }

--- a/src/csi/meta_data.rs
+++ b/src/csi/meta_data.rs
@@ -253,7 +253,12 @@ impl MetaData {
             } else {
                 self.get_node_by_id(&node_id)
                     .await
-                    .or_else(|_| panic!("failed to get node ID={node_id} from etcd"))
+                    .map_err(|err| ArgumentInvalid {
+                        context: vec![format!(
+                            "failed to get node ID={} from etcd ,err is {err}",
+                            &node_id
+                        )],
+                    })
             }
         } else if req.has_accessibility_requirements() {
             let preferred_topology = req.get_accessibility_requirements().get_preferred();
@@ -297,7 +302,12 @@ impl MetaData {
             );
             self.get_node_by_id(node_id)
                 .await
-                .or_else(|_| panic!("failed to get node ID={node_id} from etcd"))
+                .map_err(|err| ArgumentInvalid {
+                    context: vec![format!(
+                        "failed to get node ID={} from etcd ,err is {err}",
+                        &node_id
+                    )],
+                })
         } else {
             debug!("request doesn't have volume content source and accessibility requirements, select random node");
             self.select_random_node().await

--- a/src/csi/mod.rs
+++ b/src/csi/mod.rs
@@ -1,4 +1,6 @@
 //! K8S CSI `gRPC` service
+
+#[allow(clippy::map_clone)]
 mod controller;
 mod identity;
 pub mod meta_data;

--- a/src/csi/scheduler_extender.rs
+++ b/src/csi/scheduler_extender.rs
@@ -170,7 +170,7 @@ impl SchedulerExtender {
                         let candidate_nodes: Vec<_> = nodes
                             .iter()
                             .filter(|&n| accessible_nodes.contains(n))
-                            .map(|n| n.clone())
+                            .cloned()
                             .collect();
                         ExtenderFilterResult {
                             Nodes: None,

--- a/src/csi/scheduler_extender.rs
+++ b/src/csi/scheduler_extender.rs
@@ -119,6 +119,7 @@ impl SchedulerExtender {
     }
 
     /// Filter candidate nodes
+    #[allow(clippy::redundant_closure_for_method_calls)]
     async fn filter(&self, args: ExtenderArgs) -> ExtenderFilterResult {
         let pod = args.Pod.clone();
         info!("Pod name is {:?}", pod.metadata.name);
@@ -168,7 +169,8 @@ impl SchedulerExtender {
                     } else if let Some(ref nodes) = args.NodeNames {
                         let candidate_nodes: Vec<_> = nodes
                             .iter()
-                            .filter_map(|n| accessible_nodes.contains(n).then(|| n.clone()))
+                            .filter(|&n| accessible_nodes.contains(n))
+                            .map(|n| n.clone())
                             .collect();
                         ExtenderFilterResult {
                             Nodes: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,16 @@
     clippy::mod_module_files, // TODO: fix code structure to pass this lint
     clippy::std_instead_of_core, // Cause false positive in src/common/error.rs
     clippy::std_instead_of_alloc,
+    clippy::question_mark_used,  // it’s a common pattern in Rust code
+    clippy::absolute_paths,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::ref_patterns,
+    clippy::single_call_fn,
+    clippy::pub_with_shorthand,
+    clippy::min_ident_chars,
+    clippy::missing_assert_message,
+    clippy::impl_trait_in_params,
+    clippy::bind_instead_of_map,
 )]
 
 pub mod common;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,15 +51,14 @@
     clippy::std_instead_of_core, // Cause false positive in src/common/error.rs
     clippy::std_instead_of_alloc,
     clippy::question_mark_used,  // it’s a common pattern in Rust code
-    clippy::absolute_paths,
-    clippy::multiple_unsafe_ops_per_block,
-    clippy::ref_patterns,
-    clippy::single_call_fn,
-    clippy::pub_with_shorthand,
-    clippy::min_ident_chars,
-    clippy::missing_assert_message,
-    clippy::impl_trait_in_params,
-    clippy::bind_instead_of_map,
+    clippy::absolute_paths,      // Allow use through absolute paths,like `std::env::current_dir`
+    clippy::multiple_unsafe_ops_per_block,   // Mainly caused by `etcd_delegate`, will remove later
+    clippy::ref_patterns,   // Allow Some(ref x)
+    clippy::single_call_fn, // Allow function is called only once
+    clippy::pub_with_shorthand, // Allow pub(super)
+    clippy::min_ident_chars, // Allow Err(e)
+    clippy::missing_assert_message,  // Allow assert! without message, mainly in test code
+    clippy::impl_trait_in_params, // Allow impl AsRef<Path>, it's common in Rust
 )]
 
 pub mod common;

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,18 @@
     clippy::arithmetic_side_effects, // TODO: fix this
     clippy::use_debug, // Allow debug print
     clippy::print_stdout, // Allow println!
+    clippy::question_mark_used, // Allow ? operator
+    clippy::absolute_paths,
+    clippy::ref_patterns,
+    clippy::single_call_fn,
+    clippy::pub_with_shorthand,
+    clippy::min_ident_chars,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::impl_trait_in_params,
+    clippy::missing_assert_message,
+    clippy::bind_instead_of_map,
+    clippy::map_clone,
+    clippy::let_underscore_untyped,
 )]
 
 pub mod async_fuse;

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,17 +60,15 @@
     clippy::use_debug, // Allow debug print
     clippy::print_stdout, // Allow println!
     clippy::question_mark_used, // Allow ? operator
-    clippy::absolute_paths,
-    clippy::ref_patterns,
-    clippy::single_call_fn,
-    clippy::pub_with_shorthand,
-    clippy::min_ident_chars,
-    clippy::multiple_unsafe_ops_per_block,
-    clippy::impl_trait_in_params,
-    clippy::missing_assert_message,
-    clippy::bind_instead_of_map,
-    clippy::map_clone,
-    clippy::let_underscore_untyped,
+    clippy::absolute_paths,   // Allow use through absolute paths,like `std::env::current_dir`
+    clippy::ref_patterns,    // Allow Some(ref x)
+    clippy::single_call_fn,  // Allow function is called only once
+    clippy::pub_with_shorthand,  // Allow pub(super)
+    clippy::min_ident_chars,  // Allow Err(e)
+    clippy::multiple_unsafe_ops_per_block, // Mainly caused by `etcd_delegate`, will remove later
+    clippy::impl_trait_in_params,  // Allow impl AsRef<Path>, it's common in Rust
+    clippy::missing_assert_message, // Allow assert! without message, mainly in test code
+    clippy::semicolon_outside_block, // We need to choose between this and `semicolon_inside_block`, we choose outside
 )]
 
 pub mod async_fuse;


### PR DESCRIPTION
When I wanted to use `clap` version 4 , I found that it requires Rust version >= `1.70.0`. To prevent similar situations in the future, I upgraded to the latest stable version (1.74.0). The upgrade itself will introduce an upgrade to clippy, bringing in new standards.

Clippy warnings mainly occur in the following modules:

1. `fuse`: Issues with byte order calling APIs in test.
2. `etcd_delegate` and `dist`: These need to be thoroughly cleaned up as we no longer require them. We should use `kv_engine` instead.
3. `csi`: This could be maintained as a separate crate or repository.