### PR TITLE
chore : use compact log format

### DIFF
--- a/src/async_fuse/memfs/s3_metadata.rs
+++ b/src/async_fuse/memfs/s3_metadata.rs
@@ -84,7 +84,7 @@ pub struct S3MetaData<S: S3BackEnd + Send + Sync + 'static> {
 impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
     type N = S3Node<S>;
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self), err, ret)]
     async fn release(
         &self,
         ino: u64,
@@ -200,7 +200,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
         node.statefs().await
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self), err, ret)]
     async fn flush(&self, ino: u64, fh: u64) -> DatenLordResult<()> {
         let mut node = self
             .get_node_from_kv_engine(ino)
@@ -210,7 +210,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
         Ok(())
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self), err, ret)]
     async fn releasedir(&self, ino: u64, fh: u64) -> DatenLordResult<()> {
         {
             let node = self

--- a/src/common/logger.rs
+++ b/src/common/logger.rs
@@ -75,7 +75,9 @@ pub fn init_logger(role: LogRole) {
 
     let layer = tracing_subscriber::fmt::layer()
         .with_ansi(false)
-        .event_format(tracing_subscriber::fmt::format().pretty())
+        .compact()
+        .with_thread_ids(true)
+        .with_target(false)
         .with_writer(std::sync::Mutex::new(file))
         .with_filter(filter);
 


### PR DESCRIPTION
The previous logging format was too redundant. Use a more efficient format.