### PR TITLE
feat: Introduce backend and add configurable items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,11 @@ jobs:
     - uses: rustsec/audit-check@v1.4.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        # Temporarily ignore the time/chrono segfault since there are no known
+        # `RUSTSEC-2020-0071`: Temporarily ignore the time/chrono segfault since there are no known
         # good wordarounds and they are used by dependent libraries also.
-        ignore: RUSTSEC-2020-0071,RUSTSEC-2023-0052
+        #
+        # `RUSTSEC-2023-0071`: `rsa` crate depended by `opendal`. There are no better solutions now.
+        ignore: RUSTSEC-2020-0071,RUSTSEC-2023-0052,RUSTSEC-2023-0071
 
   check:
     name: Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           export ETCD_END_POINT=127.0.0.1:2379
           sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
           mkdir $DATENLORD_LOCAL_BIND_DIR
-          target/debug/datenlord --role=node --csi-endpoint=unix://$NODE_SOCKET_FILE --csi-worker-port=0 --node-name=localhost --node-ip=127.0.0.1 --csi-driver-name=io.datenlord.csi.plugin --mount-path=$DATENLORD_LOCAL_BIND_DIR --kv-server-list=$ETCD_END_POINT --storage-s3-access-key-id test  --storage-s3-secret-access-key test1234 --storage-s3-bucket  fuse-test-bucket  --storage-s3-endpoint-url http://127.0.0.1:9000 --storage-cache-capacity=1073741824 --server-port=8800 --storage-type=none &
+          target/debug/datenlord --role=node --csi-endpoint=unix://$NODE_SOCKET_FILE --csi-worker-port=0 --node-name=localhost --node-ip=127.0.0.1 --csi-driver-name=io.datenlord.csi.plugin --mount-path=$DATENLORD_LOCAL_BIND_DIR --kv-server-list=$ETCD_END_POINT --storage-fs-root=/tmp/datenlord_backend --server-port=8800 --storage-type=fs &
           target/debug/datenlord --role=controller --csi-endpoint=unix://$CONTROLLER_SOCKET_FILE --csi-worker-port=0 --node-name=localhost --node-ip=127.0.0.1 --csi-driver-name=io.datenlord.csi.plugin --mount-path=$DATENLORD_LOCAL_BIND_DIR --kv-server-list=$ETCD_END_POINT &
           ./csi-test/cmd/csi-sanity/csi-sanity -csi.endpoint=$NODE_SOCKET_FILE -csi.controllerendpoint=$CONTROLLER_SOCKET_FILE --ginkgo.flake-attempts 3
       - name: Setup tmate session

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 hashlink = "0.8.4"
 clap = { version = "4", features = ["derive"] }
+opendal = "0.43.0"
 
 [build-dependencies]
 protoc-grpcio = "3.0.0"

--- a/scripts/ci/csi-e2e-test.sh
+++ b/scripts/ci/csi-e2e-test.sh
@@ -40,9 +40,3 @@ kubernetes/test/bin/ginkgo -v -failFast -failOnPending -debug -focus='External.S
 # Run [Disruptive] test in serial and separately
 kubernetes/test/bin/ginkgo -v -failFast -failOnPending -debug -focus='External.Storage.*(\[Feature:|\[Disruptive\]|\[Serial\])' kubernetes/test/bin/e2e.test -- -v=5 -kubectl-path=`which kubectl` -kubeconfig=`realpath $K8S_CONFIG` -storage.testdriver=`realpath $E2E_TEST_CONFIG`
 /bin/sh /tmp/clean_up_mount_dir.sh $CONFIG_KIND $NODE_APP_LABEL $DATENLORD_NAMESPACE false
-
-# # Quick Start Test
-sed -e 's/e2e_test/latest/g' $CONFIG_KIND > $CONFIG_DOCKERHUB
-kubectl apply -f $CONFIG_DOCKERHUB
-kubectl wait --for=condition=Ready pod -l app=$CONTROLLER_APP_LABEL -n $DATENLORD_NAMESPACE --timeout=120s
-kubectl wait --for=condition=Ready pod -l app=$NODE_APP_LABEL -n $DATENLORD_NAMESPACE --timeout=120s

--- a/scripts/perf/datenlord-perf.yaml
+++ b/scripts/perf/datenlord-perf.yaml
@@ -32,17 +32,13 @@ spec:
           imagePullPolicy: "IfNotPresent"
           args:
             - "--role=asyncFuse"
-            - "--storage-cache-capacity=$(CACHE_CAPACITY)"
             - "--kv-server-list=$(ETCD_ENDPOINT)"
             - "--mount-path=$(FUSE_MOUNT_DIR)"
-            - "--storage-type=none"
+            - "--storage-type=fs"
             - "--node-name=$(NODE_ID)"
             - "--node-ip=$(NODE_IP)"
             - "--server-port=8800"
