### PR TITLE
feat(metadata): add file's open-to-close support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ bench.log
 .vscode/*
 localtest.sh
 *.log
+
+tests/fstest_dir/fstest

--- a/scripts/setup/start_local_node.sh
+++ b/scripts/setup/start_local_node.sh
@@ -60,7 +60,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Starting datenlord.. ... ... ..."
-./target/debug/datenlord \
+cargo run $BUILD_FLAGS --bin=datenlord -- \
 --role=node \
 --csi-endpoint=unix:///tmp/node.sock \
 --csi-worker-port=0 \

--- a/src/async_fuse/memfs/metadata.rs
+++ b/src/async_fuse/memfs/metadata.rs
@@ -78,9 +78,6 @@ pub trait MetaData {
     /// Helper function of fsync
     async fn fsync_helper(&self, ino: u64, fh: u64, datasync: bool) -> DatenLordResult<()>;
 
-    /// Try to delete node that is marked as deferred deletion
-    async fn delete_check(&self, node: &Self::N) -> DatenLordResult<bool>;
-
     /// Helper function to write data
     async fn write_helper(
         &self,

--- a/src/async_fuse/memfs/node.rs
+++ b/src/async_fuse/memfs/node.rs
@@ -41,10 +41,6 @@ pub trait Node: Sized {
     fn set_attr(&mut self, new_attr: FileAttr) -> FileAttr;
     /// Get node attr and increase lookup count
     fn lookup_attr(&self) -> FileAttr;
-    /// Get node open count
-    fn get_open_count(&self) -> i64;
-    /// Decrease node open count
-    fn dec_open_count(&self) -> i64;
     /// Get node lookup count
     fn get_lookup_count(&self) -> i64;
     /// Decrease node lookup count
@@ -92,10 +88,6 @@ pub trait Node: Sized {
     fn get_symlink_target(&self) -> &Path;
     /// Get fs stat
     async fn statefs(&self) -> DatenLordResult<StatFsParam>;
-    /// Close file
-    async fn close(&mut self);
-    /// Close dir
-    async fn closedir(&self);
     /// Mark as deferred deletion
     fn mark_deferred_deletion(&self);
     /// If node is marked as deferred deletion

--- a/src/async_fuse/memfs/open_file.rs
+++ b/src/async_fuse/memfs/open_file.rs
@@ -1,0 +1,127 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::{Mutex, RwLock};
+
+use super::fs_util::FileAttr;
+use crate::async_fuse::fuse::protocol::INum;
+
+/// A structure representing an open file with its attributes and open count.
+///
+/// The `attr` field contains the file attributes, while `open_cnt` keeps track
+/// of the number of times this file is currently opened.
+#[derive(Debug)]
+#[allow(clippy::partial_pub_fields)] // Pub attr for simplicity.
+pub struct RawOpenFile {
+    /// The file attributes.
+    pub attr: FileAttr,
+    /// The number of times this file is currently opened.
+    open_cnt: u32,
+}
+
+/// A thread-safe reference counted wrapper around `RawOpenFile`.
+///
+/// This type uses `Arc` for shared ownership and `RwLock` for thread-safe
+/// mutability, allowing multiple readers or one writer at the same time.
+pub type OpenFile = Arc<RwLock<RawOpenFile>>;
+
+/// Internal structure to keep track of all open files.
+///
+/// This structure uses a `HashMap` to associate inode numbers (`INum`) with
+/// their corresponding `OpenFile` instances.
+#[derive(Debug)]
+struct RawOpenFiles {
+    /// The collection of open files.
+    open_files: HashMap<INum, OpenFile>,
+}
+
+/// A thread-safe, mutable collection of open files.
+///
+/// This structure provides an interface to interact with open files,
+/// encapsulating the internal locking mechanism through `Mutex`.
+#[derive(Debug)]
+pub struct OpenFiles {
+    /// The internal collection of open files.
+    inner: Arc<Mutex<RawOpenFiles>>,
+}
+
+impl OpenFiles {
+    /// Constructs a new `OpenFiles` collection.
+    ///
+    /// This initializes an empty collection of open files.
+    pub fn new() -> Self {
+        OpenFiles {
+            inner: Arc::new(Mutex::new(RawOpenFiles {
+                open_files: HashMap::new(),
+            })),
+        }
+    }
+
+    /// Try to retrieves an `OpenFile` by its inode number.
+    ///
+    /// Returns `Some(OpenFile)` if the file is open, or `None` if not found.
+    pub fn try_get(&self, inum: INum) -> Option<OpenFile> {
+        let inner = self.inner.lock();
+        let open_file = inner.open_files.get(&inum).map(Arc::clone);
+        open_file
+    }
+
+    /// Retrieves an `OpenFile` by its inode number.
+    ///
+    /// Panics if the file is not found.
+    #[allow(clippy::unwrap_used)] // We should panic here
+    pub fn get(&self, inum: INum) -> OpenFile {
+        self.try_get(inum)
+            .unwrap_or_else(|| panic!("Couldn't find the open file with inum={inum}"))
+    }
+
+    /// Opens a file, adding it to the collection
+    ///
+    /// Returns a reference to the newly opened file.
+    pub fn open(&self, inum: INum, attr: FileAttr) -> OpenFile {
+        let mut inner = self.inner.lock();
+        let open_file = Arc::new(RwLock::new(RawOpenFile { attr, open_cnt: 1 }));
+        inner.open_files.insert(inum, Arc::clone(&open_file));
+        open_file
+    }
+
+    /// Tries to open a file if it is already in the collection.
+    ///
+    /// Increments the open count if the file is found. Returns `Some(OpenFile)`
+    /// if successful, or `None` if the file is not in the collection.
+    pub fn try_open(&self, inum: INum) -> Option<OpenFile> {
+        let mut inner = self.inner.lock();
+        let open_file = inner.open_files.get_mut(&inum)?;
+        {
+            let mut open_file = open_file.write();
+            open_file.open_cnt += 1;
+        }
+        Some(Arc::clone(open_file))
+    }
+
+    /// Closes an open file, identified by its inode number.
+    ///
+    /// Decrements the open count and removes the file from the collection
+    /// if its open count reaches zero. Returns the `OpenFile` if it was
+    /// removed, or `None` if it remains open.
+    #[allow(clippy::unwrap_in_result)]
+    #[allow(clippy::unwrap_used)]
+    pub fn close(&self, inum: INum) -> Option<OpenFile> {
+        let mut inner = self.inner.lock();
+        let open_count = {
+            let open_file = inner
+                .open_files
+                .get_mut(&inum)
+                .unwrap_or_else(|| panic!("Couldn't find the open file with inum={inum}"));
+            let mut open_file = open_file.write();
+            debug_assert!(open_file.open_cnt > 0);
+            open_file.open_cnt -= 1;
+            open_file.open_cnt
+        };
+        if open_count == 0 {
+            inner.open_files.remove(&inum)
+        } else {
+            None
+        }
+    }
+}

--- a/src/async_fuse/memfs/s3_metadata.rs
+++ b/src/async_fuse/memfs/s3_metadata.rs
@@ -1,23 +1,19 @@
 use std::fmt::Debug;
 use std::os::unix::ffi::OsStringExt;
 use std::os::unix::io::RawFd;
-use std::sync::atomic::AtomicU32;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use clippy_utilities::{Cast, OverflowArithmetic};
 use libc::{RENAME_EXCHANGE, RENAME_NOREPLACE};
-use lockfree_cuckoohash::{pin, LockFreeCuckooHash as HashMap};
 use nix::errno::Errno;
 use nix::fcntl::OFlag;
 use nix::sys::stat::SFlag;
 use tokio::sync::Mutex;
 use tracing::{debug, info, instrument};
 
-use super::cache::policy::LruPolicy;
-use super::cache::{Backend, Block, BlockCoordinate, GlobalCache, MemoryCache, StorageManager};
-use super::dist::server::CacheServer;
 use super::fs_util::{self, NEED_CHECK_PERM};
 use super::id_alloc_used::INumAllocator;
 use super::kv_engine::{KVEngine, KVEngineType, MetaTxn, ValueType};
@@ -25,7 +21,6 @@ use super::metadata::{error, MetaData, ReqContext};
 use super::node::Node;
 use super::open_file::OpenFiles;
 use super::s3_node::{S3Node, GLOBAL_S3_FD_CNT};
-use super::s3_wrapper::S3BackEnd;
 use super::{check_type_supported, CreateParam, RenameParam, SetAttrParam};
 use crate::async_fuse::fuse::fuse_reply::{ReplyDirectory, StatFsParam};
 use crate::async_fuse::fuse::protocol::{FuseAttr, INum, FUSE_ROOT_ID};
@@ -93,23 +88,9 @@ impl MetaData for S3MetaData {
         if flush {
             self.flush(ino, fh).await?;
         }
-        if let Some(open_file) = self.open_files.close(ino) {
+        if self.open_files.close(ino).is_some() {
             // open_count reaches 0, flush the metadata to kv
             info!("release() ino={} fh={} file is closed", ino, fh);
-            let attr = {
-                let open_file = open_file.read();
-                open_file.attr
-            };
-            retry_txn!(TXN_RETRY_LIMIT, {
-                let mut txn = self.kv_engine.new_meta_txn().await;
-                let mut node = self.get_inode_from_txn(txn.as_mut(), ino).await?;
-                node.set_attr(attr);
-                txn.set(
-                    &KeyType::INum2Node(ino),
-                    &ValueType::Node(node.to_serial_node()),
-                );
-                (txn.commit().await, ())
-            })?;
         } else {
             info!("release() ino={} fh={} file is still open", ino, fh);
         }
@@ -195,27 +176,19 @@ impl MetaData for S3MetaData {
     #[instrument(skip(self))]
     async fn flush(&self, ino: u64, _fh: u64) -> DatenLordResult<()> {
         // Flush the storage cache
-        self.storage.flush(ino).await;
+        self.storage.flush(ino).await?;
         Ok(())
     }
 
     #[instrument(skip(self))]
     async fn releasedir(&self, ino: u64, _fh: u64) -> DatenLordResult<()> {
-        retry_txn!(TXN_RETRY_LIMIT, {
-            let mut txn = self.kv_engine.new_meta_txn().await;
-            let node = self.get_inode_from_txn(txn.as_mut(), ino).await?;
-            node.closedir().await;
-            let is_deleted = self.delete_check(&node).await?;
-            if is_deleted {
-                txn.delete(&KeyType::INum2Node(ino));
-            } else {
-                txn.set(
-                    &KeyType::INum2Node(ino),
-                    &ValueType::Node(node.to_serial_node()),
-                );
-            }
-            (txn.commit().await, ())
-        })?;
+        let inode = self.get_node_from_kv_engine(ino).await?;
+        if inode.is_none() {
+            return build_error_result_from_errno(
+                Errno::ENOENT,
+                format!("releasedir() failed to find ino={ino}"),
+            );
+        }
         Ok(())
     }
 
@@ -250,6 +223,28 @@ impl MetaData for S3MetaData {
             .load(ino, offset.cast(), read_size.cast(), mtime)
             .await?;
 
+        // If now is after atime + 1s, update atime
+        let atime = open_file.read().attr.atime;
+        let now = std::time::SystemTime::now();
+        let result = now
+            .duration_since(atime)
+            .unwrap_or_else(|_| Duration::new(0, 0))
+            .as_secs();
+        if result > 1 {
+            open_file.write().attr.atime = now;
+            retry_txn!(TXN_RETRY_LIMIT, {
+                let mut txn = self.kv_engine.new_meta_txn().await;
+                let mut node = self.get_inode_from_txn(txn.as_mut(), ino).await?;
+                let mut attr = node.get_attr();
+                attr.atime = now;
+                node.set_attr(attr);
+                txn.set(
+                    &KeyType::INum2Node(ino),
+                    &ValueType::Node(node.to_serial_node()),
+                );
+                (txn.commit().await, ())
+            })?;
+        }
         Ok(data)
     }
 
@@ -257,20 +252,16 @@ impl MetaData for S3MetaData {
     async fn open(&self, context: ReqContext, ino: u64, flags: u32) -> DatenLordResult<RawFd> {
         // TODO: handle open flags
         // <https://pubs.opengroup.org/onlinepubs/9699919799/functions/open.html>
-        // let open_res = if let SFlag::S_IFLNK = node.get_type() {
-        //     node.open_symlink_target(o_flags).await.add_context(format!(
-        //         "open() failed to open symlink target={:?} with flags={}",
-        //         node.get_symlink_target(),
-        //         flags,
-        //     ))
-        // } else {
-        // First find in open_files
+
+        // Map open flags to OFlag, then parse it into `u8` for permission check
         let o_flags = fs_util::parse_oflag(flags);
         let access_mode = match o_flags & (OFlag::O_RDONLY | OFlag::O_WRONLY | OFlag::O_RDWR) {
             OFlag::O_RDONLY => 4,
             OFlag::O_WRONLY => 2,
             _ => 6,
         };
+
+        // First find in `open_files`
         if let Some(open_file) = self.open_files.try_open(ino) {
             let open_file = open_file.read();
             open_file
@@ -278,7 +269,8 @@ impl MetaData for S3MetaData {
                 .check_perm(context.user_id, context.group_id, access_mode)?;
             return Ok(GLOBAL_S3_FD_CNT.fetch_add(1, Ordering::SeqCst).cast());
         }
-        // The file was not opened before, so we need to open it.
+
+        // The file doesn't open by any process, so we need to open it
         let (result, attr) = retry_txn!(TXN_RETRY_LIMIT, {
             let mut txn = self.kv_engine.new_meta_txn().await;
             let node = self.get_inode_from_txn(txn.as_mut(), ino).await?;
@@ -291,17 +283,22 @@ impl MetaData for S3MetaData {
             );
             (txn.commit().await, (result, attr))
         })?;
+
+        // Add the file to `open_files`
         self.open_files.open(ino, attr);
         result
     }
 
     #[instrument(skip(self), err, ret)]
     async fn getattr(&self, ino: u64) -> DatenLordResult<(Duration, FuseAttr)> {
+        // If the file is open, return the attr in `open_files`
         if let Some(open_file) = self.open_files.try_get(ino) {
             let open_file = open_file.read();
             let attr = fs_util::convert_to_fuse_attr(open_file.attr);
             return Ok((Duration::new(MY_TTL_SEC, 0), attr));
         }
+
+        // If the file is not open, return the attr in kv engine
         let inode = self
             .get_node_from_kv_engine(ino)
             .await?
@@ -318,8 +315,13 @@ impl MetaData for S3MetaData {
             let mut txn = self.kv_engine.new_meta_txn().await;
             let inode = self.get_inode_from_txn(txn.as_mut(), ino).await?;
             inode.dec_lookup_count_by(nlookup);
-            let is_deleted = self.delete_check(&inode).await?;
+            let is_deleted = inode.get_lookup_count() == 0;
             if is_deleted {
+                // FIXME: rename should also rename the node's name and reset the parent ino
+                txn.delete(&KeyType::DirEntryKey((
+                    inode.get_parent_ino(),
+                    inode.get_name().to_owned(),
+                )));
                 txn.delete(&KeyType::INum2Node(ino));
             } else {
                 txn.set(
@@ -343,20 +345,27 @@ impl MetaData for S3MetaData {
         let result = retry_txn!(TXN_RETRY_LIMIT, {
             let mut txn = self.kv_engine.new_meta_txn().await;
             let mut inode = self.get_inode_from_txn(txn.as_mut(), ino).await?;
-
-            let origin_attr = inode.get_attr();
-            let applied_attr = origin_attr;
-
+            let remote_attr = inode.get_attr();
             let dirty_attr_for_reply =
-                match applied_attr.setattr_precheck(param, context.user_id, context.group_id)? {
+                match remote_attr.setattr_precheck(param, context.user_id, context.group_id)? {
                     Some(dirty_attr) => {
-                        let dirty_attr_for_kv = dirty_attr;
-                        inode.set_attr(dirty_attr_for_kv);
+                        if remote_attr.size != dirty_attr.size {
+                            inode.update_mtime_ctime_to_now();
+                            self.storage
+                                .truncate(
+                                    ino,
+                                    remote_attr.size.cast(),
+                                    dirty_attr.size.cast(),
+                                    inode.get_attr().mtime,
+                                )
+                                .await?;
+                        }
+                        inode.set_attr(dirty_attr);
                         dirty_attr
                     }
                     None => {
                         // setattr did not change any attribute.
-                        return Ok((ttl, fs_util::convert_to_fuse_attr(origin_attr)));
+                        return Ok((ttl, fs_util::convert_to_fuse_attr(remote_attr)));
                     }
                 };
 
@@ -420,14 +429,15 @@ impl MetaData for S3MetaData {
                 }
             }
 
+            // Ready to unlink
+            let deferred_deletion = child_node.get_lookup_count() > 0;
+            // Deferred deletion is for inode ,not for dir entry
+            // So we will remove the dir entry immediately
             txn.delete(&KeyType::DirEntryKey((parent, name.into())));
             parent_node.update_mtime_ctime_to_now();
 
-            // Ready to unlink
-            let deferred_deletion =
-                child_node.get_open_count() > 0 || child_node.get_lookup_count() > 0;
-
             if deferred_deletion {
+                // `forget()` will remove the inode
                 child_node.mark_deferred_deletion();
                 txn.set(
                     &KeyType::INum2Node(child_ino),
@@ -498,31 +508,8 @@ impl MetaData for S3MetaData {
         *self.fuse_fd.lock().await = fuse_fd;
     }
 
-    #[instrument(skip(self, node), ret)]
-    /// Try to delete, if the deletion succeed, returns `true`.
-    async fn delete_check(&self, node: &S3Node) -> DatenLordResult<bool> {
-        let is_deleted = if node.get_open_count() == 0 && node.get_lookup_count() == 0 {
-            if let SFlag::S_IFREG = node.get_type() {
-                let ino = node.get_ino();
-                self.storage.remove(ino).await?;
-            }
-            true
-        } else {
-            false
-        };
-        debug!(
-            "try_delete_node()  is_deleted={} i-node of ino={} and name={:?} open_count={} lookup_count={}",
-            is_deleted,
-            node.get_ino(),
-            node.get_name(),
-            node.get_open_count(),
-            node.get_lookup_count(),
-        );
-        Ok(is_deleted)
-    }
-
     #[instrument(skip(self), err, ret)]
-    // Create and open a file
+    // Create a file, but do not open it. They are two separate steps.
     // If the file does not exist, first create it with
     // the specified mode, and then open it.
     #[allow(clippy::too_many_lines)]
@@ -621,6 +608,8 @@ impl MetaData for S3MetaData {
         let new_name = param.new_name.as_str();
         let flags = param.flags;
         // TODO: replace the new_node should delete its related data
+        // TODO: we should also rename the node's name and parent_ino, not only the dir
+        // entry
         let exchange = match flags {
             0 | RENAME_NOREPLACE => false,
             RENAME_EXCHANGE => true,
@@ -779,17 +768,6 @@ impl MetaData for S3MetaData {
         _datasync: bool,
         // reply: ReplyEmpty,
     ) -> DatenLordResult<()> {
-        retry_txn!(TXN_RETRY_LIMIT, {
-            let mut txn = self.kv_engine.new_meta_txn().await;
-            let mut node = self.get_inode_from_txn(txn.as_mut(), ino).await?;
-            let open_file = self.open_files.get(ino);
-            node.set_attr(open_file.read().attr);
-            txn.set(
-                &KeyType::INum2Node(ino),
-                &ValueType::Node(node.to_serial_node()),
-            );
-            (txn.commit().await, ())
-        })?;
         self.flush(ino, fh).await
     }
 
@@ -810,7 +788,7 @@ impl MetaData for S3MetaData {
             (attr.mtime, attr.size)
         };
 
-        let new_mtime = self.storage.store(ino, offset.cast(), &data, mtime).await;
+        let new_mtime = self.storage.store(ino, offset.cast(), &data, mtime).await?;
         let written_size = data.len();
         let new_size = file_size.max(offset.cast::<u64>().overflow_add(written_size.cast()));
 
@@ -822,6 +800,19 @@ impl MetaData for S3MetaData {
             open_file.attr.size = new_size;
         }
 
+        retry_txn!(TXN_RETRY_LIMIT, {
+            let mut txn = self.kv_engine.new_meta_txn().await;
+            let mut node = self.get_inode_from_txn(txn.as_mut(), ino).await?;
+            let mut attr = node.get_attr();
+            attr.mtime = new_mtime;
+            attr.size = new_size;
+            node.set_attr(attr);
+            txn.set(
+                &KeyType::INum2Node(ino),
+                &ValueType::Node(node.to_serial_node()),
+            );
+            (txn.commit().await, ())
+        })?;
         Ok(written_size)
     }
 }
@@ -852,7 +843,7 @@ impl S3MetaData {
     async fn check_sticky_bit<T: MetaTxn + ?Sized>(
         &self,
         context: &ReqContext,
-        parent_node: &S3Node<S>,
+        parent_node: &S3Node,
         child_entry: &DirEntry,
         txn: &mut T,
     ) -> DatenLordResult<()> {
@@ -881,7 +872,7 @@ impl S3MetaData {
         &self,
         txn: &mut T,
         ino: INum,
-    ) -> DatenLordResult<Option<S3Node<S>>> {
+    ) -> DatenLordResult<Option<S3Node>> {
         let inode = txn
             .get(&KeyType::INum2Node(ino))
             .await
@@ -900,7 +891,7 @@ impl S3MetaData {
         &self,
         txn: &mut T,
         ino: INum,
-    ) -> DatenLordResult<S3Node<S>> {
+    ) -> DatenLordResult<S3Node> {
         Ok(txn
             .get(&KeyType::INum2Node(ino))
             .await

--- a/src/async_fuse/memfs/s3_metadata.rs
+++ b/src/async_fuse/memfs/s3_metadata.rs
@@ -3,23 +3,29 @@ use std::os::unix::ffi::OsStringExt;
 use std::os::unix::io::RawFd;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use clippy_utilities::{Cast, OverflowArithmetic};
 use libc::{RENAME_EXCHANGE, RENAME_NOREPLACE};
 use lockfree_cuckoohash::{pin, LockFreeCuckooHash as HashMap};
 use nix::errno::Errno;
+use nix::fcntl::OFlag;
 use nix::sys::stat::SFlag;
 use tokio::sync::Mutex;
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, info, instrument};
 
-use super::fs_util::{self, FileAttr, NEED_CHECK_PERM};
+use super::cache::policy::LruPolicy;
+use super::cache::{Backend, Block, BlockCoordinate, GlobalCache, MemoryCache, StorageManager};
+use super::dist::server::CacheServer;
+use super::fs_util::{self, NEED_CHECK_PERM};
 use super::id_alloc_used::INumAllocator;
 use super::kv_engine::{KVEngine, KVEngineType, MetaTxn, ValueType};
 use super::metadata::{error, MetaData, ReqContext};
 use super::node::Node;
-use super::s3_node::S3Node;
+use super::open_file::OpenFiles;
+use super::s3_node::{S3Node, GLOBAL_S3_FD_CNT};
+use super::s3_wrapper::S3BackEnd;
 use super::{check_type_supported, CreateParam, RenameParam, SetAttrParam};
 use crate::async_fuse::fuse::fuse_reply::{ReplyDirectory, StatFsParam};
 use crate::async_fuse::fuse::protocol::{FuseAttr, INum, FUSE_ROOT_ID};
@@ -66,8 +72,8 @@ pub struct S3MetaData {
     pub(crate) kv_engine: Arc<KVEngineType>,
     /// Inum allocator
     inum_allocator: INumAllocator<KVEngineType>,
-    /// Mtime and size cache in local
-    local_mtime_and_size: HashMap<INum, (SystemTime, u64)>,
+    /// opend files
+    open_files: OpenFiles,
 }
 
 #[async_trait]
@@ -87,16 +93,26 @@ impl MetaData for S3MetaData {
         if flush {
             self.flush(ino, fh).await?;
         }
-        retry_txn!(TXN_RETRY_LIMIT, {
-            let mut txn = self.kv_engine.new_meta_txn().await;
-            let mut inode = self.get_inode_from_txn(txn.as_mut(), ino).await?;
-            inode.close().await;
-            txn.set(
-                &KeyType::INum2Node(ino),
-                &ValueType::Node(inode.to_serial_node()),
-            );
-            (txn.commit().await, ())
-        })?;
+        if let Some(open_file) = self.open_files.close(ino) {
+            // open_count reaches 0, flush the metadata to kv
+            info!("release() ino={} fh={} file is closed", ino, fh);
+            let attr = {
+                let open_file = open_file.read();
+                open_file.attr
+            };
+            retry_txn!(TXN_RETRY_LIMIT, {
+                let mut txn = self.kv_engine.new_meta_txn().await;
+                let mut node = self.get_inode_from_txn(txn.as_mut(), ino).await?;
+                node.set_attr(attr);
+                txn.set(
+                    &KeyType::INum2Node(ino),
+                    &ValueType::Node(node.to_serial_node()),
+                );
+                (txn.commit().await, ())
+            })?;
+        } else {
+            info!("release() ino={} fh={} file is still open", ino, fh);
+        }
         Ok(())
     }
 
@@ -178,50 +194,8 @@ impl MetaData for S3MetaData {
 
     #[instrument(skip(self))]
     async fn flush(&self, ino: u64, _fh: u64) -> DatenLordResult<()> {
-        let local_mtime_and_size = {
-            let guard = pin();
-
-            self.local_mtime_and_size
-                .remove_with_guard(&ino, &guard)
-                .copied()
-        };
-
-        retry_txn!(TXN_RETRY_LIMIT, {
-            let mut txn = self.kv_engine.new_meta_txn().await;
-            let mut inode = self.get_inode_from_txn(txn.as_mut(), ino).await?;
-
-            if inode.is_deferred_deletion() {
-                // If a file is marked as deferred delete, there is no need to flush it.
-                // But the local node may continue to access this file, which depends on
-                // the local mtime and local size. Therefore, we need to insert the removed
-                // local mtime and local size back to the cache.
-                if let Some(local_mtime_and_size) = local_mtime_and_size {
-                    self.local_mtime_and_size.insert(ino, local_mtime_and_size);
-                }
-                return Ok(());
-            }
-
-            // Flush the storage cache
-            self.storage.flush(ino).await?;
-
-            let mut file_attr = inode.get_attr();
-
-            if let Some((local_mtime, local_size)) = local_mtime_and_size {
-                file_attr.mtime = local_mtime;
-                file_attr.size = local_size;
-
-                // `ctime` may be greater than `mtime`, use the greater one
-                file_attr.ctime = local_mtime.max(file_attr.ctime);
-            }
-
-            inode.set_attr(file_attr);
-
-            txn.set(
-                &KeyType::INum2Node(ino),
-                &ValueType::Node(inode.to_serial_node()),
-            );
-            (txn.commit().await, ())
-        })?;
+        // Flush the storage cache
+        self.storage.flush(ino).await;
         Ok(())
     }
 
@@ -253,15 +227,11 @@ impl MetaData for S3MetaData {
         offset: i64,
         size: u32,
     ) -> DatenLordResult<Vec<Block>> {
-        let inode = self
-            .get_node_from_kv_engine(ino)
-            .await?
-            .ok_or_else(|| build_inconsistent_fs!(ino))?;
+        let open_file = self.open_files.get(ino);
 
         let (mtime, file_size) = {
-            let local_mtime_and_size = self.get_local_mtime_and_size(ino);
-            let file_attr = inode.get_attr();
-            local_mtime_and_size.unwrap_or((file_attr.mtime, file_attr.size))
+            let attr = open_file.read().attr;
+            (attr.mtime, attr.size)
         };
 
         if offset.cast::<u64>() >= file_size {
@@ -294,28 +264,49 @@ impl MetaData for S3MetaData {
         //         flags,
         //     ))
         // } else {
-        retry_txn!(TXN_RETRY_LIMIT, {
+        // First find in open_files
+        let o_flags = fs_util::parse_oflag(flags);
+        let access_mode = match o_flags & (OFlag::O_RDONLY | OFlag::O_WRONLY | OFlag::O_RDWR) {
+            OFlag::O_RDONLY => 4,
+            OFlag::O_WRONLY => 2,
+            _ => 6,
+        };
+        if let Some(open_file) = self.open_files.try_open(ino) {
+            let open_file = open_file.read();
+            open_file
+                .attr
+                .check_perm(context.user_id, context.group_id, access_mode)?;
+            return Ok(GLOBAL_S3_FD_CNT.fetch_add(1, Ordering::SeqCst).cast());
+        }
+        // The file was not opened before, so we need to open it.
+        let (result, attr) = retry_txn!(TXN_RETRY_LIMIT, {
             let mut txn = self.kv_engine.new_meta_txn().await;
             let node = self.get_inode_from_txn(txn.as_mut(), ino).await?;
-            let o_flags = fs_util::parse_oflag(flags);
-            node.open_pre_check(o_flags, context.user_id, context.group_id)?;
-
+            let attr = node.get_attr();
+            attr.check_perm(context.user_id, context.group_id, access_mode)?;
             let result = node.dup_fd(o_flags).await;
             txn.set(
                 &KeyType::INum2Node(ino),
                 &ValueType::Node(node.to_serial_node()),
             );
-            (txn.commit().await, result)
-        })?
+            (txn.commit().await, (result, attr))
+        })?;
+        self.open_files.open(ino, attr);
+        result
     }
 
     #[instrument(skip(self), err, ret)]
     async fn getattr(&self, ino: u64) -> DatenLordResult<(Duration, FuseAttr)> {
+        if let Some(open_file) = self.open_files.try_get(ino) {
+            let open_file = open_file.read();
+            let attr = fs_util::convert_to_fuse_attr(open_file.attr);
+            return Ok((Duration::new(MY_TTL_SEC, 0), attr));
+        }
         let inode = self
             .get_node_from_kv_engine(ino)
             .await?
             .ok_or_else(|| build_inconsistent_fs!(ino))?;
-        let attr = self.apply_local_mtime_and_size(inode.get_attr());
+        let attr = inode.get_attr();
         let ttl = Duration::new(MY_TTL_SEC, 0);
         let fuse_attr = fs_util::convert_to_fuse_attr(attr);
         Ok((ttl, fuse_attr))
@@ -354,69 +345,20 @@ impl MetaData for S3MetaData {
             let mut inode = self.get_inode_from_txn(txn.as_mut(), ino).await?;
 
             let origin_attr = inode.get_attr();
-            let applied_attr = if SFlag::S_IFREG == origin_attr.kind {
-                self.apply_local_mtime_and_size(origin_attr)
-            } else {
-                origin_attr
-            };
+            let applied_attr = origin_attr;
 
-            let dirty_attr_for_reply = match applied_attr.setattr_precheck(
-                param,
-                context.user_id,
-                context.group_id,
-            )? {
-                Some(mut dirty_attr) => {
-                    // This is to be inserted in KV, whose `mtime` and `size` should be reset to
-                    // origin, because changes of this field are invisible to other
-                    // nodes until flush.
-                    let mut dirty_attr_for_kv = dirty_attr;
-
-                    // There are `mtime` and `size` caches for regular files. Check the change of
-                    // these fields, and set them to the cache.
-                    if SFlag::S_IFREG == applied_attr.kind {
-                        if (dirty_attr.mtime, dirty_attr.size)
-                            != (applied_attr.mtime, applied_attr.size)
-                        {
-                            self.local_mtime_and_size
-                                .insert(ino, (dirty_attr.mtime, dirty_attr.size));
-                        }
-                        // Reset `mtime` and `size` to origin, because changes of these fields is
-                        // invisible to other nodes until flush.
-                        dirty_attr_for_kv.mtime = origin_attr.mtime;
-                        dirty_attr_for_kv.size = origin_attr.size;
-
-                        // The file also needs to be truncated, if the new size is shorter.
-                        if dirty_attr.size < applied_attr.size {
-                            let new_mtime = self
-                                .storage
-                                .truncate(
-                                    ino,
-                                    applied_attr.size.cast(),
-                                    dirty_attr.size.cast(),
-                                    applied_attr.mtime,
-                                )
-                                .await?;
-                            self.local_mtime_and_size
-                                .insert(ino, (new_mtime, dirty_attr.size));
-                            dirty_attr.mtime = new_mtime;
-                        }
+            let dirty_attr_for_reply =
+                match applied_attr.setattr_precheck(param, context.user_id, context.group_id)? {
+                    Some(dirty_attr) => {
+                        let dirty_attr_for_kv = dirty_attr;
+                        inode.set_attr(dirty_attr_for_kv);
+                        dirty_attr
                     }
-
-                    inode.set_attr(dirty_attr_for_kv);
-
-                    debug!(
-                        "setattr() successfully set the attribute of ino={} and name={:?}, the set attr={:?}",
-                        ino, inode.get_name(), dirty_attr,
-                    );
-
-                    // The attr with new `size` and `mtime` should be replied.
-                    dirty_attr
-                }
-                None => {
-                    // setattr did not change any attribute.
-                    return Ok((ttl, fs_util::convert_to_fuse_attr(origin_attr)));
-                }
-            };
+                    None => {
+                        // setattr did not change any attribute.
+                        return Ok((ttl, fs_util::convert_to_fuse_attr(origin_attr)));
+                    }
+                };
 
             txn.set(
                 &KeyType::INum2Node(ino),
@@ -493,7 +435,6 @@ impl MetaData for S3MetaData {
                 );
             } else {
                 if let SFlag::S_IFREG = child_node.get_type() {
-                    self.local_mtime_and_size.remove(&child_ino);
                     self.storage.remove(child_ino).await?;
                 }
                 txn.delete(&KeyType::INum2Node(child_ino));
@@ -519,7 +460,7 @@ impl MetaData for S3MetaData {
             inum_allocator: INumAllocator::new(Arc::clone(&kv_engine)),
             kv_engine,
             storage: Arc::new(storage),
-            local_mtime_and_size: HashMap::new(),
+            open_files: OpenFiles::new(),
         });
 
         retry_txn!(TXN_RETRY_LIMIT, {
@@ -564,7 +505,6 @@ impl MetaData for S3MetaData {
             if let SFlag::S_IFREG = node.get_type() {
                 let ino = node.get_ino();
                 self.storage.remove(ino).await?;
-                self.local_mtime_and_size.remove(&ino);
             }
             true
         } else {
@@ -660,7 +600,7 @@ impl MetaData for S3MetaData {
 
             let child_ino = child_entry.ino();
             let child_node = self.get_inode_from_txn(txn.as_mut(), child_ino).await?;
-            let child_attr = self.apply_local_mtime_and_size(child_node.lookup_attr());
+            let child_attr = child_node.get_attr();
 
             let ttl = Duration::new(MY_TTL_SEC, 0);
             let fuse_attr = fs_util::convert_to_fuse_attr(child_attr);
@@ -839,8 +779,17 @@ impl MetaData for S3MetaData {
         _datasync: bool,
         // reply: ReplyEmpty,
     ) -> DatenLordResult<()> {
-        // We do not have completed metadata cache,
-        // so there are no need to handle the situation that the metadata is not synced.
+        retry_txn!(TXN_RETRY_LIMIT, {
+            let mut txn = self.kv_engine.new_meta_txn().await;
+            let mut node = self.get_inode_from_txn(txn.as_mut(), ino).await?;
+            let open_file = self.open_files.get(ino);
+            node.set_attr(open_file.read().attr);
+            txn.set(
+                &KeyType::INum2Node(ino),
+                &ValueType::Node(node.to_serial_node()),
+            );
+            (txn.commit().await, ())
+        })?;
         self.flush(ino, fh).await
     }
 
@@ -854,37 +803,25 @@ impl MetaData for S3MetaData {
         data: Vec<u8>,
         _flags: u32,
     ) -> DatenLordResult<usize> {
-        let mut txn = self.kv_engine.new_meta_txn().await;
-        let inode = self.get_inode_from_txn(txn.as_mut(), ino).await?;
+        let open_file = self.open_files.get(ino);
 
         let (mtime, file_size) = {
-            let local_mtime_and_size = self.get_local_mtime_and_size(ino);
-            let file_attr = inode.get_attr();
-            local_mtime_and_size.unwrap_or((file_attr.mtime, file_attr.size))
+            let attr = open_file.read().attr;
+            (attr.mtime, attr.size)
         };
 
-        let new_mtime = self.storage.store(ino, offset.cast(), &data, mtime).await?;
+        let new_mtime = self.storage.store(ino, offset.cast(), &data, mtime).await;
         let written_size = data.len();
         let new_size = file_size.max(offset.cast::<u64>().overflow_add(written_size.cast()));
 
-        // In fact, no changes will be written to the `inode`,
-        // and the `txn.set` here is just for atomic ensuring.
-        txn.set(
-            &KeyType::INum2Node(ino),
-            &ValueType::Node(inode.to_serial_node()),
-        );
-
-        if !txn.commit().await? {
-            // Transaction committed failed, but we don't retry here
-            // Print a warning log and return the result
-            warn!("write_helper() failed to commit txn");
-            // Currently, we consider it as a IO error
-            return build_error_result_from_errno(
-                Errno::EIO,
-                "write_helper() failed to commit txn".to_owned(),
-            );
+        // Update the `mtime` and `size` of the file
+        {
+            let raw_open_file = self.open_files.get(ino);
+            let mut open_file = raw_open_file.write();
+            open_file.attr.mtime = new_mtime;
+            open_file.attr.size = new_size;
         }
-        self.local_mtime_and_size.insert(ino, (new_mtime, new_size));
+
         Ok(written_size)
     }
 }
@@ -903,28 +840,6 @@ impl S3MetaData {
         Ok(raw_data.map(|value| value.into_s3_node(self)))
     }
 
-    /// Get the local cache of `mtime` and `size` of a file.
-    fn get_local_mtime_and_size(&self, ino: INum) -> Option<(SystemTime, u64)> {
-        let guard = pin();
-
-        self.local_mtime_and_size.get(&ino, &guard).copied()
-    }
-
-    /// Apply the local `mtime` and `size` to `attr`.
-    fn apply_local_mtime_and_size(&self, mut attr: FileAttr) -> FileAttr {
-        let ino = attr.ino;
-
-        let Some((local_mtime, local_size)) = self.get_local_mtime_and_size(ino) else {
-            return attr;
-        };
-
-        attr.mtime = local_mtime;
-        attr.ctime = local_mtime.max(attr.ctime);
-        attr.size = local_size;
-
-        attr
-    }
-
     /// Allocate a new uinque inum for new node
     async fn alloc_inum(&self) -> DatenLordResult<INum> {
         let result = self.inum_allocator.alloc_inum_for_fnode().await;
@@ -937,7 +852,7 @@ impl S3MetaData {
     async fn check_sticky_bit<T: MetaTxn + ?Sized>(
         &self,
         context: &ReqContext,
-        parent_node: &S3Node,
+        parent_node: &S3Node<S>,
         child_entry: &DirEntry,
         txn: &mut T,
     ) -> DatenLordResult<()> {
@@ -966,7 +881,7 @@ impl S3MetaData {
         &self,
         txn: &mut T,
         ino: INum,
-    ) -> DatenLordResult<Option<S3Node>> {
+    ) -> DatenLordResult<Option<S3Node<S>>> {
         let inode = txn
             .get(&KeyType::INum2Node(ino))
             .await
@@ -985,7 +900,7 @@ impl S3MetaData {
         &self,
         txn: &mut T,
         ino: INum,
-    ) -> DatenLordResult<S3Node> {
+    ) -> DatenLordResult<S3Node<S>> {
         Ok(txn
             .get(&KeyType::INum2Node(ino))
             .await

--- a/src/async_fuse/memfs/s3_metadata.rs
+++ b/src/async_fuse/memfs/s3_metadata.rs
@@ -358,6 +358,14 @@ impl MetaData for S3MetaData {
                                     inode.get_attr().mtime,
                                 )
                                 .await?;
+                            if param.fh.is_some() {
+                                // The file is open, update the attr in `open_files`
+                                let raw_open_file = self.open_files.get(ino);
+                                let mut open_file = raw_open_file.write();
+                                open_file.attr.size = dirty_attr.size;
+                                open_file.attr.mtime = inode.get_attr().mtime;
+                                open_file.attr.ctime = inode.get_attr().ctime;
+                            }
                         }
                         inode.set_attr(dirty_attr);
                         dirty_attr

--- a/src/async_fuse/memfs/s3_node.rs
+++ b/src/async_fuse/memfs/s3_node.rs
@@ -13,7 +13,7 @@ use nix::fcntl::OFlag;
 use nix::sys::stat::{Mode, SFlag};
 use nix::unistd;
 use parking_lot::RwLock;
-use tracing::{info, warn};
+use tracing::info;
 
 use super::direntry::{DirEntry, FileType};
 use super::fs_util::{self, FileAttr};
@@ -64,8 +64,6 @@ pub struct S3Node {
     attr: Arc<RwLock<FileAttr>>,
     /// S3Node data
     data: S3NodeData,
-    /// S3Node open counter
-    open_count: AtomicI64,
     /// S3Node lookup counter
     lookup_count: AtomicI64,
     /// If S3Node has been marked as deferred deletion
@@ -92,8 +90,6 @@ impl S3Node {
             name: name.to_owned(),
             attr,
             data,
-            // open count set to 0 by creation
-            open_count: AtomicI64::new(0),
             // lookup count set to 1 by creation
             lookup_count: AtomicI64::new(1),
             deferred_deletion: AtomicBool::new(false),
@@ -106,9 +102,8 @@ impl S3Node {
     pub fn from_serial_node(serial_node: SerialNode, meta: &S3MetaData) -> S3Node {
         let dir_data = serial_node.data.into_s3_nodedata();
         info!(
-            "ino={}, open_count={}, lookup_count={},attr={:?}",
+            "ino={},lookup_count={},attr={:?}",
             serial_node.attr.get_ino(),
-            serial_node.open_count,
             serial_node.lookup_count,
             serial_node.attr
         );
@@ -117,7 +112,6 @@ impl S3Node {
             name: serial_node.name,
             attr: Arc::new(RwLock::new(serial_to_file_attr(&serial_node.attr))),
             data: dir_data,
-            open_count: AtomicI64::new(serial_node.open_count),
             lookup_count: AtomicI64::new(serial_node.lookup_count),
             deferred_deletion: AtomicBool::new(serial_node.deferred_deletion),
             kv_engine: Arc::clone(&meta.kv_engine),
@@ -132,7 +126,6 @@ impl S3Node {
             name: self.name.clone(),
             attr: file_attr_to_serial(&self.attr.read().clone()),
             data: self.data.serial(),
-            open_count: self.open_count.load(Ordering::SeqCst),
             lookup_count: self.lookup_count.load(Ordering::SeqCst),
             deferred_deletion: self.deferred_deletion.load(Ordering::SeqCst),
         }
@@ -163,8 +156,6 @@ impl S3Node {
             attr: child_attr,
             data,
             // lookup count set to 0 for sync
-            open_count: AtomicI64::new(0),
-            // open count set to 0 for sync
             lookup_count: AtomicI64::new(0),
             deferred_deletion: AtomicBool::new(false),
             kv_engine: Arc::clone(&parent.kv_engine),
@@ -191,12 +182,6 @@ impl S3Node {
     /// Increase node lookup count
     fn inc_lookup_count(&self) -> i64 {
         self.lookup_count.fetch_add(1, Ordering::AcqRel)
-    }
-
-    /// Increase node open count
-    fn inc_open_count(&self) -> i64 {
-        // TODO: add the usage
-        self.open_count.fetch_add(1, Ordering::AcqRel)
     }
 
     /// Open root node
@@ -341,24 +326,6 @@ impl Node for S3Node {
         attr
     }
 
-    /// Get node open count
-    fn get_open_count(&self) -> i64 {
-        self.open_count.load(Ordering::Acquire)
-    }
-
-    /// Decrease node open count
-    fn dec_open_count(&self) -> i64 {
-        if self.open_count.load(Ordering::Acquire) == 0 {
-            warn!(
-                "dec_open_count() found open_count is 0, ino={}, name={}",
-                self.get_ino(),
-                self.get_name()
-            );
-        }
-        debug_assert!(self.open_count.load(Ordering::Acquire) > 0);
-        self.open_count.fetch_sub(1, Ordering::AcqRel)
-    }
-
     /// Get node lookup count
     fn get_lookup_count(&self) -> i64 {
         self.lookup_count.load(Ordering::Acquire)
@@ -392,7 +359,6 @@ impl Node for S3Node {
 
     /// Duplicate fd
     async fn dup_fd(&self, _oflags: OFlag) -> DatenLordResult<RawFd> {
-        self.inc_open_count();
         Ok(self.new_fd().cast())
     }
 
@@ -562,14 +528,6 @@ impl Node for S3Node {
             namelen: 1024,
             frsize: 4096,
         })
-    }
-
-    async fn close(&mut self) {
-        self.dec_open_count();
-    }
-
-    async fn closedir(&self) {
-        self.dec_open_count();
     }
 
     /// Create child node

--- a/src/async_fuse/memfs/s3_node.rs
+++ b/src/async_fuse/memfs/s3_node.rs
@@ -28,7 +28,7 @@ use crate::async_fuse::util::build_error_result_from_errno;
 use crate::common::error::DatenLordResult;
 
 /// S3's available fd count
-static GLOBAL_S3_FD_CNT: AtomicU32 = AtomicU32::new(4);
+pub static GLOBAL_S3_FD_CNT: AtomicU32 = AtomicU32::new(4);
 
 /// A file node data or a directory node data
 #[derive(Debug)]

--- a/src/async_fuse/memfs/serial.rs
+++ b/src/async_fuse/memfs/serial.rs
@@ -92,8 +92,6 @@ pub struct SerialNode {
     pub(crate) attr: SerialFileAttr,
     /// Node data
     pub(crate) data: SerialNodeData,
-    /// S3Node open counter
-    pub(crate) open_count: i64,
     /// S3Node lookup counter
     pub(crate) lookup_count: i64,
     /// If S3Node has been marked as deferred deletion

--- a/src/async_fuse/test/integration_tests.rs
+++ b/src/async_fuse/test/integration_tests.rs
@@ -225,75 +225,27 @@ fn test_rename_file(mount_dir: &Path) -> anyhow::Result<()> {
 
 #[cfg(test)]
 fn test_rename_file_replace(mount_dir: &Path) -> anyhow::Result<()> {
-    info!("test rename file no replace");
-    let oflags = OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_RDWR;
-    let file_mode = Mode::from_bits_truncate(0o644);
+    info!("test rename file replace");
+    let old_file = Path::new(mount_dir).join("test_rename_file_replace_old.txt");
+    let new_file = Path::new(mount_dir).join("test_rename_file_replace_new.txt");
 
-    let old_file = Path::new(mount_dir).join("old.txt");
-    let old_fd = fcntl::open(&old_file, oflags, file_mode)?;
-    let old_file_write_size = unistd::write(old_fd, FILE_CONTENT.as_bytes())?;
-    assert_eq!(
-        old_file_write_size,
-        FILE_CONTENT.len(),
-        "the file write size {} is not the same as the expected size {}",
-        old_file_write_size,
-        FILE_CONTENT.len(),
-    );
+    let old_content = "old content";
+    let new_content = "new content";
 
-    let new_file = Path::new(&mount_dir).join("new.txt");
-    let new_fd = fcntl::open(&new_file, oflags, file_mode)?;
-    let new_file_write_size = unistd::write(new_fd, FILE_CONTENT.as_bytes())?;
-    assert_eq!(
-        new_file_write_size,
-        FILE_CONTENT.len(),
-        "the file write size {} is not the same as the expected size {}",
-        new_file_write_size,
-        FILE_CONTENT.len(),
-    );
+    fs::write(&old_file, old_content)?;
+    fs::write(&new_file, new_content)?;
 
-    fs::rename(&old_file, &new_file).context("rename replace should not fail")?;
-
-    let mut buffer: Vec<u8> = iter::repeat(0_u8).take(FILE_CONTENT.len()).collect();
-    unistd::lseek(old_fd, 0, Whence::SeekSet)?;
-    let old_file_read_size = unistd::read(old_fd, &mut buffer)?;
-    let content = String::from_utf8(buffer)?;
-    unistd::close(old_fd)?;
-    assert_eq!(
-        old_file_read_size,
-        FILE_CONTENT.len(),
-        "the file read size {} is not the same as the expected size {}",
-        old_file_read_size,
-        FILE_CONTENT.len(),
-    );
-    assert_eq!(
-        content, FILE_CONTENT,
-        "the file read result is not the same as the expected content",
-    );
-
-    let mut buffer: Vec<u8> = iter::repeat(0_u8).take(FILE_CONTENT.len()).collect();
-    unistd::lseek(new_fd, 0, Whence::SeekSet)?;
-    let new_file_read_size = unistd::read(new_fd, &mut buffer)?;
-    let content = String::from_utf8(buffer)?;
-    unistd::close(new_fd)?;
-    assert_eq!(
-        new_file_read_size,
-        FILE_CONTENT.len(),
-        "the file read size {} is not the same as the expected size {}",
-        new_file_read_size,
-        FILE_CONTENT.len(),
-    );
-    assert_eq!(
-        content, FILE_CONTENT,
-        "the file read result is not the same as the expected content",
-    );
+    fs::rename(&old_file, &new_file)?;
 
     assert!(
         !old_file.exists(),
-        "the old file {new_file:?} should not exist",
+        "the old file {old_file:?} should have been removed",
     );
     assert!(new_file.exists(), "the new file {new_file:?} should exist",);
+    let bytes = fs::read(&new_file)?;
+    let content = String::from_utf8(bytes)?;
+    assert_eq!(content, old_content);
 
-    // Clean up
     fs::remove_file(&new_file)?;
     Ok(())
 }

--- a/src/async_fuse/test/integration_tests.rs
+++ b/src/async_fuse/test/integration_tests.rs
@@ -104,14 +104,14 @@ fn test_directory_manipulation_rust_way(mount_dir: &Path) -> anyhow::Result<()> 
     info!("test Directory manipulation Rust style");
 
     // Fixed directory name
-    let dir_name = "test_dir";
+    let dir_name = "dir_manipulation_test_dir";
     let dir_path = Path::new(mount_dir).join(dir_name);
 
     // Create directory
     fs::create_dir_all(&dir_path)?;
 
     // Fixed file name
-    let file_name = "tmp.txt";
+    let file_name = "dir_manipulation_tmp.txt";
     let file_path = dir_path.join(file_name);
 
     // Write to file

--- a/src/common/logger.rs
+++ b/src/common/logger.rs
@@ -62,7 +62,7 @@ pub fn init_logger(role: LogRole) {
         .with_target("hyper", Level::WARN)
         .with_target("h2", Level::WARN)
         .with_target("tower", Level::WARN)
-        .with_target("datenlord::async_fuse::fuse", Level::INFO)
+        .with_target("datenlord::async_fuse::fuse", Level::WARN)
         .with_target("", Level::INFO);
 
     let log_path = format!("./datenlord_{}.log", role.as_str());


### PR DESCRIPTION
In this pull request, I've added an open-to-close metadata cache for files. This significantly enhances read and write performance. There's an issue worth noting, though. When flushing to the KV store on close, do we need to call set_attr() to overwrite all remote information, or should we just update the IO-related attributes like time and size?