### PR TITLE
reafctor(metadata) : use txn to do operations

### DIFF
--- a/src/async_fuse/memfs/metadata.rs
+++ b/src/async_fuse/memfs/metadata.rs
@@ -110,7 +110,7 @@ pub trait MetaData {
     async fn fsync_helper(&self, ino: u64, fh: u64, datasync: bool) -> DatenLordResult<()>;
 
     /// Try to delete node that is marked as deferred deletion
-    async fn try_delete_node(&self, ino: INum) -> DatenLordResult<bool>;
+    async fn delete_check(&self, node: &Self::N) -> DatenLordResult<bool>;
 
     /// Helper function to write data
     async fn write_helper(
@@ -130,7 +130,7 @@ pub trait MetaData {
         &self,
         context: ReqContext,
         ino: u64,
-        param: SetAttrParam,
+        param: &SetAttrParam,
     ) -> DatenLordResult<(Duration, FuseAttr)>;
 
     /// Helper function to unlink

--- a/src/async_fuse/memfs/mod.rs
+++ b/src/async_fuse/memfs/mod.rs
@@ -367,7 +367,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
             user_id: req.uid(),
             group_id: req.gid(),
         };
-        let set_res = self.metadata.setattr_helper(context, ino, param).await;
+        let set_res = self.metadata.setattr_helper(context, ino, &param).await;
         match set_res {
             Ok((ttl, fuse_attr)) => reply.attr(ttl, fuse_attr).await,
             Err(e) => reply.error(e).await,

--- a/src/async_fuse/memfs/node.rs
+++ b/src/async_fuse/memfs/node.rs
@@ -106,7 +106,7 @@ pub trait Node: Sized {
         global_cache: Arc<GlobalCache>,
     ) -> DatenLordResult<Self>;
     /// Load data from directory, file or symlink target.
-    async fn load_data(&mut self, offset: usize, len: usize) -> DatenLordResult<usize>;
+    async fn load_data(&self, offset: usize, len: usize) -> DatenLordResult<usize>;
     /// Insert directory entry for rename()
     fn insert_entry_for_rename(&mut self, child_entry: DirEntry) -> Option<DirEntry>;
     /// Remove directory entry from cache only for rename()
@@ -137,7 +137,7 @@ pub trait Node: Sized {
     /// Precheck before set attr
     async fn setattr_precheck(
         &self,
-        param: SetAttrParam,
+        param: &SetAttrParam,
         uid: u32,
         gid: u32,
     ) -> DatenLordResult<(bool, FileAttr)>;


### PR DESCRIPTION
This pull request introduces **transactional mechanisms** to the metadata 's **read-modify-write** operations to ensure **atomicity**  and prevent race conditions. 

Over the coming days, I plan to refactor some of the longer functions.