-            - "--storage-s3-access-key-id test"
-            - "--storage-s3-secret-access-key test1234"
-            - "--storage-s3-endpoint-url http://127.0.0.1:9000"
-            - "--storage-s3-bucket fuse-test-bucket"
+            - "--storage-fs-root=/tmp/datenlord_backend"
           lifecycle:
             #postStart:
             #  exec:

--- a/scripts/setup/datenlord.yaml
+++ b/scripts/setup/datenlord.yaml
@@ -207,18 +207,14 @@ spec:
           args:
             - "--role=node"
             - "--mount-path=$(FUSE_MOUNT_DIR)"
-            - "--storage-s3-access-key-id test"
-            - "--storage-s3-secret-access-key test1234"
-            - "--storage-s3-endpoint-url http://127.0.0.1:9000"
-            - "--storage-s3-bucket fuse-test-bucket"
+            - "--storage-fs-root=/tmp/datenlord_backend"
             - "--csi-endpoint=$(CSI_NODE_ENDPOINT)"
             - "--csi-driver-name=csi.datenlord.io"
             - "--kv-server-list=$(ETCD_ENDPOINT)"
             - "--node-name=$(NODE_ID)"
             - "--node-ip=$(NODE_IP)"
-            - "--storage-cache-capacity=$(CACHE_CAPACITY)"
             - "--server-port=8800"
-            - "--storage-type=none"
+            - "--storage-type=fs"
             - "--csi-worker-port=50051"
           lifecycle:
             #postStart:

--- a/scripts/setup/start_local_node.sh
+++ b/scripts/setup/start_local_node.sh
@@ -60,4 +60,15 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Starting datenlord.. ... ... ..."
-./target/debug/datenlord --role=node --csi-endpoint=unix:///tmp/node.sock --csi-worker-port=0 --node-name=localhost --node-ip=127.0.0.1 --csi-driver-name=io.datenlord.csi.plugin --mount-path=$DATENLORD_LOCAL_BIND_DIR --kv-server-list=127.0.0.1:2379 --storage-s3-access-key-id test  --storage-s3-secret-access-key test1234 --storage-s3-bucket  fuse-test-bucket  --storage-s3-endpoint-url http://127.0.0.1:9000 --storage-cache-capacity=1073741824 --server-port=8800 --storage-type=none 
+./target/debug/datenlord \
+--role=node \
+--csi-endpoint=unix:///tmp/node.sock \
+--csi-worker-port=0 \
+--node-name=localhost \
+--node-ip=127.0.0.1 \
+--csi-driver-name=io.datenlord.csi.plugin \
+--mount-path=$DATENLORD_LOCAL_BIND_DIR \
+--kv-server-list=127.0.0.1:2379 \
+--storage-fs-root=/tmp/datenlord_backend \
+--server-port=8800 \
+--storage-type=fs 

