### PR TITLE
refactor(log): Use compact log format

### DIFF
--- a/src/async_fuse/fuse/fuse_request.rs
+++ b/src/async_fuse/fuse/fuse_request.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 
 use clippy_utilities::Cast;
-use tracing::warn;
+use tracing::debug;
 
 use super::context::ProtoVersion;
 use super::de::{DeserializeError, Deserializer};
@@ -703,8 +703,8 @@ impl fmt::Display for Request<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "FUSE({:3}) ino={:#018x} opcode={} operation={}",
-            self.header.unique, self.header.nodeid, self.header.opcode, self.operation,
+            "fuse={} ino={} operation={}",
+            self.header.unique, self.header.nodeid, self.operation,
         )
     }
 }
@@ -735,7 +735,7 @@ impl<'a> Request<'a> {
             }
         })?;
         if de.remaining_len() > 0 {
-            warn!(
+            debug!(
                 "request bytes is not completely consumed: \
                     bytes.len() = {}, header = {:?}, de.remaining_len() = {}, de = {:?}",
                 bytes.len(),

--- a/src/async_fuse/fuse/protocol.rs
+++ b/src/async_fuse/fuse/protocol.rs
@@ -85,7 +85,6 @@ pub const FUSE_ROOT_ID: u64 = 1;
 pub type INum = u64;
 
 /// FUSE attribute `fuse_attr`
-#[derive(Debug)]
 #[repr(C)]
 pub struct FuseAttr {
     /// Node i-number
@@ -122,6 +121,30 @@ pub struct FuseAttr {
     /// Alignment padding
     #[cfg(feature = "abi-7-9")]
     pub padding: u32,
+}
+
+impl std::fmt::Debug for FuseAttr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // fmt like : ino=xx,size=xx,blocks=xx,xx
+        write!(
+            f,
+            "ino={},size={},blocks={},atime={},mtime={},ctime={},atimensec={},mtimensec={},ctimensec={},mode={},nlink={},uid={},gid={},rdev={}",
+            self.ino,
+            self.size,
+            self.blocks,
+            self.atime,
+            self.mtime,
+            self.ctime,
+            self.atimensec,
+            self.mtimensec,
+            self.ctimensec,
+            self.mode,
+            self.nlink,
+            self.uid,
+            self.gid,
+            self.rdev,
+        )
+    }
 }
 
 /// FUSE kstatfs `fuse_kstatfs`

--- a/src/async_fuse/memfs/mod.rs
+++ b/src/async_fuse/memfs/mod.rs
@@ -143,7 +143,6 @@ const MAX_NAME_LEN: usize = 255;
 
 /// Check the name length is valid or not
 pub fn check_name_length(name: &str) -> DatenLordResult<()> {
-    debug!("check name length = {}", name.chars().count());
     if name.len() > MAX_NAME_LEN {
         error!("name = {} is too long ,size = {}", name, name.len());
         build_error_result_from_errno(Errno::ENAMETOOLONG, "name too long ".to_owned())
@@ -238,22 +237,8 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         };
         let lookup_res = self.metadata.lookup_helper(context, parent, name).await;
         match lookup_res {
-            Ok((ttl, fuse_attr, generation)) => {
-                debug!(
-                    "lookup() successfully found the node name={:?} \
-                        under parent ino={}, the attr={:?}",
-                    name, parent, &fuse_attr,
-                );
-                reply.entry(ttl, fuse_attr, generation).await
-            }
-            Err(e) => {
-                debug!(
-                    "lookup() failed to find the node name={:?} under parent ino={}, \
-                        the error is: {:?}",
-                    name, parent, e,
-                );
-                reply.error(e).await
-            }
+            Ok((ttl, fuse_attr, generation)) => reply.entry(ttl, fuse_attr, generation).await,
+            Err(e) => reply.error(e).await,
         }
     }
 

--- a/src/async_fuse/memfs/s3_metadata.rs
+++ b/src/async_fuse/memfs/s3_metadata.rs
@@ -50,7 +50,7 @@ const MY_TTL_SEC: u64 = 3600; // TODO: should be a long value, say 1 hour
 const MY_GENERATION: u64 = 1; // TODO: find a proper way to set generation
 #[allow(dead_code)]
 /// The limit of transaction commit retrying times.
-const TXN_RETRY_LIMIT: u32 = 5;
+const TXN_RETRY_LIMIT: u32 = 10;
 
 /// File system in-memory meta-data
 #[derive(Debug)]
@@ -121,15 +121,6 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
                     child_name,
                 );
                 num_child_entries = num_child_entries.overflow_add(1);
-                debug!(
-                    "readdir() found one child of ino={}, name={:?}, offset={}, and entry={:?} \
-                        under the directory of ino={}",
-                    child_ino,
-                    child_name,
-                    offset.overflow_add(i.cast()).overflow_add(1),
-                    child_entry,
-                    ino,
-                );
             }
             num_child_entries
         };

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -229,7 +229,7 @@ pub enum DatenLordError {
     },
 
     /// Error caused by datenlord's internal logic
-    #[error("InternalErr, the error is {:?} context is {:#?}", .source,.context)]
+    #[error("InternalErr, the error is {} context is {:#?}", .source,.context)]
     InternalErr {
         /// Error source
         source: anyhow::Error,

--- a/src/common/logger.rs
+++ b/src/common/logger.rs
@@ -1,5 +1,6 @@
 use tracing::level_filters::LevelFilter as Level;
 use tracing_subscriber::filter;
+use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::prelude::*;
 
@@ -51,7 +52,6 @@ impl LogRole {
         }
     }
 }
-
 /// Initialize the logger with the default settings.
 /// The log file is located at `./datenlord.log`.
 #[allow(clippy::let_underscore_must_use)]
@@ -63,7 +63,7 @@ pub fn init_logger(role: LogRole) {
         .with_target("h2", Level::WARN)
         .with_target("tower", Level::WARN)
         .with_target("datenlord::async_fuse::fuse", Level::INFO)
-        .with_target("", Level::DEBUG);
+        .with_target("", Level::INFO);
 
     let log_path = format!("./datenlord_{}.log", role.as_str());
     let file = std::fs::OpenOptions::new()
@@ -74,9 +74,12 @@ pub fn init_logger(role: LogRole) {
         .unwrap_or_else(|err| panic!("Failed to open log file ,err {err}"));
 
     let layer = tracing_subscriber::fmt::layer()
+        .compact()
+        .with_file(false)
+        .with_target(false)
         .with_ansi(false)
-        .event_format(tracing_subscriber::fmt::format().pretty())
         .with_writer(std::sync::Mutex::new(file))
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
         .with_filter(filter);
 
     let subscriber = tracing_subscriber::Registry::default().with(layer);

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,6 @@ async fn parse_metadata(config: &InnerConfig) -> DatenLordResult<MetaData> {
     .await
 }
 
-#[allow(clippy::too_many_lines)]
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let config = InnerConfig::try_from(config::Config::parse())?;


### PR DESCRIPTION
In this pull request, I refactor the log datenlord print. Make it more compact, and more easier to process and read.