### PR TITLE
refactor: Prepare for error handling of storage

### DIFF
--- a/src/storage/error.rs
+++ b/src/storage/error.rs
@@ -1,0 +1,71 @@
+//! Error types for storage.
+
+use thiserror::Error;
+
+use super::BlockId;
+use crate::async_fuse::fuse::protocol::INum;
+
+/// The result of storage operation.
+pub type StorageResult<T> = Result<T, StorageError>;
+
+/// An error occurs in storage operation.
+#[derive(Debug, Error)]
+#[error("Storage Error on {operation:?}, inner is {inner}.")]
+pub struct StorageError {
+    /// The operation kind.
+    pub operation: StorageOperation,
+    /// The inner error.
+    pub inner: StorageErrorInner,
+}
+
+/// The kind of storage operation.
+#[derive(Debug)]
+pub enum StorageOperation {
+    /// Load operation.
+    Load {
+        /// The inode number of this error
+        ino: INum,
+        /// The block id of this error.
+        block_id: BlockId,
+    },
+    /// Store operation.
+    Store {
+        /// The inode number of this error
+        ino: INum,
+        /// The block id of this error.
+        block_id: BlockId,
+    },
+    /// Remove operation.
+    Remove {
+        /// The inode number of this error
+        ino: INum,
+    },
+    /// Truncate operation.
+    Truncate {
+        /// The inode number of this error
+        ino: INum,
+        /// The start block id of truncate.
+        from: BlockId,
+        /// The end block id of truncate.
+        to: BlockId,
+    },
+}
+
+/// The inner details of `StorageError`
+#[derive(Debug, Error)]
+pub enum StorageErrorInner {
+    /// The storage operation is out of range of a block
+    #[error("{found} is out of range of {maximum}")]
+    OutOfRange {
+        /// The maximum size of the operated block
+        maximum: usize,
+        /// The size or offset found in argument
+        found: usize,
+    },
+    /// An error caused by [`std::io::Error`]
+    #[error("{0}")]
+    StdIoError(#[from] std::io::Error),
+    /// An error caused by [`opendal::Error`]
+    #[error("{0}")]
+    OpenDalError(#[from] opendal::Error),
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -6,10 +6,12 @@ mod memory_cache;
 mod storage_manager;
 mod storage_trait;
 
+pub mod error;
 pub mod policy;
 
 pub use backend::{Backend, BackendBuilder};
 pub use block::{Block, BlockCoordinate};
+pub use error::{StorageError, StorageErrorInner};
 pub use memory_cache::{MemoryCache, MemoryCacheBuilder};
 pub use storage_manager::StorageManager;
 pub use storage_trait::Storage;

--- a/src/storage/storage_trait.rs
+++ b/src/storage/storage_trait.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
+use super::error::StorageResult;
 use super::Block;
 use crate::async_fuse::fuse::protocol::INum;
 
@@ -14,29 +15,34 @@ pub trait Storage {
     // Required methods
 
     /// Loads a block from `self` but not from its backend.
-    async fn load_from_self(&self, ino: INum, block_id: usize) -> Option<Block>;
+    async fn load_from_self(&self, ino: INum, block_id: usize) -> StorageResult<Option<Block>>;
 
     /// Loads a block from the `backend`.
-    async fn load_from_backend(&self, ino: INum, block_id: usize) -> Option<Block>;
+    async fn load_from_backend(&self, ino: INum, block_id: usize) -> StorageResult<Option<Block>>;
 
     /// Caches a block that is just loaded from the backend.
     ///
     /// This may evict a block to the backend.
-    async fn cache_block_from_backend(&self, ino: INum, block_id: usize, block: Block);
+    async fn cache_block_from_backend(
+        &self,
+        ino: INum,
+        block_id: usize,
+        block: Block,
+    ) -> StorageResult<()>;
     /// Store a block to the storage.
-    async fn store(&self, ino: INum, block_id: usize, block: Block);
+    async fn store(&self, ino: INum, block_id: usize, block: Block) -> StorageResult<()>;
 
     /// Remove a file from storage.
-    async fn remove(&self, ino: INum);
+    async fn remove(&self, ino: INum) -> StorageResult<()>;
 
     /// Invalidate caches of a file, if the storage contains caches.
-    async fn invalidate(&self, ino: INum);
+    async fn invalidate(&self, ino: INum) -> StorageResult<()>;
 
     /// Flush a file
-    async fn flush(&self, ino: INum);
+    async fn flush(&self, ino: INum) -> StorageResult<()>;
 
     /// Flush all files
-    async fn flush_all(&self);
+    async fn flush_all(&self) -> StorageResult<()>;
 
     /// Truncate a file from the block id of `from` to a lower one, and fill
     /// zeros in the end of the last block. Both `from` and `to` are in
@@ -44,22 +50,28 @@ pub trait Storage {
     /// If `fill_start` is set to block size, this method should not fill any
     /// zero. After the truncating, the block range of the file is
     /// `[0, to_block)`.
-    async fn truncate(&self, ino: INum, from_block: usize, to_block: usize, fill_start: usize);
+    async fn truncate(
+        &self,
+        ino: INum,
+        from_block: usize,
+        to_block: usize,
+        fill_start: usize,
+    ) -> StorageResult<()>;
 
     // Provided methods
 
     /// Load a block from the storage.
-    async fn load(&self, ino: INum, block_id: usize) -> Option<Block> {
-        if let Some(block_in_cache) = self.load_from_self(ino, block_id).await {
-            Some(block_in_cache)
+    async fn load(&self, ino: INum, block_id: usize) -> StorageResult<Option<Block>> {
+        if let Some(block_in_cache) = self.load_from_self(ino, block_id).await? {
+            Ok(Some(block_in_cache))
         } else {
-            let res = self.load_from_backend(ino, block_id).await;
+            let res = self.load_from_backend(ino, block_id).await?;
             if let Some(block) = res {
                 self.cache_block_from_backend(ino, block_id, block.clone())
-                    .await;
-                Some(block)
+                    .await?;
+                Ok(Some(block))
             } else {
-                None
+                Ok(None)
             }
         }
     }
@@ -70,47 +82,58 @@ impl<T> Storage for Arc<T>
 where
     T: Storage + Send + Sync,
 {
-    async fn load_from_self(&self, ino: INum, block_id: usize) -> Option<Block> {
+    async fn load_from_self(&self, ino: INum, block_id: usize) -> StorageResult<Option<Block>> {
         self.as_ref().load_from_self(ino, block_id).await
     }
 
-    async fn load_from_backend(&self, ino: INum, block_id: usize) -> Option<Block> {
+    async fn load_from_backend(&self, ino: INum, block_id: usize) -> StorageResult<Option<Block>> {
         self.as_ref().load_from_backend(ino, block_id).await
     }
 
-    async fn cache_block_from_backend(&self, ino: INum, block_id: usize, block: Block) {
+    async fn cache_block_from_backend(
+        &self,
+        ino: INum,
+        block_id: usize,
+        block: Block,
+    ) -> StorageResult<()> {
         self.as_ref()
             .cache_block_from_backend(ino, block_id, block)
-            .await;
+            .await
     }
 
-    async fn load(&self, ino: INum, block_id: usize) -> Option<Block> {
+    async fn load(&self, ino: INum, block_id: usize) -> StorageResult<Option<Block>> {
         self.as_ref().load(ino, block_id).await
     }
 
-    async fn store(&self, ino: INum, block_id: usize, block: Block) {
-        self.as_ref().store(ino, block_id, block).await;
+    async fn store(&self, ino: INum, block_id: usize, block: Block) -> StorageResult<()> {
+        self.as_ref().store(ino, block_id, block).await
     }
 
-    async fn remove(&self, ino: INum) {
-        self.as_ref().remove(ino).await;
+    async fn remove(&self, ino: INum) -> StorageResult<()> {
+        self.as_ref().remove(ino).await
     }
 
-    async fn invalidate(&self, ino: INum) {
-        self.as_ref().invalidate(ino).await;
+    async fn invalidate(&self, ino: INum) -> StorageResult<()> {
+        self.as_ref().invalidate(ino).await
     }
 
-    async fn flush(&self, ino: INum) {
-        self.as_ref().flush(ino).await;
+    async fn flush(&self, ino: INum) -> StorageResult<()> {
+        self.as_ref().flush(ino).await
     }
 
-    async fn flush_all(&self) {
-        self.as_ref().flush_all().await;
+    async fn flush_all(&self) -> StorageResult<()> {
+        self.as_ref().flush_all().await
     }
 
-    async fn truncate(&self, ino: INum, from_block: usize, to_block: usize, fill_start: usize) {
+    async fn truncate(
+        &self,
+        ino: INum,
+        from_block: usize,
+        to_block: usize,
+        fill_start: usize,
+    ) -> StorageResult<()> {
         self.as_ref()
             .truncate(ino, from_block, to_block, fill_start)
-            .await;
+            .await
     }
 }


### PR DESCRIPTION
In this PR, we introduced some new error types for `storage` mod, and refactored some interfaces for futher refactoring later.