--- a/src/async_fuse/memfs/cache/backend.rs
+++ b/src/async_fuse/memfs/cache/backend.rs
@@ -1,0 +1,429 @@
+//! The implementation of backend.
+
+use async_trait::async_trait;
+use clippy_utilities::OverflowArithmetic;
+use futures::{stream, AsyncReadExt, AsyncWriteExt, StreamExt};
+use opendal::{ErrorKind, Operator};
+
+use super::{Block, Storage};
+use crate::async_fuse::fuse::protocol::INum;
+
+/// Get file path by `ino`
+fn get_file_path(ino: INum) -> String {
+    format!("{ino}/")
+}
+
+/// Get block path by `ino` and `block_id`
+fn get_block_path(ino: INum, block_id: usize) -> String {
+    format!("{ino}/{block_id}.block")
+}
+
+/// The backend wrapper of `openDAL` operator.
+#[derive(Debug)]
+pub struct Backend {
+    /// The inner `Operator`
+    operator: Operator,
+    /// Block size
+    block_size: usize,
+}
+
+impl Backend {
+    /// Create a new backend
+    #[must_use]
+    pub fn new(operator: Operator, block_size: usize) -> Self {
+        Self {
+            operator,
+            block_size,
+        }
+    }
+}
+
+#[async_trait]
+impl Storage for Backend {
+    async fn load_from_self(&self, ino: INum, block_id: usize) -> Option<Block> {
+        let mut block = Block::new_zeroed(self.block_size);
+
+        if let Err(e) = self
+            .operator
+            .reader(&get_block_path(ino, block_id))
+            .await
+            .unwrap_or_else(|e| {
+                panic!("Failed to get a reader where ino={ino} and block={block_id}: {e}")
+            })
+            .read(block.make_mut_slice())
+            .await
+        {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                None
+            } else {
+                panic!(
+                    "Failed to load a block from backend where ino={ino} and block={block_id}: {e}"
+                );
+            }
+        } else {
+            Some(block)
+        }
+    }
+
+    async fn load_from_backend(&self, _: INum, _: usize) -> Option<Block> {
+        // This storage has no backend.
+        None
+    }
+
+    async fn cache_block_from_backend(&self, _: INum, _: usize, _: Block) {
+        unreachable!("This storage has no backend, and has no cache.");
+    }
+
+    async fn store(&self, ino: INum, block_id: usize, block: Block) {
+        let path = get_block_path(ino, block_id);
+
+        let block_start = block.start();
+        let block_end = block.end();
+
+        if block_start == 0 && block_end == self.block_size {
+            // To store a whole block
+            let mut writer = self.operator.writer(&path).await.unwrap_or_else(|e| {
+                panic!(
+                    "Failed to get a writer to backend where ino={ino} and block={block_id}: {e}"
+                )
+            });
+            writer.write_all(block.as_slice()).await.unwrap_or_else(|e| panic!("Failed to store a block to backend where ino={ino} and block={block_id}: {e}"));
+            writer.close().await.unwrap_or_else(|e| {
+                panic!("Failed to close the writer where ion={ino} and block={block_id}: {e}")
+            });
+            return;
+        }
+
+        let mut dest = self.operator.read(&path).await.unwrap_or_else(|e| {
+            if e.kind() == ErrorKind::NotFound {
+                // Create an empty block for overwriting is ok.
+                vec![]
+            } else {
+                panic!("Failed to load a block to backend for overwrite where ino={ino} and block={block_id}: {e}");
+            }
+        });
+
+        // Ensure that the vector is long enough to be overwritten
+        if dest.len() < block_end {
+            dest.resize(block_end, 0);
+        }
+
+        // merge two blocks
+        dest.get_mut(block_start..block_end)
+            .unwrap_or_else(|| unreachable!("The vector is ensured to be long enough."))
+            .copy_from_slice(block.as_slice());
+        self.operator.write(&path, dest).await.unwrap_or_else(|e| {
+            panic!("Failed to store a block to backend where ino={ino} and block={block_id}: {e}")
+        });
+    }
+
+    async fn remove(&self, ino: INum) {
+        self.operator
+            .remove_all(&get_file_path(ino))
+            .await
+            .unwrap_or_else(|e| panic!("Failed to remove a file of ino={ino}: {e}"));
+    }
+
+    async fn invalidate(&self, _: INum) {
+        // This storage has no cache, therefore, its contents cannot be
+        // invalidated.
+    }
+
+    async fn flush(&self, _: INum) {
+        // This storage has no cache and backend, therefore, there is no need to
+        // flush its data.
+    }
+
+    async fn flush_all(&self) {
+        // This storage has no cache and backend, therefore, there is no need to
+        // flush its data.
+    }
+
+    async fn truncate(&self, ino: INum, from_block: usize, to_block: usize, fill_start: usize) {
+        let paths =
+            stream::iter(to_block..from_block).map(|block_id| get_block_path(ino, block_id));
+
+        let file_path = get_file_path(ino);
+
+        let file_exists = self.operator.is_exist(&file_path).await.unwrap_or(false);
+
+        if file_exists {
+            if to_block == 0 {
+                self.operator
+                    .remove_all(&file_path)
+                    .await
+                    .unwrap_or_else(|e| panic!("Failed to remove file a file of ino={ino}: {e}"));
+                return;
+            }
+
+            self.operator.remove_via(paths).await.unwrap_or_else(|e| panic!("Failed to truncate file ino={ino} from block {from_block} to block {to_block}: {e}"));
+
+            // truncate the last block
+            if to_block > 0 && fill_start < self.block_size {
+                let truncate_block_id = to_block.overflow_sub(1);
+                let path = get_block_path(ino, truncate_block_id);
+                match self.operator.read(&path).await {
+                    Ok(mut dest) => {
+                        dest.truncate(fill_start);
+                        self.operator.write(&path, dest).await.unwrap_or_else(|e| panic!("Failed to store a block to backend where ino={ino} and block={truncate_block_id}: {e}"));
+                    }
+                    Err(e) => {
+                        // It's OK that the block is not found for truncate.
+                        assert!(e.kind() == ErrorKind::NotFound, "Failed to load a block from backend for truncate where ino={ino} and block={truncate_block_id}: {e}");
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::indexing_slicing)]
+mod tests {
+    use std::path::Path;
+
+    use opendal::services::Fs;
+    use opendal::Operator;
+    use tokio::fs;
+
+    use super::{Backend, Block, Storage};
+
+    const BLOCK_SIZE_IN_BYTES: usize = 8;
+    const BLOCK_CONTENT: &[u8; BLOCK_SIZE_IN_BYTES] = b"foo bar ";
+    const BACKEND_ROOT: &str = "/tmp/opendal";
+
+    /// Prepare a backend
+    fn prepare_backend(root: &str) -> Backend {
+        let mut builder = Fs::default();
+        builder.root(root);
+        let op = Operator::new(builder).unwrap().finish();
+
+        Backend::new(op, BLOCK_SIZE_IN_BYTES)
+    }
+
+    #[tokio::test]
+    async fn test_backend_read() {
+        let backend_root = format!("{BACKEND_ROOT}/read");
+        fs::create_dir_all(&backend_root).await.unwrap();
+
+        let backend = prepare_backend(&backend_root);
+
+        let backend_root = Path::new(&backend_root);
+
+        let loaded = backend.load(0, 0).await;
+        assert!(loaded.is_none());
+
+        fs::create_dir_all(backend_root.join("0")).await.unwrap();
+        fs::write(backend_root.join("0").join("0.block"), BLOCK_CONTENT)
+            .await
+            .unwrap();
+
+        let loaded = backend.load(0, 0).await.unwrap();
+        assert_eq!(loaded.as_slice(), BLOCK_CONTENT);
+
+        fs::remove_dir_all(backend_root).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_write_whole_block() {
+        let backend_root = format!("{BACKEND_ROOT}/write_whole_block");
+        fs::create_dir_all(&backend_root).await.unwrap();
+        let backend = prepare_backend(&backend_root);
+
+        let backend_root = Path::new(&backend_root);
+
+        let block = Block::from_slice(BLOCK_SIZE_IN_BYTES, BLOCK_CONTENT);
+        backend.store(0, 0, block.clone()).await;
+
+        let block_path = backend_root.join("0").join("0.block");
+
+        let read_block_content = fs::read(&block_path).await.unwrap();
+        assert_eq!(BLOCK_CONTENT, &read_block_content[..BLOCK_SIZE_IN_BYTES]);
+
+        let loaded = backend.load(0, 0).await.unwrap();
+        assert_eq!(loaded.as_slice(), BLOCK_CONTENT);
+
+        fs::remove_dir_all(backend_root).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_write_in_middle() {
+        let backend_root = format!("{BACKEND_ROOT}/write_in_middle");
+        fs::create_dir_all(&backend_root).await.unwrap();
+        let backend = prepare_backend(&backend_root);
+
+        let backend_root = Path::new(&backend_root);
+
+        let mut block = Block::from_slice(BLOCK_SIZE_IN_BYTES, BLOCK_CONTENT);
+        block.set_start(3);
+        block.set_end(7);
+        backend.store(0, 0, block).await;
+        let loaded = backend.load(0, 0).await.unwrap();
+        assert_eq!(loaded.as_slice(), b"\0\0\0 bar\0");
+
+        fs::remove_dir_all(backend_root).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_write_append() {
+        let backend_root = format!("{BACKEND_ROOT}/write_append");
+        fs::create_dir_all(&backend_root).await.unwrap();
+        let backend = prepare_backend(&backend_root);
+
+        let backend_root = Path::new(&backend_root);
+
+        let mut block = Block::from_slice(BLOCK_SIZE_IN_BYTES, BLOCK_CONTENT);
+        block.set_start(0);
+        block.set_end(4);
+        backend.store(0, 0, block).await;
+        let loaded = backend.load(0, 0).await.unwrap();
+        assert_eq!(loaded.as_slice(), b"foo \0\0\0\0");
+
+        let mut block = Block::from_slice(BLOCK_SIZE_IN_BYTES, BLOCK_CONTENT);
+        block.set_start(4);
+        block.set_end(8);
+        backend.store(0, 0, block).await;
+        let loaded = backend.load(0, 0).await.unwrap();
+        assert_eq!(loaded.as_slice(), BLOCK_CONTENT);
+
+        fs::remove_dir_all(backend_root).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_overwrite() {
+        let backend_root = format!("{BACKEND_ROOT}/overwrite");
+        fs::create_dir_all(&backend_root).await.unwrap();
+        let backend = prepare_backend(&backend_root);
+
+        let backend_root = Path::new(&backend_root);
+
+        let block = Block::from_slice(BLOCK_SIZE_IN_BYTES, BLOCK_CONTENT);
+        backend.store(0, 0, block).await;
+        let loaded = backend.load(0, 0).await.unwrap();
+        assert_eq!(loaded.as_slice(), BLOCK_CONTENT);
+
+        let block = Block::from_slice_with_range(BLOCK_SIZE_IN_BYTES, 4, 8, b"foo ");
+        backend.store(0, 0, block).await;
+        let loaded = backend.load(0, 0).await.unwrap();
+        assert_eq!(loaded.as_slice(), b"foo foo ");
+
+        fs::remove_dir_all(backend_root).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_truncate() {
+        let backend_root = format!("{BACKEND_ROOT}/truncate");
+        fs::create_dir_all(&backend_root).await.unwrap();
+        let backend = prepare_backend(&backend_root);
+
+        let backend_root = Path::new(&backend_root);
+
+        for block_id in 0..4 {
+            backend
+                .store(
+                    0,
+                    block_id,
+                    Block::from_slice(BLOCK_SIZE_IN_BYTES, BLOCK_CONTENT),
+                )
+                .await;
+        }
+
+        backend.truncate(0, 4, 1, BLOCK_SIZE_IN_BYTES).await;
+        let loaded = backend.load(0, 0).await.unwrap();
+        assert_eq!(loaded.as_slice(), BLOCK_CONTENT);
+
+        for block_id in 1..4 {
+            let loaded = backend.load(0, block_id).await;
+            assert!(loaded.is_none());
+        }
+
+        // truncate to block_id=0 will remove the whole file.
+        backend.truncate(0, 1, 0, BLOCK_SIZE_IN_BYTES).await;
+
+        // check if the file is removed from the backend.
+        let file_path = backend_root.join("0");
+        let file_dir_exist = fs::try_exists(&file_path).await.unwrap();
+        assert!(!file_dir_exist);
+
+        fs::remove_dir_all(backend_root).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_truncate_block() {
+        let backend_root = format!("{BACKEND_ROOT}/truncate_block");
+        fs::create_dir_all(&backend_root).await.unwrap();
+        let backend = prepare_backend(&backend_root);
+
+        let backend_root = Path::new(&backend_root);
+
+        for block_id in 0..4 {
+            backend
+                .store(
+                    0,
+                    block_id,
+                    Block::from_slice(BLOCK_SIZE_IN_BYTES, BLOCK_CONTENT),
+                )
+                .await;
+        }
+
+        backend.truncate(0, 4, 1, 4).await;
+        let loaded = backend.load(0, 0).await.unwrap();
+        assert_eq!(loaded.as_slice(), b"foo \0\0\0\0");
+
+        fs::remove_dir_all(backend_root).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_truncate_not_found() {
+        let backend_root = format!("{BACKEND_ROOT}/truncate_not_found");
+        fs::create_dir_all(&backend_root).await.unwrap();
+        let backend = prepare_backend(&backend_root);
+
+        let backend_root = Path::new(&backend_root);
+
+        backend
+            .store(0, 0, Block::from_slice(BLOCK_SIZE_IN_BYTES, BLOCK_CONTENT))
+            .await;
+
+        fs::remove_file(backend_root.join("0").join("0.block"))
+            .await
+            .unwrap();
+
+        // Should not panic
+        backend.truncate(0, 4, 1, 4).await;
+
+        fs::remove_dir_all(backend_root).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_remove() {
+        let backend_root = format!("{BACKEND_ROOT}/remove");
+        fs::create_dir_all(&backend_root).await.unwrap();
+        let backend = prepare_backend(&backend_root);
+
+        let backend_root = Path::new(&backend_root);
+
+        backend
+            .store(0, 0, Block::from_slice(BLOCK_SIZE_IN_BYTES, BLOCK_CONTENT))
+            .await;
+        backend.remove(0).await;
+
+        assert!(!fs::try_exists(backend_root.join("0")).await.unwrap());
+
+        fs::remove_dir_all(backend_root).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_unused() {
+        let backend_root = format!("{BACKEND_ROOT}/unused");
+        fs::create_dir_all(&backend_root).await.unwrap();
+        let backend = prepare_backend(&backend_root);
+
+        // Do nothing, and should not panic.
+        backend.flush(0).await;
+        backend.flush_all().await;
+        backend.invalidate(0).await;
+
+        fs::remove_dir_all(backend_root).await.unwrap();
+    }
+}

--- a/src/async_fuse/memfs/cache/backend.rs
+++ b/src/async_fuse/memfs/cache/backend.rs
@@ -175,7 +175,9 @@ impl Storage for Backend {
         self.operator
             .remove_all(&get_file_path(ino))
             .await
-            .unwrap_or_else(|e| panic!("Failed to remove a file of ino={ino}: {e}"));
+            .unwrap_or_else(|e| {
+                panic!("Failed to remove a file from the backend of ino={ino}: {e}")
+            });
     }
 
     async fn invalidate(&self, _: INum) {
@@ -219,7 +221,7 @@ impl Storage for Backend {
                 match self.operator.read(&path).await {
                     Ok(mut dest) => {
                         dest.truncate(fill_start);
-                        self.operator.write(&path, dest).await.unwrap_or_else(|e| panic!("Failed to store a block to backend where ino={ino} and block={truncate_block_id}: {e}"));
+                        self.operator.write(&path, dest).await.unwrap_or_else(|e| panic!("Failed to store a block to backend for truncate where ino={ino} and block={truncate_block_id}: {e}"));
                     }
                     Err(e) => {
                         // It's OK that the block is not found for truncate.
@@ -479,5 +481,123 @@ mod tests {
         backend.invalidate(0).await;
 
         fs::remove_dir_all(backend_root).await.unwrap();
+    }
+
+    mod pessimistic {
+        use std::fs::Permissions;
+        use std::path::Path;
+
+        use smol::fs::unix::PermissionsExt;
+        use tokio::fs;
+
+        use super::{prepare_backend, BACKEND_ROOT, BLOCK_CONTENT, BLOCK_SIZE_IN_BYTES};
+        use crate::async_fuse::memfs::cache::{Block, Storage};
+
+        async fn cleanup(backend_root: &str) {
+            if fs::try_exists(backend_root).await.unwrap() {
+                std::process::Command::new("chmod")
+                    .args(["-R", "755", backend_root])
+                    .output()
+                    .unwrap();
+                fs::remove_dir_all(backend_root).await.unwrap();
+            }
+        }
+
+        #[tokio::test]
+        #[should_panic(expected = "backend")]
+        async fn test_failed_load() {
+            let backend_root = format!("{BACKEND_ROOT}/failed_load");
+            cleanup(&backend_root).await;
+            fs::create_dir_all(&backend_root).await.unwrap();
+            let backend = prepare_backend(&backend_root);
+
+            let backend_root = Path::new(&backend_root);
+            let file_0_path = backend_root.join("0");
+            fs::create_dir_all(&file_0_path).await.unwrap();
+            fs::write(file_0_path.join("0.block"), BLOCK_CONTENT)
+                .await
+                .unwrap();
+
+            // permission: -w-------
+            let permissions = Permissions::from_mode(0o200);
+            fs::set_permissions(file_0_path.join("0.block"), permissions)
+                .await
+                .unwrap();
+
+            // Permission Denied
+            let _: Option<Block> = backend.load(0, 0).await;
+        }
+
+        #[tokio::test]
+        #[should_panic(expected = "backend")]
+        async fn test_failed_store() {
+            let backend_root = format!("{BACKEND_ROOT}/failed_store");
+            cleanup(&backend_root).await;
+            fs::create_dir_all(&backend_root).await.unwrap();
+            let backend = prepare_backend(&backend_root);
+
+            let backend_root = Path::new(&backend_root);
+
+            // permission: r-xr-xr-x
+            let permissions = Permissions::from_mode(0o555);
+            fs::set_permissions(&backend_root, permissions)
+                .await
+                .unwrap();
+
+            // Permission Denied
+            backend
+                .store(0, 0, Block::new_zeroed(BLOCK_SIZE_IN_BYTES))
+                .await;
+        }
+
+        #[tokio::test]
+        #[should_panic(expected = "backend")]
+        async fn test_failed_remove() {
+            let backend_root = format!("{BACKEND_ROOT}/failed_remove");
+            cleanup(&backend_root).await;
+            fs::create_dir_all(&backend_root).await.unwrap();
+            let backend = prepare_backend(&backend_root);
+
+            backend
+                .store(0, 0, Block::new_zeroed(BLOCK_SIZE_IN_BYTES))
+                .await;
+
+            let backend_root = Path::new(&backend_root);
+
+            // permission: r-xr-xr-x
+            let permissions = Permissions::from_mode(0o555);
+            fs::set_permissions(&backend_root, permissions)
+                .await
+                .unwrap();
+
+            // Permission Denied
+            backend.remove(0).await;
+        }
+
+        #[tokio::test]
+        #[should_panic(expected = "truncate")]
+        async fn test_failed_truncate() {
+            let backend_root = format!("{BACKEND_ROOT}/failed_truncate");
+            cleanup(&backend_root).await;
+            fs::create_dir_all(&backend_root).await.unwrap();
+            let backend = prepare_backend(&backend_root);
+
+            for block_id in 0..8 {
+                backend
+                    .store(0, block_id, Block::new_zeroed(BLOCK_SIZE_IN_BYTES))
+                    .await;
+            }
+
+            let backend_root = Path::new(&backend_root);
+
+            // permission: r-xr-xr-x
+            let permissions = Permissions::from_mode(0o555);
+            fs::set_permissions(backend_root.join("0"), permissions)
+                .await
+                .unwrap();
+
+            // Permission Denied
+            backend.truncate(0, 8, 4, 4).await;
+        }
     }
 }

--- a/src/async_fuse/memfs/cache/block.rs
+++ b/src/async_fuse/memfs/cache/block.rs
@@ -81,6 +81,7 @@ impl Block {
     }
 
     /// Creates a block with `size` and a range.
+    #[must_use]
     pub fn new_zeroed_with_range(size: usize, start: usize, end: usize) -> Self {
         Block {
             inner: Arc::new(AlignedBytes::new_zeroed(size, PAGE_SIZE)),
@@ -95,6 +96,7 @@ impl Block {
     /// If `data` is longer than the block, the rest of the slice will be
     /// ignored; if `data` is shorter than the block, the rest part of the
     /// block will remains 0.
+    #[must_use]
     pub fn from_slice(size: usize, data: &[u8]) -> Self {
         let mut inner = AlignedBytes::new_zeroed(size, PAGE_SIZE);
 
@@ -120,6 +122,7 @@ impl Block {
     /// If `data` is longer than the block, the rest of the slice will be
     /// ignored; if `data` is shorter than the block, the rest part of the
     /// block will remains 0.
+    #[must_use]
     pub fn from_slice_with_range(size: usize, start: usize, end: usize, data: &[u8]) -> Self {
         debug_assert!(start <= end);
         debug_assert!(
@@ -170,6 +173,7 @@ impl Block {
     }
 
     /// Gets the valid range of this block.
+    #[must_use]
     pub fn as_slice(&self) -> &[u8] {
         self.inner.get(self.start..self.end).unwrap_or_else(|| {
             unreachable!(
@@ -359,7 +363,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "out of range")]
     fn test_io_block_out_of_range() {
-        Block::from_slice_with_range(4, 0, 8, b"abcd");
+        let _block = Block::from_slice_with_range(4, 0, 8, b"abcd");
     }
 
     #[test]

--- a/src/async_fuse/memfs/cache/memory_cache/builder.rs
+++ b/src/async_fuse/memfs/cache/memory_cache/builder.rs
@@ -4,11 +4,12 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
+use datenlord::config::SoftLimit;
 use tokio::sync::mpsc;
 
 use super::{write_back_task, MemoryCache};
 use crate::async_fuse::memfs::cache::policy::EvictPolicy;
-use crate::async_fuse::memfs::cache::{BlockCoordinate, SoftLimit, Storage};
+use crate::async_fuse::memfs::cache::{BlockCoordinate, Storage};
 
 /// The default limitation of the command queue of write back task.
 const DEFAULT_COMMAND_QUEUE_LIMIT: usize = 1000;
@@ -16,6 +17,7 @@ const DEFAULT_COMMAND_QUEUE_LIMIT: usize = 1000;
 const DEFAULT_INTERVAL_IN_MILLISEC: u64 = 100;
 
 /// A builder to configure and build a `MemoryCache`.
+#[derive(Debug)]
 pub struct MemoryCacheBuilder<P, S> {
     /// The `policy` used by the built `MemoryCache`
     policy: P,
@@ -57,6 +59,7 @@ where
     }
 
     /// Set write policy. Write through is enabled by default.
+    #[must_use]
     pub fn write_through(mut self, write_through: bool) -> Self {
         self.write_through = write_through;
         self
@@ -65,18 +68,21 @@ where
     /// Set the soft limit for the write back task.
     ///
     /// See [`SoftLimit`] for details.
+    #[must_use]
     pub fn limit(mut self, limit: SoftLimit) -> Self {
         self.limit = limit;
         self
     }
 
     /// Set the interval for the write back task
+    #[must_use]
     pub fn interval(mut self, interval: Duration) -> Self {
         self.interval = interval;
         self
     }
 
     /// Set the limitation of the message queue of the write back task.
+    #[must_use]
     pub fn command_queue_limit(mut self, limit: usize) -> Self {
         self.command_queue_limit = limit;
         self

--- a/src/async_fuse/memfs/cache/memory_cache/mod.rs
+++ b/src/async_fuse/memfs/cache/memory_cache/mod.rs
@@ -6,7 +6,6 @@ mod write_back_task;
 
 pub use builder::MemoryCacheBuilder;
 pub use cache::MemoryCache;
-pub use write_back_task::SoftLimit;
 
 #[cfg(test)]
 mod tests;

--- a/src/async_fuse/memfs/cache/memory_cache/tests.rs
+++ b/src/async_fuse/memfs/cache/memory_cache/tests.rs
@@ -4,7 +4,8 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
-use super::write_back_task::SoftLimit;
+use datenlord::config::SoftLimit;
+
 use super::{MemoryCache, MemoryCacheBuilder};
 use crate::async_fuse::memfs::cache::mock::MemoryStorage;
 use crate::async_fuse::memfs::cache::policy::LruPolicy;

--- a/src/async_fuse/memfs/cache/memory_cache/write_back_task.rs
+++ b/src/async_fuse/memfs/cache/memory_cache/write_back_task.rs
@@ -2,11 +2,11 @@
 
 use std::collections::HashMap;
 use std::mem;
-use std::num::NonZeroUsize;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 use clippy_utilities::OverflowArithmetic;
+use datenlord::config::SoftLimit;
 use hashlink::LinkedHashSet;
 use tokio::select;
 use tokio::sync::{mpsc, oneshot};
@@ -234,14 +234,3 @@ pub(super) async fn run_write_back_task<P, S>(
         }
     }
 }
-
-/// A type to represent the soft limit of cache.
-///
-/// It's represented as a fraction, for example,
-/// a soft limit of `SoftLimit(3, 5)` means the soft limit is
-/// `3/5` if the policy's capacity.
-///
-/// Because the second component of this struct is used as a denominator,
-/// it cannot be zero, therefore, we use `NonZeroUsize` here.
-#[derive(Debug, Clone, Copy)]
-pub struct SoftLimit(pub usize, pub NonZeroUsize);

--- a/src/async_fuse/memfs/cache/mod.rs
+++ b/src/async_fuse/memfs/cache/mod.rs
@@ -12,10 +12,10 @@ mod storage_manager;
 
 pub mod policy;
 
-pub use backend::Backend;
+pub use backend::{Backend, BackendBuilder};
 pub use block::{Block, BlockCoordinate};
 pub use global_cache::*;
-pub use memory_cache::{MemoryCache, MemoryCacheBuilder, SoftLimit};
+pub use memory_cache::{MemoryCache, MemoryCacheBuilder};
 pub use storage::Storage;
 pub use storage_manager::StorageManager;
 

--- a/src/async_fuse/memfs/cache/mod.rs
+++ b/src/async_fuse/memfs/cache/mod.rs
@@ -3,6 +3,7 @@
 // TODO: Remove this after the storage is ready for product env.
 #![allow(dead_code)]
 
+mod backend;
 mod block;
 mod global_cache;
 mod memory_cache;
@@ -11,6 +12,7 @@ mod storage_manager;
 
 pub mod policy;
 
+pub use backend::Backend;
 pub use block::{Block, BlockCoordinate};
 pub use global_cache::*;
 pub use memory_cache::{MemoryCache, MemoryCacheBuilder, SoftLimit};

--- a/src/async_fuse/memfs/cache/storage_manager.rs
+++ b/src/async_fuse/memfs/cache/storage_manager.rs
@@ -811,12 +811,12 @@ mod tests {
         use std::time::{Duration, SystemTime};
 
         use clippy_utilities::OverflowArithmetic;
+        use datenlord::config::SoftLimit;
 
         use super::{
             BlockCoordinate, LruPolicy, MemoryCacheBuilder, MemoryStorage, Storage, StorageManager,
             BLOCK_CONTENT, BLOCK_SIZE_IN_BYTES,
         };
-        use crate::async_fuse::memfs::cache::SoftLimit;
 
         macro_rules! elapsed {
             ($body:expr) => {{

--- a/src/async_fuse/memfs/mod.rs
+++ b/src/async_fuse/memfs/mod.rs
@@ -1,5 +1,5 @@
 //! The implementation of user space file system
-mod cache;
+pub mod cache;
 mod dir;
 /// distributed communication module
 pub mod dist;

--- a/src/async_fuse/mod.rs
+++ b/src/async_fuse/mod.rs
@@ -37,12 +37,12 @@ pub async fn start_async_fuse(
     memfs::kv_engine::kv_utils::register_volume(&kv_engine, &args.node_id, &volume_info).await?;
 
     let mount_point = std::path::Path::new(&args.mount_dir);
-
+    let global_cache_capacity = args.storage_config.memory_cache_config.capacity;
     match args.storage_config.params {
         StorageParams::S3(_) => {
             let fs: memfs::MemFs<memfs::S3MetaData<S3BackEndImpl>> = memfs::MemFs::new(
                 &args.mount_dir,
-                args.storage_config.cache_capacity,
+                global_cache_capacity,
                 &args.ip_address.to_string(),
                 args.server_port,
                 kv_engine,
@@ -54,10 +54,10 @@ pub async fn start_async_fuse(
             let ss = session::new_session_of_memfs(mount_point, fs).await?;
             ss.run().await?;
         }
-        StorageParams::None(_) => {
+        StorageParams::Fs(_) => {
             let fs: memfs::MemFs<memfs::S3MetaData<DoNothingImpl>> = memfs::MemFs::new(
                 &args.mount_dir,
-                args.storage_config.cache_capacity,
+                global_cache_capacity,
                 &args.ip_address.to_string(),
                 args.server_port,
                 kv_engine,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,4 +6,7 @@ mod config;
 mod inner;
 
 pub use config::Config;
-pub use inner::{InnerConfig, Role as NodeRole, StorageConfig, StorageParams, StorageS3Config};
+pub use inner::{
+    InnerConfig, MemoryCacheConfig, Role as NodeRole, SoftLimit, StorageConfig, StorageParams,
+    StorageS3Config,
+};


### PR DESCRIPTION
In this PR, we introduced the backend with `openDAL`, and added new items to configure the storage module.

The patches of config items are listed below:
1. Renamed one of the variant of storage type from `None` to `Fs`, and changed its member from a `S3StorageConfig` to a String representing the root of filesystem based backend.
2. Added `--storage-mem-cache-capacity`, `--storage-mem-cache-command-limit`, `--storage-mem-write-back` and `--storage-mem-cache-soft-limit` as the cocnfig of memory cache.
3. Removed `--storage-cache-capacity`, it's for the legacy `GlobalCache`, which will be removed soon.
