### PR TITLE
feat(kv): Introduce 'DirEntry' realted codes

### DIFF
--- a/src/async_fuse/memfs/direntry.rs
+++ b/src/async_fuse/memfs/direntry.rs
@@ -1,0 +1,128 @@
+// Use of external crates and modules
+use datenlord::common::error::DatenLordError;
+use nix::sys::stat::SFlag;
+use serde::{Deserialize, Serialize};
+use tracing::error;
+
+use crate::async_fuse::fuse::protocol::INum;
+
+/// Represents the type of a file in a filesystem.
+///
+/// This enum is used to distinguish between directories, files, and symlinks.
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+pub enum FileType {
+    /// A directory.
+    Dir,
+    /// A regular file.
+    File,
+    /// A symbolic link.
+    Symlink,
+}
+
+impl TryFrom<SFlag> for FileType {
+    type Error = DatenLordError;
+
+    /// Attempts to convert an `SFlag` value into a `FileType`.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The `SFlag` value representing file type at the OS level.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(FileType)` - If the conversion is successful.
+    /// * `Err(DatenLordError)` - If the `SFlag` value does not correspond to a
+    ///   known `FileType`.
+    fn try_from(value: SFlag) -> Result<Self, Self::Error> {
+        match value {
+            SFlag::S_IFDIR => Ok(Self::Dir),
+            SFlag::S_IFREG => Ok(Self::File),
+            SFlag::S_IFLNK => Ok(Self::Symlink),
+            _ => {
+                error!("Try convert {:?} to FileType failed.", value);
+                Err(DatenLordError::ArgumentInvalid { context: vec![] })
+            }
+        }
+    }
+}
+
+/// Represents a directory entry in a filesystem.
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct DirEntry {
+    /// The inode number of the child
+    inum: INum,
+    /// The name of the child
+    name: String,
+    /// The type of the child
+    file_type: FileType,
+}
+
+impl DirEntry {
+    /// Creates a new `DirEntry`.
+    ///
+    /// # Arguments
+    ///
+    /// * `inum` - The inode number of the file or directory.
+    /// * `name` - The name of the file or directory.
+    /// * `file_type` - The type of the file (directory, file, or symlink).
+    ///
+    /// # Returns
+    ///
+    /// * `DirEntry` - The new `DirEntry` instance.
+    #[must_use]
+    pub fn new(inum: INum, name: String, file_type: FileType) -> Self {
+        Self {
+            inum,
+            name,
+            file_type,
+        }
+    }
+
+    /// Returns the inode number of the file or directory.
+    #[must_use]
+    pub fn inum(&self) -> INum {
+        self.inum
+    }
+
+    /// Returns the name of the file or directory.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the type of the file (directory, file, or symlink).
+    #[must_use]
+    pub fn file_type(&self) -> FileType {
+        self.file_type.clone()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::assertions_on_result_states)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_file_type_serialization() {
+        let file_type = FileType::Dir;
+        let file_type_bytes = bincode::serialize(&file_type).unwrap();
+        let file_type2: FileType = bincode::deserialize(&file_type_bytes).unwrap();
+        assert_eq!(file_type, file_type2);
+    }
+
+    #[test]
+    fn test_unsupported_file_type_conversion() {
+        let unsupported_sflag = SFlag::S_IFSOCK; // Assuming S_IFSOCK is not supported
+        let file_type_result = FileType::try_from(unsupported_sflag);
+        assert!(file_type_result.is_err());
+    }
+
+    #[test]
+    fn test_dir_entry_serialization() {
+        let dir_entry = DirEntry::new(1, "test".to_owned(), FileType::Dir);
+        let dir_entry_bytes = bincode::serialize(&dir_entry).unwrap();
+        let dir_entry2: DirEntry = bincode::deserialize(&dir_entry_bytes).unwrap();
+        assert_eq!(dir_entry, dir_entry2);
+    }
+}

--- a/src/async_fuse/memfs/dist/id_alloc.rs
+++ b/src/async_fuse/memfs/dist/id_alloc.rs
@@ -1,5 +1,6 @@
 //! Allocate unique id between nodes.
 
