### PR TITLE
refactor(fs): Introduce storage for fs

### DIFF
--- a/scripts/setup/create-kind-cluster.sh
+++ b/scripts/setup/create-kind-cluster.sh
@@ -13,10 +13,20 @@ nodes:
 # the three workers
 - role: worker
   image: $KIND_NODE_VERSION
+  # The volume is mounted for FS backend for DatenLord. 
+  extraMounts:
+  - hostPath: /tmp/kind-volume
+    containerPath: /tmp/kind-volume
 - role: worker
   image: $KIND_NODE_VERSION
+  extraMounts:
+  - hostPath: /tmp/kind-volume
+    containerPath: /tmp/kind-volume
 - role: worker
   image: $KIND_NODE_VERSION
+  extraMounts:
+  - hostPath: /tmp/kind-volume
+    containerPath: /tmp/kind-volume
 END
 
 kind create cluster --config /tmp/kind-config.yaml

--- a/scripts/setup/datenlord.yaml
+++ b/scripts/setup/datenlord.yaml
@@ -268,6 +268,10 @@ spec:
               # since DatenLord use bind mount to publish volume here
               mountPath: /var/lib/kubelet/pods
               mountPropagation: Bidirectional
+            - name: datenlord-fs-backend
+              # This is the FS backend of `DatenLord`
+              mountPath: /tmp/datenlord_backend
+              mountPropagation: Bidirectional
         - name: csi-node-driver-registrar
           securityContext:
             privileged: true
@@ -329,6 +333,10 @@ spec:
         - name: mountpoint-dir
           hostPath:
             path: /var/lib/kubelet/pods
+            type: Directory
+        - name: datenlord-fs-backend
+          hostPath:
+            path: /tmp/kind-volume
             type: Directory
         #- name: plugins-dir
         #  hostPath:

--- a/scripts/setup/start_local_node.sh
+++ b/scripts/setup/start_local_node.sh
@@ -71,4 +71,5 @@ echo "Starting datenlord.. ... ... ..."
 --kv-server-list=127.0.0.1:2379 \
 --storage-fs-root=/tmp/datenlord_backend \
 --server-port=8800 \
---storage-type=fs 
+--storage-type=fs \
+--storage-mem-cache-write-back