+use std::fmt::{self, Display};
 use std::ops::Add;
 use std::sync::Arc;
 use std::time::Duration;
@@ -21,6 +22,15 @@ pub enum IdType {
     Fd,
 }
 
+impl Display for IdType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            IdType::INum => write!(f, "INum"),
+            IdType::Fd => write!(f, "Fd"),
+        }
+    }
+}
+
 impl IdType {
     /// Convert to str for unique key
     /// The return value can't be same
@@ -28,8 +38,8 @@ impl IdType {
     #[inline]
     pub fn to_unique_id(&self) -> u8 {
         match *self {
-            IdType::INum => 0,
-            IdType::Fd => 1,
+            IdType::INum => b'0',
+            IdType::Fd => b'1',
         }
     }
 }

--- a/src/async_fuse/memfs/kv_engine/key_type.rs
+++ b/src/async_fuse/memfs/kv_engine/key_type.rs
@@ -1,0 +1,265 @@
+use std::fmt::{self, Display, Formatter, Write};
+
+use crate::async_fuse::fuse::protocol::INum;
+use crate::async_fuse::memfs::dist::id_alloc::IdType;
+
+/// The `KeyType` is used to locate the value in the distributed K/V storage.
+/// Every key is prefixed with a string to indicate the type of the value.
+/// If you want to add a new type of value, you need to add a new variant to the
+/// enum. And you need to add a new match arm to the `get_key` function , make
+/// sure the key is unique.
+#[derive(Debug, Eq, PartialEq)]
+pub enum KeyType {
+    /// INum -> SerailNode
+    INum2Node(INum),
+    /// (paretn_id,child_name) -> DirEntry
+    DirEntryKey((INum, String)),
+    /// IdAllocator value key
+    IdAllocatorValue(IdType),
+    /// Node ip and port info : node_id -> "{node_ipaddr}:{port}"
+    /// The corresponding value type is ValueType::String
+    NodeIpPort(String),
+    /// Volume information
+    /// The corresponding value type is ValueType::RawData
+    VolumeInfo(String),
+    /// Node list
+    /// The corresponding value type is ValueType::RawData
+    FileNodeList(INum),
+    /// Just a string key for testing the KVEngine.
+    #[cfg(test)]
+    String(String),
+}
+
+// ::<KeyType>::get() -> ValueType
+/// Lock key type the memfs used.
+#[derive(Debug, Eq, PartialEq)]
+#[allow(variant_size_differences)]
+pub enum LockKeyType {
+    /// IdAllocator lock key
+    IdAllocatorLock(IdType),
+    /// ETCD volume information lock
+    VolumeInfoLock,
+    /// ETCD file node list lock
+    FileNodeListLock(INum),
+}
+
+impl Display for KeyType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match *self {
+            KeyType::INum2Node(ref inum) => write!(f, "INum2Node({inum})"),
+            KeyType::DirEntryKey((ref parent_id, ref child_name)) => {
+                write!(f, "DirEntryKey(({parent_id}, {child_name}))")
+            }
+            KeyType::IdAllocatorValue(ref id_type) => write!(f, "IdAllocatorValue({id_type})"),
+            KeyType::NodeIpPort(ref s) => write!(f, "NodeIpPort({s})"),
+            KeyType::VolumeInfo(ref s) => write!(f, "VolumeInfo({s})"),
+            KeyType::FileNodeList(ref inum) => write!(f, "FileNodeList({inum})"),
+            #[cfg(test)]
+            KeyType::String(ref s) => write!(f, "String({s})"),
+        }
+    }
+}
+
+impl Display for LockKeyType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match *self {
+            LockKeyType::IdAllocatorLock(ref id_type) => {
+                write!(f, "IdAllocatorLock({id_type:?})")
+            }
+            LockKeyType::VolumeInfoLock => {
+                write!(f, "VolumeInfoLock")
+            }
+            LockKeyType::FileNodeListLock(ref inum) => {
+                write!(f, "FileNodeListLock({inum:?})")
+            }
+        }
+    }
+}
+
+impl KeyType {
+    /// Creates a string representation of the key.
+    /// This method concatenates the key's prefix with its formatted key value,
+    #[must_use]
+    pub fn to_string_key(&self) -> String {
+        let mut result = String::new();
+        let prefix = self.prefix();
+        write!(&mut result, "{prefix}").unwrap();
+        self.write_key(&mut result);
+        result
+    }
+
+    /// Retrieves the specific prefix associated with the key type
+    #[must_use]
+    pub fn prefix(&self) -> &str {
+        match *self {
+            KeyType::INum2Node(_) => "I",
+            KeyType::DirEntryKey(_) => "D",
+            #[cfg(test)]
+            KeyType::String(_) => "TEST_",
+            KeyType::IdAllocatorValue(_) => "IdAlloc",
+            KeyType::NodeIpPort(_) => "NodeIpPort",
+            KeyType::VolumeInfo(_) => "VolumeInfo",
+            KeyType::FileNodeList(_) => "FileNodeList",
+        }
+    }
+
+    /// Appends the unique part of the key to a mutable string buffer.
+    fn write_key(&self, f: &mut String) {
+        match *self {
+            KeyType::INum2Node(ref inum) => {
+                write!(f, "{inum}").unwrap();
+            }
+            KeyType::DirEntryKey((ref parent_id, ref child_name)) => {
+                write!(f, "{parent_id}_{child_name}").unwrap();
+            }
+            #[cfg(test)]
+            KeyType::String(ref s) => {
+                write!(f, "{s}").unwrap();
+            }
+            KeyType::IdAllocatorValue(ref id_type) => {
+                write!(f, "{id_type}").unwrap();
+            }
+            KeyType::NodeIpPort(ref s) => {
+                write!(f, "{s}").unwrap();
+            }
+            KeyType::VolumeInfo(ref s) => {
+                write!(f, "{s}").unwrap();
+            }
+            KeyType::FileNodeList(ref inum) => {
+                write!(f, "{inum}").unwrap();
+            }
+        }
+    }
+}
+
+impl LockKeyType {
+    /// Creates a string representation of the key.
+    /// This method concatenates the key's prefix with its formatted key value,
+    #[must_use]
+    pub fn to_string_key(&self) -> String {
+        let mut result = String::new();
+        let prefix = self.prefix();
+        write!(&mut result, "{prefix}").unwrap();
+        self.write_key(&mut result);
+        result
+    }
+
+    /// Retrieves the specific prefix associated with the lock key type.
+    #[must_use]
+    fn prefix(&self) -> &str {
+        match *self {
+            LockKeyType::IdAllocatorLock(_) => "IdAllocLock",
+            LockKeyType::VolumeInfoLock => "VolumeInfoLock",
+            LockKeyType::FileNodeListLock(_) => "FileNodeListLock",
+        }
+    }
+
+    /// Appends the unique part of the key to a mutable string buffer.
+    fn write_key(&self, f: &mut String) {
+        match *self {
+            LockKeyType::IdAllocatorLock(ref id_type) => {
+                write!(f, "{id_type}").unwrap();
+            }
+            LockKeyType::VolumeInfoLock => {
+                // No additional data is appended for VolumeInfoLock
+            }
+            LockKeyType::FileNodeListLock(ref inum) => {
+                write!(f, "{inum}").unwrap();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{IdType, KeyType, LockKeyType};
+
+    #[test]
+    fn test_inum2node_key() {
+        let key = KeyType::INum2Node(123);
+        assert_eq!(key.to_string_key(), "I123", "INum2Node key mismatch");
+    }
+
+    #[test]
+    fn test_direntry_key() {
+        let key = KeyType::DirEntryKey((456, "child".to_owned()));
+        assert_eq!(key.to_string_key(), "D456_child", "DirEntry key mismatch");
+    }
+
+    #[test]
+    fn test_idallocatorvalue_key() {
+        let key = KeyType::IdAllocatorValue(IdType::INum);
+        assert_eq!(
+            key.to_string_key(),
+            "IdAllocINum",
+            "IdAllocatorValue key mismatch"
+        );
+    }
+
+    #[test]
+    fn test_nodeipport_key() {
+        let key = KeyType::NodeIpPort("127.0.0.1:8080".to_owned());
+        assert_eq!(
+            key.to_string_key(),
+            "NodeIpPort127.0.0.1:8080",
+            "NodeIpPort key mismatch"
+        );
+    }
+
+    #[test]
+    fn test_volumeinfo_key() {
+        let key = KeyType::VolumeInfo("volume1".to_owned());
+        assert_eq!(
+            key.to_string_key(),
+            "VolumeInfovolume1",
+            "VolumeInfo key mismatch"
+        );
+    }
+
+    #[test]
+    fn test_filenodelist_key() {
+        let key = KeyType::FileNodeList(789);
+        assert_eq!(
+            key.to_string_key(),
+            "FileNodeList789",
+            "FileNodeList key mismatch"
+        );
+    }
+
+    #[cfg(test)]
+    #[test]
+    fn test_string_key() {
+        let key = KeyType::String("test".to_owned());
+        assert_eq!(key.to_string_key(), "TEST_test", "String key mismatch");
+    }
+
+    #[test]
+    fn test_idallocatorlock_key() {
+        let key = LockKeyType::IdAllocatorLock(IdType::INum);
+        assert_eq!(
+            key.to_string_key(),
+            "IdAllocLockINum",
+            "IdAllocatorLock key mismatch"
+        );
+    }
+
+    #[test]
+    fn test_volumeinfolock_key() {
+        let key = LockKeyType::VolumeInfoLock;
+        assert_eq!(
+            key.to_string_key(),
+            "VolumeInfoLock",
+            "VolumeInfoLock key mismatch"
+        );
+    }
+
+    #[test]
+    fn test_filenodelistlock_key() {
+        let key = LockKeyType::FileNodeListLock(123);
+        assert_eq!(
+            key.to_string_key(),
+            "FileNodeListLock123",
+            "FileNodeListLock key mismatch"
+        );
+    }
+}

--- a/src/async_fuse/memfs/kv_engine/value_type.rs
+++ b/src/async_fuse/memfs/kv_engine/value_type.rs
@@ -1,0 +1,92 @@
+use serde::{Deserialize, Serialize};
+
+use crate::async_fuse::memfs::direntry::DirEntry;
+use crate::async_fuse::memfs::s3_node::S3Node;
+use crate::async_fuse::memfs::s3_wrapper::S3BackEnd;
+use crate::async_fuse::memfs::serial::SerialNode;
+use crate::async_fuse::memfs::S3MetaData;
+use crate::common::error::DatenLordResult;
+
+/// The `ValueType` is used to provide support for metadata.
+///
+/// The variants `DirEntry`, `INum` and `Attr` are not used currently,
+/// but preserved for the future.
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub enum ValueType {
+    /// SerialNode
+    Node(SerialNode),
+    /// SerialDirEntry
+    DirEntry(DirEntry),
+    /// Next id allocate range begin
+    NextIdAllocateRangeBegin(u64),
+    /// Raw value
+    Raw(Vec<u8>),
+    /// String value
+    String(String),
+}
+
+impl ValueType {
+    #[allow(dead_code, clippy::wildcard_enum_match_arm)] // Allow wildcard because there should be only one enum branch matches one specific type.
+    /// Turn the `ValueType` into `SerialNode` then into `S3Node`.
+    /// # Panics
+    /// Panics if `ValueType` is not `ValueType::Node`.
+    pub async fn into_s3_node<S: S3BackEnd + Send + Sync + 'static>(
+        self,
+        meta: &S3MetaData<S>,
+    ) -> DatenLordResult<S3Node<S>> {
+        match self {
+            ValueType::Node(node) => S3Node::from_serial_node(node, meta).await,
+            _ => {
+                panic!("expect ValueType::Node but get {self:?}");
+            }
+        }
+    }
+
+    /// Turn the `ValueType` into `NextIdAllocateRangeBegin`.
+    /// # Panics
+    /// Panics if `ValueType` is not `ValueType::NextIdAllocateRangeBegin`.
+    #[allow(clippy::wildcard_enum_match_arm)] // Allow wildcard because there should be only one enum branch matches one specific type.
+    #[must_use]
+    pub fn into_next_id_allocate_range_begin(self) -> u64 {
+        match self {
+            ValueType::NextIdAllocateRangeBegin(begin) => begin,
+            _ => panic!("expect ValueType::NextIdAllocateRangeBegin but get {self:?}"),
+        }
+    }
+
+    /// Turn the `ValueType` into `String`
+    /// # Panics
+    /// Panics if `ValueType` is not `ValueType::String`.
+    #[allow(clippy::wildcard_enum_match_arm)] // Allow wildcard because there should be only one enum branch matches one specific type.
+    #[must_use]
+    pub fn into_string(self) -> String {
+        match self {
+            ValueType::String(string) => string,
+            _ => panic!("expect ValueType::String but get {self:?}"),
+        }
+    }
+
+    /// Turn the `ValueType` into `Raw`
+    /// # Panics
+    /// Panics if `ValueType` is not `ValueType::Raw`.
+    #[allow(clippy::wildcard_enum_match_arm)] // Allow wildcard because there should be only one enum branch matches one specific type.
+    #[must_use]
+    pub fn into_raw(self) -> Vec<u8> {
+        match self {
+            ValueType::Raw(raw) => raw,
+            _ => panic!("expect ValueType::Raw but get {self:?}"),
+        }
+    }
+
+    /// Turn the `ValueType` into `DirEntry`
+    /// # Panics
+    /// Panics if `ValueType` is not `ValueType::DirEntry`.
+    #[allow(clippy::wildcard_enum_match_arm)] // Allow wildcard because there should be only one enum branch matches one specific type.
+    #[must_use]
+    pub fn into_dir_entry(self) -> DirEntry {
+        match self {
+            ValueType::DirEntry(direntry) => direntry,
+            _ => panic!("expect ValueType::DirEntry but get {self:?}"),
+        }
+    }
+}

--- a/src/async_fuse/memfs/mod.rs
+++ b/src/async_fuse/memfs/mod.rs
@@ -8,6 +8,9 @@ mod id_alloc_used;
 /// The KV engine module
 #[macro_use]
 pub mod kv_engine;
+/// Dir entry module
+#[allow(dead_code)]
+pub mod direntry;
 /// fs metadata module
 mod metadata;
 mod node;

--- a/src/async_fuse/memfs/s3_metadata.rs
+++ b/src/async_fuse/memfs/s3_metadata.rs
@@ -22,7 +22,7 @@ use super::dist::client as dist_client;
 use super::dist::server::CacheServer;
 use super::fs_util::{self, NEED_CHECK_PERM};
 use super::id_alloc_used::INumAllocator;
-use super::kv_engine::{KVEngine, KVEngineType, KeyType, MetaTxn, ValueType};
+use super::kv_engine::{KVEngine, KVEngineType, MetaTxn, ValueType};
 use super::metadata::{error, MetaData, ReqContext};
 use super::node::Node;
 use super::s3_node::S3Node;
@@ -31,6 +31,7 @@ use super::{check_type_supported, CreateParam, RenameParam, SetAttrParam};
 use crate::async_fuse::fuse::fuse_reply::{ReplyDirectory, StatFsParam};
 use crate::async_fuse::fuse::protocol::{FuseAttr, INum, FUSE_ROOT_ID};
 use crate::async_fuse::memfs::check_name_length;
+use crate::async_fuse::memfs::kv_engine::KeyType;
 use crate::async_fuse::util::build_error_result_from_errno;
 use crate::common::error::DatenLordResult;
 use crate::common::error::{Context as DatenLordContext, DatenLordError}; /* conflict with anyhow::Context */


### PR DESCRIPTION
For the subsequent folder restructuring, in this PR, we have done some preliminary work for refactoring. We have added new key/value `direntry` and also restructured the structure of the `kv_engine` module.