--- a/src/async_fuse/memfs/kv_engine/value_type.rs
+++ b/src/async_fuse/memfs/kv_engine/value_type.rs
@@ -30,10 +30,10 @@ impl ValueType {
     /// Turn the `ValueType` into `SerialNode` then into `S3Node`.
     /// # Panics
     /// Panics if `ValueType` is not `ValueType::Node`.
-    pub async fn into_s3_node<S: S3BackEnd + Send + Sync + 'static>(
-        self,
-        meta: &S3MetaData<S>,
-    ) -> DatenLordResult<S3Node<S>> {
+    pub async fn into_s3_node<S>(self, meta: &S3MetaData<S>) -> DatenLordResult<S3Node<S>>
+    where
+        S: S3BackEnd + Send + Sync + 'static,
+    {
         match self {
             ValueType::Node(node) => S3Node::from_serial_node(node, meta).await,
             _ => {

--- a/src/async_fuse/memfs/metadata.rs
+++ b/src/async_fuse/memfs/metadata.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use datenlord::config::StorageConfig;
 
-use super::cache::IoMemBlock;
+use super::cache::{IoMemBlock, Storage, StorageManager};
 use super::dist::server::CacheServer;
 use super::kv_engine::KVEngineType;
 use super::node::Node;
@@ -46,6 +46,9 @@ pub trait MetaData {
     /// Node type
     type N: Node + Send + Sync + 'static;
 
+    /// Storage type
+    type St: Storage + Send + Sync + 'static;
+
     /// Create `MetaData`
     #[allow(clippy::too_many_arguments)]
     async fn new(
@@ -55,6 +58,7 @@ pub trait MetaData {
         kv_engine: Arc<KVEngineType>,
         node_id: &str,
         storage_config: &StorageConfig,
+        storage: StorageManager<Self::St>,
     ) -> DatenLordResult<(Arc<Self>, Option<CacheServer>)>;
 
     /// Helper function to create node

--- a/src/async_fuse/memfs/metadata.rs
+++ b/src/async_fuse/memfs/metadata.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use datenlord::config::StorageConfig;
 
-use super::cache::{IoMemBlock, Storage, StorageManager};
+use super::cache::{Block, Storage, StorageManager};
 use super::dist::server::CacheServer;
 use super::kv_engine::KVEngineType;
 use super::node::Node;
@@ -121,7 +121,7 @@ pub trait MetaData {
         fh: u64,
         offset: i64,
         size: u32,
-    ) -> DatenLordResult<Vec<IoMemBlock>>;
+    ) -> DatenLordResult<Vec<Block>>;
 
     /// Helper function to flush node by ino
     async fn flush(&self, ino: u64, fh: u64) -> DatenLordResult<()>;

--- a/src/async_fuse/memfs/mod.rs
+++ b/src/async_fuse/memfs/mod.rs
@@ -39,6 +39,7 @@ pub use s3_metadata::S3MetaData;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, warn};
 
+use self::cache::StorageManager;
 use self::kv_engine::KVEngineType;
 use crate::async_fuse::fuse::file_system::FileSystem;
 use crate::async_fuse::fuse::fuse_reply::{
@@ -179,14 +180,23 @@ impl<M: MetaData + Send + Sync + 'static> MemFs<M> {
         kv_engine: Arc<KVEngineType>,
         node_id: &str,
         storage_config: &StorageConfig,
+        storage: StorageManager<<M as MetaData>::St>,
     ) -> anyhow::Result<Self> {
         // print the args
         debug!(
             "mount_point: ${}$, capacity: ${}$, ip: ${}$, port: ${}$, node_id: {}, storage_config: {:?}",
             mount_point, capacity, ip, port, node_id, storage_config
         );
-        let (metadata, server) =
-            M::new(capacity, ip, port, kv_engine, node_id, storage_config).await?;
+        let (metadata, server) = M::new(
+            capacity,
+            ip,
+            port,
+            kv_engine,
+            node_id,
+            storage_config,
+            storage,
+        )
+        .await?;
         Ok(Self { metadata, server })
     }
 

--- a/src/async_fuse/memfs/node.rs
+++ b/src/async_fuse/memfs/node.rs
@@ -13,7 +13,7 @@ use parking_lot::RwLock;
 use super::cache::{GlobalCache, IoMemBlock};
 use super::dir::DirEntry;
 use super::fs_util::FileAttr;
-use super::{CreateParam, SetAttrParam};
+use super::CreateParam;
 use crate::async_fuse::fuse::fuse_reply::StatFsParam;
 use crate::async_fuse::fuse::protocol::INum;
 use crate::common::error::DatenLordResult;
@@ -51,8 +51,6 @@ pub trait Node: Sized {
     fn get_lookup_count(&self) -> i64;
     /// Decrease node lookup count
     fn dec_lookup_count_by(&self, nlookup: u64) -> i64;
-    /// Flush node data
-    async fn flush(&mut self, ino: INum, fh: u64);
     /// Duplicate fd
     async fn dup_fd(&self, oflags: OFlag) -> DatenLordResult<RawFd>;
     /// Check whether a node is an empty file or an empty directory
@@ -131,16 +129,9 @@ pub trait Node: Sized {
         write_to_disk: bool,
     ) -> DatenLordResult<usize>;
     /// Close file
-    async fn close(&mut self, ino: INum, fh: u64, flush: bool);
+    async fn close(&mut self);
     /// Close dir
-    async fn closedir(&self, ino: INum, fh: u64);
-    /// Precheck before set attr
-    async fn setattr_precheck(
-        &self,
-        param: &SetAttrParam,
-        uid: u32,
-        gid: u32,
-    ) -> DatenLordResult<(bool, FileAttr)>;
+    async fn closedir(&self);
     /// Mark as deferred deletion
     fn mark_deferred_deletion(&self);
     /// If node is marked as deferred deletion

--- a/src/async_fuse/memfs/s3_metadata.rs
+++ b/src/async_fuse/memfs/s3_metadata.rs
@@ -897,8 +897,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
                                 );
                             } else {
                                 if let SFlag::S_IFREG = dest_node.get_type() {
-                                    self.local_mtime.remove(&dest_ino);
-                                    self.local_size.remove(&dest_ino);
+                                    self.local_mtime_and_size.remove(&dest_ino);
                                     self.storage.remove(dest_ino).await;
                                 }
                                 txn.delete(&KeyType::INum2Node(dest_ino));

--- a/src/async_fuse/memfs/s3_metadata.rs
+++ b/src/async_fuse/memfs/s3_metadata.rs
@@ -11,20 +11,18 @@ use async_trait::async_trait;
 use clippy_utilities::{Cast, OverflowArithmetic};
 use datenlord::config::{StorageConfig, StorageS3Config};
 use libc::{RENAME_EXCHANGE, RENAME_NOREPLACE};
-use lockfree_cuckoohash::LockFreeCuckooHash as HashMap;
+use lockfree_cuckoohash::{pin, LockFreeCuckooHash as HashMap};
 use nix::errno::Errno;
 use nix::sys::stat::SFlag;
 use tokio::sync::Mutex;
 use tracing::{debug, info, instrument, warn};
 
 use super::cache::policy::LruPolicy;
-use super::cache::{
-    Backend, BlockCoordinate, GlobalCache, IoMemBlock, MemoryCache, StorageManager,
-};
+use super::cache::{Backend, Block, BlockCoordinate, GlobalCache, MemoryCache, StorageManager};
 use super::dir::DirEntry;
 use super::dist::client as dist_client;
 use super::dist::server::CacheServer;
-use super::fs_util::{self, NEED_CHECK_PERM};
+use super::fs_util::{self, FileAttr, NEED_CHECK_PERM};
 use super::id_alloc_used::INumAllocator;
 use super::kv_engine::{KVEngine, KVEngineType, MetaTxn, ValueType};
 use super::metadata::{error, MetaData, ReqContext};
@@ -100,10 +98,13 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
         _lock_owner: u64,
         flush: bool,
     ) -> DatenLordResult<()> {
+        if flush {
+            self.flush(ino, fh).await?;
+        }
         retry_txn!(TXN_RETRY_LIMIT, {
             let mut txn = self.kv_engine.new_meta_txn().await;
             let mut inode = self.get_inode_from_txn(txn.as_mut(), ino).await?;
-            inode.close(ino, fh, flush).await;
+            inode.close().await;
             txn.set(
                 &KeyType::INum2Node(ino),
                 &ValueType::Node(inode.to_serial_node()),
@@ -198,11 +199,45 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
     }
 
     #[instrument(skip(self))]
-    async fn flush(&self, ino: u64, fh: u64) -> DatenLordResult<()> {
+    async fn flush(&self, ino: u64, _fh: u64) -> DatenLordResult<()> {
+        let local_mtime_and_size = {
+            let guard = pin();
+
+            self.local_mtime_and_size
+                .remove_with_guard(&ino, &guard)
+                .copied()
+        };
+
         retry_txn!(TXN_RETRY_LIMIT, {
             let mut txn = self.kv_engine.new_meta_txn().await;
             let mut inode = self.get_inode_from_txn(txn.as_mut(), ino).await?;
-            inode.flush(ino, fh).await;
+
+            if inode.is_deferred_deletion() {
+                // If a file is marked as deferred delete, there is no need to flush it.
+                // But the local node may continue to access this file, which depends on
+                // the local mtime and local size. Therefore, we need to insert the removed
+                // local mtime and local size back to the cache.
+                if let Some(local_mtime_and_size) = local_mtime_and_size {
+                    self.local_mtime_and_size.insert(ino, local_mtime_and_size);
+                }
+                return Ok(());
+            }
+
+            // Flush the storage cache
+            self.storage.flush(ino).await;
+
+            let mut file_attr = inode.get_attr();
+
+            if let Some((local_mtime, local_size)) = local_mtime_and_size {
+                file_attr.mtime = local_mtime;
+                file_attr.size = local_size;
+
+                // `ctime` may be greater than `mtime`, use the greater one
+                file_attr.ctime = local_mtime.max(file_attr.ctime);
+            }
+
+            inode.set_attr(file_attr);
+
             txn.set(
                 &KeyType::INum2Node(ino),
                 &ValueType::Node(inode.to_serial_node()),
@@ -213,11 +248,11 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
     }
 
     #[instrument(skip(self))]
-    async fn releasedir(&self, ino: u64, fh: u64) -> DatenLordResult<()> {
+    async fn releasedir(&self, ino: u64, _fh: u64) -> DatenLordResult<()> {
         retry_txn!(TXN_RETRY_LIMIT, {
             let mut txn = self.kv_engine.new_meta_txn().await;
             let node = self.get_inode_from_txn(txn.as_mut(), ino).await?;
-            node.closedir(ino, fh).await;
+            node.closedir().await;
             let is_deleted = self.delete_check(&node).await?;
             if is_deleted {
                 txn.delete(&KeyType::INum2Node(ino));
@@ -239,23 +274,35 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
         _fh: u64,
         offset: i64,
         size: u32,
-    ) -> DatenLordResult<Vec<IoMemBlock>> {
+    ) -> DatenLordResult<Vec<Block>> {
         let inode = self
             .get_node_from_kv_engine(ino)
             .await?
             .ok_or_else(|| build_inconsistent_fs!(ino))?;
 
-        let size: u64 =
-            if offset.cast::<u64>().overflow_add(size.cast::<u64>()) > inode.get_attr().size {
-                inode.get_attr().size.overflow_sub(offset.cast::<u64>())
-            } else {
-                size.cast()
-            };
+        let (mtime, file_size) = {
+            let local_mtime_and_size = self.get_local_mtime_and_size(ino);
+            let file_attr = inode.get_attr();
+            local_mtime_and_size.unwrap_or((file_attr.mtime, file_attr.size))
+        };
 
-        if inode.need_load_file_data(offset.cast(), size.cast()).await {
-            inode.load_data(offset.cast(), size.cast()).await?;
+        if offset.cast::<u64>() >= file_size {
+            return Ok(vec![]);
         }
-        return Ok(inode.get_file_data(offset.cast(), size.cast()).await);
+
+        // Ensure `offset + size` is le than the size of the file
+        let read_size: u64 = if offset.cast::<u64>().overflow_add(size.cast::<u64>()) > file_size {
+            file_size.overflow_sub(offset.cast::<u64>())
+        } else {
+            size.cast()
+        };
+
+        let data = self
+            .storage
+            .load(ino, offset.cast(), read_size.cast(), mtime)
+            .await;
+
+        Ok(data)
     }
 
     #[instrument(skip(self), err, ret)]
@@ -290,7 +337,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
             .get_node_from_kv_engine(ino)
             .await?
             .ok_or_else(|| build_inconsistent_fs!(ino))?;
-        let attr = inode.get_attr();
+        let attr = self.apply_local_mtime_and_size(inode.get_attr());
         let ttl = Duration::new(MY_TTL_SEC, 0);
         let fuse_attr = fs_util::convert_to_fuse_attr(attr);
         Ok((ttl, fuse_attr))
@@ -324,23 +371,88 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
         param: &SetAttrParam,
     ) -> DatenLordResult<(Duration, FuseAttr)> {
         let ttl = Duration::new(MY_TTL_SEC, 0);
-        let file_attr = retry_txn!(TXN_RETRY_LIMIT, {
-            let mut txn = self.kv_engine.new_meta_txn().await;
-            let mut inode = self.get_inode_from_txn(txn.as_mut(), ino).await?;
-            let (attr_changed, file_attr) = inode
-                .setattr_precheck(param, context.user_id, context.group_id)
-                .await?;
-            debug!("setattr_helper() attr_changed={}", attr_changed);
-            if attr_changed {
-                inode.set_attr(file_attr);
+
+        let mut txn = self.kv_engine.new_meta_txn().await;
+        let mut inode = self.get_inode_from_txn(txn.as_mut(), ino).await?;
+
+        let origin_attr = inode.get_attr();
+        let applied_attr = if SFlag::S_IFREG == origin_attr.kind {
+            self.apply_local_mtime_and_size(origin_attr)
+        } else {
+            origin_attr
+        };
+
+        let dirty_attr_for_reply = match applied_attr.setattr_precheck(
+            param,
+            context.user_id,
+            context.group_id,
+        )? {
+            Some(mut dirty_attr) => {
+                // This is to be inserted in KV, whose `mtime` and `size` should be reset to
+                // origin, because changes of this field are invisible to other
+                // nodes until flush.
+                let mut dirty_attr_for_kv = dirty_attr;
+
+                // There are `mtime` and `size` caches for regular files. Check the change of
+                // these fields, and set them to the cache.
+                if SFlag::S_IFREG == applied_attr.kind {
+                    if (dirty_attr.mtime, dirty_attr.size)
+                        != (applied_attr.mtime, applied_attr.size)
+                    {
+                        self.local_mtime_and_size
+                            .insert(ino, (dirty_attr.mtime, dirty_attr.size));
+                    }
+                    // Reset `mtime` and `size` to origin, because changes of these fields is
+                    // invisible to other nodes until flush.
+                    dirty_attr_for_kv.mtime = origin_attr.mtime;
+                    dirty_attr_for_kv.size = origin_attr.size;
+
+                    // The file also needs to be truncated, if the new size is shorter.
+                    if dirty_attr.size < applied_attr.size {
+                        let new_mtime = self
+                            .storage
+                            .truncate(
+                                ino,
+                                applied_attr.size.cast(),
+                                dirty_attr.size.cast(),
+                                applied_attr.mtime,
+                            )
+                            .await;
+                        self.local_mtime_and_size
+                            .insert(ino, (new_mtime, dirty_attr.size));
+                        dirty_attr.mtime = new_mtime;
+                    }
+                }
+
+                inode.set_attr(dirty_attr_for_kv);
+
+                debug!(
+                        "setattr() successfully set the attribute of ino={} and name={:?}, the set attr={:?}",
+                        ino, inode.get_name(), dirty_attr,
+                    );
+
+                // The attr with new `size` and `mtime` should be replied.
+                dirty_attr
             }
-            txn.set(
-                &KeyType::INum2Node(ino),
-                &ValueType::Node(inode.to_serial_node()),
-            );
-            (txn.commit().await, file_attr)
-        })?;
-        Ok((ttl, fs_util::convert_to_fuse_attr(file_attr)))
+            None => {
+                // setattr did not change any attribute.
+                return Ok((ttl, fs_util::convert_to_fuse_attr(origin_attr)));
+            }
+        };
+
+        txn.set(
+            &KeyType::INum2Node(ino),
+            &ValueType::Node(inode.to_serial_node()),
+        );
+
+        if txn.commit().await? {
+            Ok((ttl, fs_util::convert_to_fuse_attr(dirty_attr_for_reply)))
+        } else {
+            build_error_result_from_errno(
+                Errno::EIO,
+                "setattr(): Txn commit failed in a write operation.".to_owned(),
+            )
+        }
     }
 
     #[instrument(skip(self), err, ret)]
@@ -402,7 +514,8 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
                 );
             } else {
                 if let SFlag::S_IFREG = child_node.get_type() {
-                    self.data_cache.remove_file_cache(child_ino).await;
+                    self.local_mtime_and_size.remove(&child_ino);
+                    self.storage.remove(child_ino).await;
                 }
                 txn.delete(&KeyType::INum2Node(child_ino));
             }
@@ -508,11 +621,13 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
     }
 
     #[instrument(skip(self, node), ret)]
-    /// Try to delete node that is marked as deferred deletion
+    /// Try to delete, if the deletion succeed, returns `true`.
     async fn delete_check(&self, node: &S3Node<S>) -> DatenLordResult<bool> {
         let is_deleted = if node.get_open_count() == 0 && node.get_lookup_count() == 0 {
             if let SFlag::S_IFREG = node.get_type() {
-                self.data_cache.remove_file_cache(node.get_ino()).await;
+                let ino = node.get_ino();
+                self.storage.remove(ino).await;
+                self.local_mtime_and_size.remove(&ino);
             }
             true
         } else {
@@ -594,7 +709,7 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
 
             let child_ino = child_entry.ino();
             let child_node = self.get_inode_from_txn(txn.as_mut(), child_ino).await?;
-            let child_attr = child_node.lookup_attr();
+            let child_attr = self.apply_local_mtime_and_size(child_node.lookup_attr());
 
             let ttl = Duration::new(MY_TTL_SEC, 0);
             let fuse_attr = fs_util::convert_to_fuse_attr(child_attr);
@@ -787,14 +902,9 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
         _datasync: bool,
         // reply: ReplyEmpty,
     ) -> DatenLordResult<()> {
-        let mut inode = self
-            .get_node_from_kv_engine(ino)
-            .await?
-            .ok_or_else(|| build_inconsistent_fs!(ino))?;
-
-        inode.flush(ino, fh).await;
-
-        Ok(())
+        // We do not have completed metadata cache,
+        // so there are no need to handle the situation that the metadata is not synced.
+        self.flush(ino, fh).await
     }
 
     #[instrument(skip(self), err, ret)]
@@ -802,20 +912,31 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
     async fn write_helper(
         &self,
         ino: u64,
-        fh: u64,
+        _fh: u64,
         offset: i64,
         data: Vec<u8>,
-        flags: u32,
+        _flags: u32,
     ) -> DatenLordResult<usize> {
-        let data_len = data.len();
         let mut txn = self.kv_engine.new_meta_txn().await;
-        let mut inode = self.get_inode_from_txn(txn.as_mut(), ino).await?;
-        let o_flags = fs_util::parse_oflag(flags);
-        let result = inode.write_file(fh, offset, data, o_flags, false).await;
+        let inode = self.get_inode_from_txn(txn.as_mut(), ino).await?;
+
+        let (mtime, file_size) = {
+            let local_mtime_and_size = self.get_local_mtime_and_size(ino);
+            let file_attr = inode.get_attr();
+            local_mtime_and_size.unwrap_or((file_attr.mtime, file_attr.size))
+        };
+
+        let new_mtime = self.storage.store(ino, offset.cast(), &data, mtime).await;
+        let written_size = data.len();
+        let new_size = file_size.max(offset.cast::<u64>().overflow_add(written_size.cast()));
+
+        // In fact, no changes will be written to the `inode`,
+        // and the `txn.set` here is just for atomic ensuring.
         txn.set(
             &KeyType::INum2Node(ino),
             &ValueType::Node(inode.to_serial_node()),
         );
+
         if !txn.commit().await? {
             // Transaction committed failed, but we don't retry here
             // Print a warning log and return the result
@@ -826,8 +947,8 @@ impl<S: S3BackEnd + Sync + Send + 'static> MetaData for S3MetaData<S> {
                 "write_helper() failed to commit txn".to_owned(),
             );
         }
-        self.invalidate_remote(ino, offset, data_len).await?;
-        result
+        self.local_mtime_and_size.insert(ino, (new_mtime, new_size));
+        Ok(written_size)
     }
 }
 
@@ -848,6 +969,28 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
         })
     }
 
+    /// Get the local cache of `mtime` and `size` of a file.
+    fn get_local_mtime_and_size(&self, ino: INum) -> Option<(SystemTime, u64)> {
+        let guard = pin();
+
+        self.local_mtime_and_size.get(&ino, &guard).copied()
+    }
+
+    /// Apply the local `mtime` and `size` to `attr`.
+    fn apply_local_mtime_and_size(&self, mut attr: FileAttr) -> FileAttr {
+        let ino = attr.ino;
+
+        let Some((local_mtime, local_size)) = self.get_local_mtime_and_size(ino) else {
+            return attr;
+        };
+
+        attr.mtime = local_mtime;
+        attr.ctime = local_mtime.max(attr.ctime);
+        attr.size = local_size;
+
+        attr
+    }
+
     /// Allocate a new uinque inum for new node
     async fn alloc_inum(&self) -> DatenLordResult<INum> {
         let result = self.inum_allocator.alloc_inum_for_fnode().await;
@@ -856,6 +999,7 @@ impl<S: S3BackEnd + Send + Sync + 'static> S3MetaData<S> {
     }
 
     /// Invalidate cache from other nodes
+    #[allow(dead_code)]
     async fn invalidate_remote(
         &self,
         full_ino: INum,

--- a/src/async_fuse/mod.rs
+++ b/src/async_fuse/mod.rs
@@ -2,9 +2,12 @@
 
 use std::sync::Arc;
 
+use clippy_utilities::OverflowArithmetic;
 use datenlord::config::StorageParams;
 use memfs::s3_wrapper::{DoNothingImpl, S3BackEndImpl};
 
+use self::memfs::cache::policy::LruPolicy;
+use self::memfs::cache::{BackendBuilder, BlockCoordinate, MemoryCacheBuilder, StorageManager};
 use self::memfs::kv_engine::KVEngineType;
 use crate::async_fuse::fuse::session;
 use crate::AsyncFuseArgs;
@@ -33,11 +36,31 @@ pub async fn start_async_fuse(
     )
     .await?;
 
-    let volume_info = serde_json::to_string(&args.storage_config)?;
+    let storage_config = &args.storage_config;
+
+    let volume_info = serde_json::to_string(storage_config)?;
     memfs::kv_engine::kv_utils::register_volume(&kv_engine, &args.node_id, &volume_info).await?;
 
     let mount_point = std::path::Path::new(&args.mount_dir);
     let global_cache_capacity = args.storage_config.memory_cache_config.capacity;
+    let storage = {
+        let storage_param = &storage_config.params;
+        let memory_cache_config = &storage_config.memory_cache_config;
+
+        let block_size = storage_config.block_size;
+        let capacity_in_blocks = memory_cache_config.capacity.overflow_div(block_size);
+
+        let backend = BackendBuilder::new(storage_param.clone(), block_size).build()?;
+        let lru_policy = LruPolicy::<BlockCoordinate>::new(capacity_in_blocks);
+        let memory_cache = MemoryCacheBuilder::new(lru_policy, backend, block_size)
+            .command_queue_limit(memory_cache_config.command_queue_limit)
+            .limit(memory_cache_config.soft_limit)
+            .write_through(!memory_cache_config.write_back)
+            .build();
+        StorageManager::new(memory_cache, block_size)
+    };
+
+    // TODO: Remove this matching when `S3Baackend` is removed.
     match args.storage_config.params {
         StorageParams::S3(_) => {
             let fs: memfs::MemFs<memfs::S3MetaData<S3BackEndImpl>> = memfs::MemFs::new(
@@ -47,7 +70,8 @@ pub async fn start_async_fuse(
                 args.server_port,
                 kv_engine,
                 &args.node_id,
-                &args.storage_config,
+                storage_config,
+                storage,
             )
             .await?;
 
@@ -62,7 +86,8 @@ pub async fn start_async_fuse(
                 args.server_port,
                 kv_engine,
                 &args.node_id,
-                &args.storage_config,
+                storage_config,
+                storage,
             )
             .await?;
 

--- a/src/async_fuse/test/integration_tests.rs
+++ b/src/async_fuse/test/integration_tests.rs
@@ -796,13 +796,13 @@ async fn test_all() -> anyhow::Result<()> {
 }
 
 async fn run_test() -> anyhow::Result<()> {
-    _run_test(DEFAULT_MOUNT_DIR, true).await
+    _run_test(DEFAULT_MOUNT_DIR, false).await
 }
 
 #[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn run_s3_test() -> anyhow::Result<()> {
-    _run_test(S3_DEFAULT_MOUNT_DIR, false).await
+    _run_test(S3_DEFAULT_MOUNT_DIR, true).await
 }
 
 async fn _run_test(mount_dir_str: &str, is_s3: bool) -> anyhow::Result<()> {

--- a/src/async_fuse/test/integration_tests.rs
+++ b/src/async_fuse/test/integration_tests.rs
@@ -342,9 +342,9 @@ fn test_rename_no_replace_flag(mount_dir: &Path) -> anyhow::Result<()> {
     // RENAME_NOREPLACE flag
     let result = renameat2(
         None,
-        source_file_str,
+        &source_file,
         None,
-        destination_file_str,
+        &destination_file,
         RenameFlags::RENAME_NOREPLACE,
     );
 

--- a/src/async_fuse/test/test_util.rs
+++ b/src/async_fuse/test/test_util.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
+use clippy_utilities::OverflowArithmetic;
 use datenlord::config::{
     MemoryCacheConfig, SoftLimit, StorageConfig, StorageParams, StorageS3Config,
 };
@@ -11,9 +12,12 @@ use tracing::{debug, info}; // warn, error
 
 use crate::async_fuse::fuse::{mount, session};
 use crate::async_fuse::memfs;
-use crate::async_fuse::memfs::cache::BLOCK_SIZE_IN_BYTES;
+use crate::async_fuse::memfs::cache::policy::LruPolicy;
+use crate::async_fuse::memfs::cache::{
+    BackendBuilder, BlockCoordinate, MemoryCacheBuilder, StorageManager, BLOCK_SIZE_IN_BYTES,
+};
 use crate::async_fuse::memfs::kv_engine::{KVEngine, KVEngineType};
-use crate::async_fuse::memfs::s3_wrapper::DoNothingImpl;
+use crate::async_fuse::memfs::s3_wrapper::{DoNothingImpl, S3BackEndImpl};
 use crate::common::logger::{init_logger, LogRole};
 
 pub const TEST_NODE_IP: &str = "127.0.0.1";
@@ -24,12 +28,18 @@ pub const TEST_ETCD_ENDPOINT: &str = "127.0.0.1:2379";
 /// The default capacity in bytes for test, 1GB
 const CACHE_DEFAULT_CAPACITY: usize = 1024 * 1024 * 1024;
 
-fn test_storage_config() -> StorageConfig {
-    let s3_config = StorageS3Config {
-        endpoint_url: "http://127.0.0.1:9000".to_owned(),
-        access_key_id: "test".to_owned(),
-        secret_access_key: "test1234".to_owned(),
-        bucket_name: "fuse-test-bucket".to_owned(),
+fn test_storage_config(is_s3: bool) -> StorageConfig {
+    let params = if is_s3 {
+        let s3_config = StorageS3Config {
+            endpoint_url: "http://127.0.0.1:9000".to_owned(),
+            access_key_id: "test".to_owned(),
+            secret_access_key: "test1234".to_owned(),
+            bucket_name: "fuse-test-bucket".to_owned(),
+        };
+
+        StorageParams::S3(s3_config)
+    } else {
+        StorageParams::Fs("/tmp/datenlord_backend".to_owned())
     };
 
     let soft_limit = SoftLimit(
@@ -41,11 +51,73 @@ fn test_storage_config() -> StorageConfig {
         memory_cache_config: MemoryCacheConfig {
             capacity: CACHE_DEFAULT_CAPACITY,
             command_queue_limit: 1000,
-            write_back: false,
+            write_back: true,
             soft_limit,
         },
-        params: StorageParams::S3(s3_config),
+        params,
     }
+}
+
+async fn run_fs(mount_point: &Path, is_s3: bool) -> anyhow::Result<()> {
+    let storage_config = test_storage_config(is_s3);
+    let kv_engine: Arc<memfs::kv_engine::etcd_impl::EtcdKVEngine> =
+        Arc::new(KVEngineType::new(vec![TEST_ETCD_ENDPOINT.to_owned()]).await?);
+
+    let storage = {
+        let storage_param = &storage_config.params;
+        let memory_cache_config = &storage_config.memory_cache_config;
+
+        let block_size = storage_config.block_size;
+        let capacity_in_blocks = memory_cache_config.capacity.overflow_div(block_size);
+
+        let backend = BackendBuilder::new(storage_param.clone(), block_size).build()?;
+        let lru_policy = LruPolicy::<BlockCoordinate>::new(capacity_in_blocks);
+        let memory_cache = MemoryCacheBuilder::new(lru_policy, backend, block_size)
+            .command_queue_limit(memory_cache_config.command_queue_limit)
+            .limit(memory_cache_config.soft_limit)
+            .write_through(!memory_cache_config.write_back)
+            .build();
+        StorageManager::new(memory_cache, block_size)
+    };
+
+    // TODO: remove the `if` statement when `S3Backend` is removed.
+    if is_s3 {
+        let fs: memfs::MemFs<memfs::S3MetaData<S3BackEndImpl>> = memfs::MemFs::new(
+            mount_point
+                .as_os_str()
+                .to_str()
+                .unwrap_or_else(|| panic!("failed to convert to utf8 string")),
+            CACHE_DEFAULT_CAPACITY,
+            TEST_NODE_IP,
+            TEST_PORT,
+            kv_engine,
+            TEST_NODE_ID,
+            &storage_config,
+            storage,
+        )
+        .await?;
+        let ss = session::new_session_of_memfs(mount_point, fs).await?;
+        ss.run().await?;
+    } else {
+        let fs: memfs::MemFs<memfs::S3MetaData<DoNothingImpl>> = memfs::MemFs::new(
+            mount_point
+                .as_os_str()
+                .to_str()
+                .unwrap_or_else(|| panic!("failed to convert to utf8 string")),
+            CACHE_DEFAULT_CAPACITY,
+            TEST_NODE_IP,
+            TEST_PORT,
+            Arc::<KVEngineType>::clone(&kv_engine),
+            TEST_NODE_ID,
+            &storage_config,
+            storage,
+        )
+        .await?;
+        let ss = session::new_session_of_memfs(mount_point, fs).await?;
+        ss.run().await?;
+    };
+
+    Ok(())
 }
 
 #[allow(clippy::let_underscore_must_use)]
@@ -77,46 +149,6 @@ pub async fn setup(mount_dir: &Path, is_s3: bool) -> anyhow::Result<tokio::task:
     let abs_root_path = fs::canonicalize(mount_dir)?;
 
     let fs_task = tokio::task::spawn(async move {
-        async fn run_fs(mount_point: &Path, is_s3: bool) -> anyhow::Result<()> {
-            let storage_config = test_storage_config();
-            let kv_engine: Arc<memfs::kv_engine::etcd_impl::EtcdKVEngine> =
-                Arc::new(KVEngineType::new(vec![TEST_ETCD_ENDPOINT.to_owned()]).await?);
-            if is_s3 {
-                let fs: memfs::MemFs<memfs::S3MetaData<DoNothingImpl>> = memfs::MemFs::new(
-                    mount_point
-                        .as_os_str()
-                        .to_str()
-                        .unwrap_or_else(|| panic!("failed to convert to utf8 string")),
-                    CACHE_DEFAULT_CAPACITY,
-                    TEST_NODE_IP,
-                    TEST_PORT,
-                    kv_engine,
-                    TEST_NODE_ID,
-                    &storage_config,
-                )
-                .await?;
-                let ss = session::new_session_of_memfs(mount_point, fs).await?;
-                ss.run().await?;
-            } else {
-                let fs: memfs::MemFs<memfs::S3MetaData<DoNothingImpl>> = memfs::MemFs::new(
-                    mount_point
-                        .as_os_str()
-                        .to_str()
-                        .unwrap_or_else(|| panic!("failed to convert to utf8 string")),
-                    CACHE_DEFAULT_CAPACITY,
-                    TEST_NODE_IP,
-                    TEST_PORT,
-                    Arc::<KVEngineType>::clone(&kv_engine),
-                    TEST_NODE_ID,
-                    &storage_config,
-                )
-                .await?;
-                let ss = session::new_session_of_memfs(mount_point, fs).await?;
-                ss.run().await?;
-            };
-
-            Ok(())
-        }
         if let Err(e) = run_fs(&abs_root_path, is_s3).await {
             panic!(
                 "failed to run filesystem, the error is: {}",


### PR DESCRIPTION
In this PR, we refactored the `S3Metadata` with new `StorageManager`, thus the old `S3Backend`, distributed cache and `GlobalCache` are deprecated.

Because of the patch size, they will not be removed in this PR, causing the decreasing coverage.