### PR TITLE
fix: handle errors in `Storage`

### DIFF
--- a/src/storage/backend/backend_impl.rs
+++ b/src/storage/backend/backend_impl.rs
@@ -8,8 +8,8 @@ use opendal::services::{Fs, S3};
 use opendal::{ErrorKind, Operator};
 
 use crate::async_fuse::fuse::protocol::INum;
-use crate::storage::error::{StorageError, StorageOperation, StorageResult};
-use crate::storage::{Block, Storage};
+use crate::storage::error::StorageResult;
+use crate::storage::{Block, Storage, StorageError, StorageOperation};
 
 /// Get file path by `ino`
 fn get_file_path(ino: INum) -> String {

--- a/src/storage/backend/test/common.rs
+++ b/src/storage/backend/test/common.rs
@@ -10,7 +10,7 @@ async fn test_backend_read() {
     let backend_root = format!("{BACKEND_ROOT}/read");
     fs::create_dir_all(&backend_root).await.unwrap();
 
-    let backend = prepare_backend(&backend_root);
+    let (backend, _) = prepare_backend(&backend_root);
 
     let backend_root = Path::new(&backend_root);
 
@@ -32,7 +32,7 @@ async fn test_backend_read() {
 async fn test_write_whole_block() {
     let backend_root = format!("{BACKEND_ROOT}/write_whole_block");
     fs::create_dir_all(&backend_root).await.unwrap();
-    let backend = prepare_backend(&backend_root);
+    let (backend, _) = prepare_backend(&backend_root);
 
     let backend_root = Path::new(&backend_root);
 
@@ -54,7 +54,7 @@ async fn test_write_whole_block() {
 async fn test_write_in_middle() {
     let backend_root = format!("{BACKEND_ROOT}/write_in_middle");
     fs::create_dir_all(&backend_root).await.unwrap();
-    let backend = prepare_backend(&backend_root);
+    let (backend, _) = prepare_backend(&backend_root);
 
     let backend_root = Path::new(&backend_root);
 
@@ -72,7 +72,7 @@ async fn test_write_in_middle() {
 async fn test_write_append() {
     let backend_root = format!("{BACKEND_ROOT}/write_append");
     fs::create_dir_all(&backend_root).await.unwrap();
-    let backend = prepare_backend(&backend_root);
+    let (backend, _) = prepare_backend(&backend_root);
 
     let backend_root = Path::new(&backend_root);
 
@@ -97,7 +97,7 @@ async fn test_write_append() {
 async fn test_overwrite() {
     let backend_root = format!("{BACKEND_ROOT}/overwrite");
     fs::create_dir_all(&backend_root).await.unwrap();
-    let backend = prepare_backend(&backend_root);
+    let (backend, _) = prepare_backend(&backend_root);
 
     let backend_root = Path::new(&backend_root);
 
@@ -118,7 +118,7 @@ async fn test_overwrite() {
 async fn test_truncate() {
     let backend_root = format!("{BACKEND_ROOT}/truncate");
     fs::create_dir_all(&backend_root).await.unwrap();
-    let backend = prepare_backend(&backend_root);
+    let (backend, _) = prepare_backend(&backend_root);
 
     let backend_root = Path::new(&backend_root);
 
@@ -163,7 +163,7 @@ async fn test_truncate() {
 async fn test_truncate_block() {
     let backend_root = format!("{BACKEND_ROOT}/truncate_block");
     fs::create_dir_all(&backend_root).await.unwrap();
-    let backend = prepare_backend(&backend_root);
+    let (backend, _) = prepare_backend(&backend_root);
 
     let backend_root = Path::new(&backend_root);
 
@@ -189,7 +189,7 @@ async fn test_truncate_block() {
 async fn test_truncate_not_found() {
     let backend_root = format!("{BACKEND_ROOT}/truncate_not_found");
     fs::create_dir_all(&backend_root).await.unwrap();
-    let backend = prepare_backend(&backend_root);
+    let (backend, _) = prepare_backend(&backend_root);
 
     let backend_root = Path::new(&backend_root);
 
@@ -212,7 +212,7 @@ async fn test_truncate_not_found() {
 async fn test_remove() {
     let backend_root = format!("{BACKEND_ROOT}/remove");
     fs::create_dir_all(&backend_root).await.unwrap();
-    let backend = prepare_backend(&backend_root);
+    let (backend, _) = prepare_backend(&backend_root);
 
     let backend_root = Path::new(&backend_root);
 
@@ -231,7 +231,7 @@ async fn test_remove() {
 async fn test_unused() {
     let backend_root = format!("{BACKEND_ROOT}/unused");
     fs::create_dir_all(&backend_root).await.unwrap();
-    let backend = prepare_backend(&backend_root);
+    let (backend, _) = prepare_backend(&backend_root);
 
     // Do nothing, and should not panic.
     backend.flush(0).await.unwrap();

--- a/src/storage/backend/test/mock.rs
+++ b/src/storage/backend/test/mock.rs
@@ -1,0 +1,474 @@
+//! Mock types for backend testing.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::task::Poll;
+
+use async_trait::async_trait;
+use futures::FutureExt;
+use opendal::raw::oio::{BlockingRead, BlockingWrite, Read, Write};
+use opendal::raw::{
+    Accessor, Layer, LayeredAccessor, OpDelete, OpList, OpRead, OpWrite, RpDelete, RpList, RpRead,
+    RpWrite,
+};
+use opendal::ErrorKind as OpenDalErrorKind;
+
+fn arc_atom_true() -> Arc<AtomicBool> {
+    Arc::new(AtomicBool::new(true))
+}
+
+/// An `openDAL` layer to simulate IO errors of backend.
+#[derive(Debug, Clone)]
+pub struct FilterLayer {
+    /// Writer related
+    pub write: WriterAttr,
+    /// Reader related
+    pub read: ReaderAttr,
+    /// To remove a file / blocks from backend.
+    pub remove: Arc<AtomicBool>,
+}
+
+impl FilterLayer {
+    pub fn remove(&self) -> bool {
+        self.remove.load(Ordering::Acquire)
+    }
+
+    pub fn enable_remove(&self) -> &Self {
+        self.remove.store(true, Ordering::Release);
+        self
+    }
+
+    pub fn disable_remove(&self) -> &Self {
+        self.remove.store(false, Ordering::Release);
+        self
+    }
+}
+
+impl Default for FilterLayer {
+    fn default() -> Self {
+        Self {
+            write: WriterAttr::default(),
+            read: ReaderAttr::default(),
+            remove: arc_atom_true(),
+        }
+    }
+}
+
+impl<A: Accessor> Layer<A> for FilterLayer {
+    type LayeredAccessor = FilteredAccessor<A>;
+
+    fn layer(&self, inner: A) -> Self::LayeredAccessor {
+        FilteredAccessor {
+            attr: self.clone(),
+            inner,
+        }
+    }
+}
+
+/// Writer related attributes
+#[derive(Debug, Clone)]
+pub struct WriterAttr {
+    /// To get a writer.
+    pub get: Arc<AtomicBool>,
+    /// To write into the writer.
+    pub write: Arc<AtomicBool>,
+    /// To flush (close) the writer.
+    pub close: Arc<AtomicBool>,
+}
+
+impl WriterAttr {
+    pub fn get(&self) -> bool {
+        self.get.load(Ordering::Acquire)
+    }
+
+    #[allow(dead_code)]
+    pub fn enable_get(&self) -> &Self {
+        self.get.store(true, Ordering::Release);
+        self
+    }
+
+    pub fn disable_get(&self) -> &Self {
+        self.get.store(false, Ordering::Release);
+        self
+    }
+
+    pub fn write(&self) -> bool {
+        self.write.load(Ordering::Acquire)
+    }
+
+    pub fn enable_write(&self) -> &Self {
+        self.write.store(true, Ordering::Release);
+        self
+    }
+
+    pub fn disable_write(&self) -> &Self {
+        self.write.store(false, Ordering::Release);
+        self
+    }
+
+    pub fn close(&self) -> bool {
+        self.close.load(Ordering::Acquire)
+    }
+
+    pub fn enable_close(&self) -> &Self {
+        self.close.store(true, Ordering::Release);
+        self
+    }
+
+    pub fn disable_close(&self) -> &Self {
+        self.close.store(false, Ordering::Release);
+        self
+    }
+}
+
+impl Default for WriterAttr {
+    fn default() -> Self {
+        Self {
+            get: arc_atom_true(),
+            write: arc_atom_true(),
+            close: arc_atom_true(),
+        }
+    }
+}
+
+/// Reader related attributes
+#[derive(Debug, Clone)]
+pub struct ReaderAttr {
+    /// To get a reader.
+    pub get: Arc<AtomicBool>,
+    /// To read from the reader.
+    pub read: Arc<AtomicBool>,
+}
+
+impl ReaderAttr {
+    pub fn get(&self) -> bool {
+        self.get.load(Ordering::Acquire)
+    }
+
+    #[allow(dead_code)]
+    pub fn enable_get(&self) -> &Self {
+        self.get.store(true, Ordering::Release);
+        self
+    }
+
+    pub fn disable_get(&self) -> &Self {
+        self.get.store(false, Ordering::Release);
+        self
+    }
+
+    pub fn read(&self) -> bool {
+        self.read.load(Ordering::Acquire)
+    }
+
+    pub fn enable_read(&self) -> &Self {
+        self.read.store(true, Ordering::Release);
+        self
+    }
+
+    pub fn disable_read(&self) -> &Self {
+        self.read.store(false, Ordering::Release);
+        self
+    }
+}
+
+impl Default for ReaderAttr {
+    fn default() -> Self {
+        Self {
+            get: arc_atom_true(),
+            read: arc_atom_true(),
+        }
+    }
+}
+
+pub struct ReaderWrapper<R> {
+    attr: ReaderAttr,
+    inner: R,
+}
+
+impl<R: Read> Read for ReaderWrapper<R> {
+    fn poll_seek(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+        pos: std::io::SeekFrom,
+    ) -> Poll<opendal::Result<u64>> {
+        self.inner.poll_seek(cx, pos)
+    }
+
+    fn poll_next(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<opendal::Result<hyper::body::Bytes>>> {
+        let flag = self.attr.read();
+        if flag {
+            self.inner.poll_next(cx)
+        } else {
+            Poll::Ready(Some(Err(opendal::Error::new(
+                OpenDalErrorKind::PermissionDenied,
+                "Disabled",
+            ))))
+        }
+    }
+
+    fn poll_read(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<opendal::Result<usize>> {
+        let flag = self.attr.read();
+        if flag {
+            self.inner.poll_read(cx, buf)
+        } else {
+            Poll::Ready(Err(opendal::Error::new(
+                OpenDalErrorKind::PermissionDenied,
+                "Disabled",
+            )))
+        }
+    }
+}
+
+impl<R: BlockingRead> BlockingRead for ReaderWrapper<R> {
+    fn read(&mut self, buf: &mut [u8]) -> opendal::Result<usize> {
+        let flag = self.attr.read();
+        if flag {
+            self.inner.read(buf)
+        } else {
+            Err(opendal::Error::new(
+                OpenDalErrorKind::PermissionDenied,
+                "Disabled",
+            ))
+        }
+    }
+
+    fn seek(&mut self, pos: std::io::SeekFrom) -> opendal::Result<u64> {
+        self.inner.seek(pos)
+    }
+
+    fn next(&mut self) -> Option<opendal::Result<hyper::body::Bytes>> {
+        let flag = self.attr.read();
+        if flag {
+            self.inner.next()
+        } else {
+            Some(Err(opendal::Error::new(
+                OpenDalErrorKind::PermissionDenied,
+                "Disabled",
+            )))
+        }
+    }
+}
+
+pub struct WriterWrapper<W> {
+    attr: WriterAttr,
+    inner: W,
+}
+impl<W: Write> Write for WriterWrapper<W> {
+    fn poll_write(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+        bs: &dyn opendal::raw::oio::WriteBuf,
+    ) -> Poll<opendal::Result<usize>> {
+        let flag = self.attr.write();
+        if flag {
+            self.inner.poll_write(cx, bs)
+        } else {
+            Poll::Ready(Err(opendal::Error::new(
+                OpenDalErrorKind::PermissionDenied,
+                "Disabled",
+            )))
+        }
+    }
+
+    fn poll_close(&mut self, cx: &mut std::task::Context<'_>) -> Poll<opendal::Result<()>> {
+        let flag = self.attr.close();
+        if flag {
+            self.inner.poll_close(cx)
+        } else {
+            Poll::Ready(Err(opendal::Error::new(
+                OpenDalErrorKind::PermissionDenied,
+                "Disabled",
+            )))
+        }
+    }
+
+    fn poll_abort(&mut self, cx: &mut std::task::Context<'_>) -> Poll<opendal::Result<()>> {
+        self.inner.poll_abort(cx)
+    }
+}
+
+impl<W: BlockingWrite> BlockingWrite for WriterWrapper<W> {
+    fn write(&mut self, bs: &dyn opendal::raw::oio::WriteBuf) -> opendal::Result<usize> {
+        let flag = self.attr.write();
+        if flag {
+            self.inner.write(bs)
+        } else {
+            Err(opendal::Error::new(
+                OpenDalErrorKind::PermissionDenied,
+                "Disabled",
+            ))
+        }
+    }
+
+    fn close(&mut self) -> opendal::Result<()> {
+        let flag = self.attr.close();
+        if flag {
+            self.inner.close()
+        } else {
+            Err(opendal::Error::new(
+                OpenDalErrorKind::PermissionDenied,
+                "Disabled",
+            ))
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FilteredAccessor<A> {
+    attr: FilterLayer,
+    inner: A,
+}
+
+#[async_trait]
+impl<A: Accessor> LayeredAccessor for FilteredAccessor<A> {
+    type BlockingLister = A::BlockingLister;
+    type BlockingReader = ReaderWrapper<A::BlockingReader>;
+    type BlockingWriter = WriterWrapper<A::BlockingWriter>;
+    type Inner = A;
+    type Lister = A::Lister;
+    type Reader = ReaderWrapper<A::Reader>;
+    type Writer = WriterWrapper<A::Writer>;
+
+    fn inner(&self) -> &Self::Inner {
+        &self.inner
+    }
+
+    async fn read(&self, path: &str, args: OpRead) -> opendal::Result<(RpRead, Self::Reader)> {
+        if self.attr.read.get() {
+            self.inner
+                .read(path, args)
+                .map(|res| {
+                    res.map(|(rp_read, reader)| {
+                        (
+                            rp_read,
+                            ReaderWrapper {
+                                attr: self.attr.read.clone(),
+                                inner: reader,
+                            },
+                        )
+                    })
+                })
+                .await
+        } else {
+            Err(opendal::Error::new(
+                OpenDalErrorKind::PermissionDenied,
+                "Disabled",
+            ))
+        }
+    }
+
+    async fn write(&self, path: &str, args: OpWrite) -> opendal::Result<(RpWrite, Self::Writer)> {
+        if self.attr.write.get() {
+            self.inner
+                .write(path, args)
+                .map(|res| {
+                    res.map(|(rp_write, writer)| {
+                        (
+                            rp_write,
+                            WriterWrapper {
+                                attr: self.attr.write.clone(),
+                                inner: writer,
+                            },
+                        )
+                    })
+                })
+                .await
+        } else {
+            Err(opendal::Error::new(
+                OpenDalErrorKind::PermissionDenied,
+                "Disabled",
+            ))
+        }
+    }
+
+    async fn list(&self, path: &str, args: OpList) -> opendal::Result<(RpList, Self::Lister)> {
+        self.inner.list(path, args).await
+    }
+
+    fn blocking_read(
+        &self,
+        path: &str,
+        args: OpRead,
+    ) -> opendal::Result<(RpRead, Self::BlockingReader)> {
+        if self.attr.read.get() {
+            self.inner
+                .blocking_read(path, args)
+                .map(|(rp_read, reader)| {
+                    (
+                        rp_read,
+                        ReaderWrapper {
+                            attr: self.attr.read.clone(),
+                            inner: reader,
+                        },
+                    )
+                })
+        } else {
+            Err(opendal::Error::new(
+                OpenDalErrorKind::PermissionDenied,
+                "Disabled",
+            ))
+        }
+    }
+
+    fn blocking_write(
+        &self,
+        path: &str,
+        args: OpWrite,
+    ) -> opendal::Result<(RpWrite, Self::BlockingWriter)> {
+        if self.attr.write.get() {
+            self.inner
+                .blocking_write(path, args)
+                .map(|(rp_write, writer)| {
+                    (
+                        rp_write,
+                        WriterWrapper {
+                            attr: self.attr.write.clone(),
+                            inner: writer,
+                        },
+                    )
+                })
+        } else {
+            Err(opendal::Error::new(
+                OpenDalErrorKind::PermissionDenied,
+                "Disabled",
+            ))
+        }
+    }
+
+    fn blocking_list(
+        &self,
+        path: &str,
+        args: OpList,
+    ) -> opendal::Result<(RpList, Self::BlockingLister)> {
+        self.inner.blocking_list(path, args)
+    }
+
+    async fn delete(&self, path: &str, args: OpDelete) -> opendal::Result<RpDelete> {
+        if self.attr.remove() {
+            self.inner.delete(path, args).await
+        } else {
+            Err(opendal::Error::new(
+                OpenDalErrorKind::PermissionDenied,
+                "Disabled",
+            ))
+        }
+    }
+
+    fn blocking_delete(&self, path: &str, args: OpDelete) -> opendal::Result<RpDelete> {
+        if self.attr.remove() {
+            self.inner.blocking_delete(path, args)
+        } else {
+            Err(opendal::Error::new(
+                OpenDalErrorKind::PermissionDenied,
+                "Disabled",
+            ))
+        }
+    }
+}

--- a/src/storage/backend/test/mod.rs
+++ b/src/storage/backend/test/mod.rs
@@ -3,6 +3,7 @@ const BLOCK_CONTENT: &[u8; BLOCK_SIZE_IN_BYTES] = b"foo bar ";
 const BACKEND_ROOT: &str = "/tmp/opendal";
 
 mod common;
+mod mock;
 mod pessimistic;
 
 use opendal::services::Fs;
@@ -11,10 +12,15 @@ use opendal::Operator;
 use super::Backend;
 
 /// Prepare a backend
-fn prepare_backend(root: &str) -> Backend {
+fn prepare_backend(root: &str) -> (Backend, mock::FilterLayer) {
+    let layer = mock::FilterLayer::default();
+
     let mut builder = Fs::default();
     builder.root(root);
-    let op = Operator::new(builder).unwrap().finish();
+    let op = Operator::new(builder)
+        .unwrap()
+        .layer(layer.clone())
+        .finish();
 
-    Backend::new(op, BLOCK_SIZE_IN_BYTES)
+    (Backend::new(op, BLOCK_SIZE_IN_BYTES), layer)
 }

--- a/src/storage/backend/test/pessimistic.rs
+++ b/src/storage/backend/test/pessimistic.rs
@@ -5,7 +5,7 @@ use opendal::ErrorKind as OpenDalErrorKind;
 use tokio::fs;
 
 use super::{prepare_backend, BACKEND_ROOT, BLOCK_CONTENT, BLOCK_SIZE_IN_BYTES};
-use crate::storage::{Block, Storage, StorageError, StorageErrorInner, StorageOperation};
+use crate::storage::{Block, Storage, StorageError};
 
 async fn cleanup(backend_root: impl AsRef<Path>) {
     if fs::try_exists(&backend_root).await.unwrap() {
@@ -39,10 +39,7 @@ async fn test_failed_load() {
     assert!(
         matches!(
             err,
-            StorageError {
-                operation: StorageOperation::Load { ino: 0, block_id: 0 },
-                inner: StorageErrorInner::StdIoError(ref e),
-            }
+            StorageError::StdIoError(ref e)
             if e.kind() == StdErrorKind::PermissionDenied
         ),
         "Mismatched: error={err:?}"
@@ -55,10 +52,7 @@ async fn test_failed_load() {
     assert!(
         matches!(
             err,
-            StorageError {
-                operation: StorageOperation::Load { ino: 0, block_id: 0 },
-                inner: StorageErrorInner::OpenDalError(ref e),
-            }
+            StorageError::OpenDalError(ref e)
             if e.kind() == OpenDalErrorKind::PermissionDenied
         ),
         "Mismatched: error={err:?}"
@@ -85,10 +79,7 @@ async fn test_failed_store() {
     assert!(
         matches!(
             err,
-            StorageError {
-                operation: StorageOperation::Store { ino: 0, block_id: 0 },
-                inner: StorageErrorInner::StdIoError(ref e),
-            }
+            StorageError::StdIoError(ref e)
             if e.kind() == StdErrorKind::Other  // openDAL mapped all write error to `StdErrorKind::Other`
         ),
         "Mismatched: error={err:?}"
@@ -104,10 +95,7 @@ async fn test_failed_store() {
     assert!(
         matches!(
             err,
-            StorageError {
-                operation: StorageOperation::Store { ino: 0, block_id: 0 },
-                inner: StorageErrorInner::OpenDalError(ref e),
-            }
+            StorageError::OpenDalError(ref e)
             if e.kind() == OpenDalErrorKind::PermissionDenied
         ),
         "Mismatched: error={err:?}"
@@ -123,10 +111,7 @@ async fn test_failed_store() {
     assert!(
         matches!(
             err,
-            StorageError {
-                operation: StorageOperation::Store { ino: 0, block_id: 0 },
-                inner: StorageErrorInner::OpenDalError(ref e),
-            }
+            StorageError::OpenDalError(ref e)
             if e.kind() == OpenDalErrorKind::PermissionDenied
         ),
         "Mismatched: error={err:?}"
@@ -161,10 +146,7 @@ async fn test_failed_partial_store() {
     assert!(
         matches!(
             err,
-            StorageError {
-                operation: StorageOperation::Load { ino: 0, block_id: 0 },
-                inner: StorageErrorInner::OpenDalError(ref e),
-            }
+            StorageError::OpenDalError(ref e)
             if e.kind() == OpenDalErrorKind::PermissionDenied
         ),
         "Mismatched: error={err:?}"
@@ -185,10 +167,7 @@ async fn test_failed_partial_store() {
     assert!(
         matches!(
             err,
-            StorageError {
-                operation: StorageOperation::Store { ino: 0, block_id: 0 },
-                inner: StorageErrorInner::OpenDalError(ref e),
-            }
+            StorageError::OpenDalError(ref e)
             if e.kind() == OpenDalErrorKind::PermissionDenied
         ),
         "Mismatched: error={err:?}"
@@ -216,10 +195,7 @@ async fn test_failed_remove() {
     assert!(
         matches!(
             err,
-            StorageError {
-                operation: StorageOperation::Remove { ino: 0 },
-                inner: StorageErrorInner::OpenDalError(ref e),
-            }
+            StorageError::OpenDalError(ref e)
             if e.kind() == OpenDalErrorKind::PermissionDenied
         ),
         "Mismatched: error={err:?}"
@@ -251,10 +227,7 @@ async fn test_failed_truncate() {
     assert!(
         matches!(
             err,
-            StorageError {
-                operation: StorageOperation::Remove { ino: 0 },
-                inner: StorageErrorInner::OpenDalError(ref e),
-            }
+            StorageError::OpenDalError(ref e)
             if e.kind() == OpenDalErrorKind::PermissionDenied
         ),
         "Mismatched: error={err:?}"
@@ -268,10 +241,7 @@ async fn test_failed_truncate() {
     assert!(
         matches!(
             err,
-            StorageError {
-                operation: StorageOperation::Truncate { ino: 0, from: 8, to: 4 },
-                inner: StorageErrorInner::OpenDalError(ref e),
-            }
+            StorageError::OpenDalError(ref e)
             if e.kind() == OpenDalErrorKind::PermissionDenied
         ),
         "Mismatched: error={err:?}"
@@ -285,10 +255,7 @@ async fn test_failed_truncate() {
     assert!(
         matches!(
             err,
-            StorageError {
-                operation: StorageOperation::Load { ino: 0, block_id: 3 },
-                inner: StorageErrorInner::OpenDalError(ref e),
-            }
+            StorageError::OpenDalError(ref e)
             if e.kind() == OpenDalErrorKind::PermissionDenied
         ),
         "Mismatched: error={err:?}"
@@ -302,10 +269,7 @@ async fn test_failed_truncate() {
     assert!(
         matches!(
             err,
-            StorageError {
-                operation: StorageOperation::Store { ino: 0, block_id: 3 },
-                inner: StorageErrorInner::OpenDalError(ref e),
-            }
+            StorageError::OpenDalError(ref e)
             if e.kind() == OpenDalErrorKind::PermissionDenied
         ),
         "Mismatched: error={err:?}"

--- a/src/storage/block.rs
+++ b/src/storage/block.rs
@@ -7,7 +7,7 @@ use aligned_utils::bytes::AlignedBytes;
 use clippy_utilities::OverflowArithmetic;
 use nix::sys::uio::IoVec;
 
-use super::StorageErrorInner;
+use super::StorageError;
 use crate::async_fuse::fuse::fuse_reply::{AsIoVec, CouldBeAsIoVecList};
 use crate::async_fuse::fuse::protocol::INum;
 
@@ -205,9 +205,9 @@ impl Block {
     /// range of `self` will be extended.
     ///
     /// This method calls `make_mut_slice` internal.
-    pub fn update(&mut self, other: &Block) -> Result<(), StorageErrorInner> {
+    pub fn update(&mut self, other: &Block) -> Result<(), StorageError> {
         if self.inner.len() < other.end {
-            return Err(StorageErrorInner::OutOfRange {
+            return Err(StorageError::OutOfRange {
                 maximum: self.inner.len(),
                 found: other.end,
             });

--- a/src/storage/error.rs
+++ b/src/storage/error.rs
@@ -2,58 +2,12 @@
 
 use thiserror::Error;
 
-use super::BlockId;
-use crate::async_fuse::fuse::protocol::INum;
-
 /// The result of storage operation.
 pub type StorageResult<T> = Result<T, StorageError>;
 
 /// An error occurs in storage operation.
 #[derive(Debug, Error)]
-#[error("Storage Error on {operation:?}, inner is {inner}.")]
-pub struct StorageError {
-    /// The operation kind.
-    pub operation: StorageOperation,
-    /// The inner error.
-    pub inner: StorageErrorInner,
-}
-
-/// The kind of storage operation.
-#[derive(Debug)]
-pub enum StorageOperation {
-    /// Load operation.
-    Load {
-        /// The inode number of this error
-        ino: INum,
-        /// The block id of this error.
-        block_id: BlockId,
-    },
-    /// Store operation.
-    Store {
-        /// The inode number of this error
-        ino: INum,
-        /// The block id of this error.
-        block_id: BlockId,
-    },
-    /// Remove operation.
-    Remove {
-        /// The inode number of this error
-        ino: INum,
-    },
-    /// Truncate operation.
-    Truncate {
-        /// The inode number of this error
-        ino: INum,
-        /// The start block id of truncate.
-        from: BlockId,
-        /// The end block id of truncate.
-        to: BlockId,
-    },
-}
-
-/// The inner details of `StorageError`
-#[derive(Debug, Error)]
-pub enum StorageErrorInner {
+pub enum StorageError {
     /// The storage operation is out of range of a block
     #[error("{found} is out of range of {maximum}")]
     OutOfRange {

--- a/src/storage/error.rs
+++ b/src/storage/error.rs
@@ -68,4 +68,7 @@ pub enum StorageErrorInner {
     /// An error caused by [`opendal::Error`]
     #[error("{0}")]
     OpenDalError(#[from] opendal::Error),
+    /// A internal storage error.
+    #[error("{0}")]
+    Internal(#[from] anyhow::Error),
 }

--- a/src/storage/memory_cache/tests.rs
+++ b/src/storage/memory_cache/tests.rs
@@ -9,9 +9,7 @@ use datenlord::config::SoftLimit;
 use super::{MemoryCache, MemoryCacheBuilder};
 use crate::storage::mock::MemoryStorage;
 use crate::storage::policy::LruPolicy;
-use crate::storage::{
-    Block, BlockCoordinate, Storage, StorageError, StorageErrorInner, StorageOperation,
-};
+use crate::storage::{Block, BlockCoordinate, Storage, StorageError};
 
 const BLOCK_SIZE_IN_BYTES: usize = 8;
 const BLOCK_CONTENT: &[u8; BLOCK_SIZE_IN_BYTES] = b"foo bar ";
@@ -341,15 +339,9 @@ async fn test_write_out_of_range() {
     assert!(
         matches!(
             res,
-            StorageError {
-                operation: StorageOperation::Store {
-                    ino: 0,
-                    block_id: 0
-                },
-                inner: StorageErrorInner::OutOfRange {
-                    maximum: 8,
-                    found: 16
-                },
+            StorageError::OutOfRange {
+                maximum: 8,
+                found: 16
             }
         ),
         "Mismatched: res={res:?}"

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -11,7 +11,7 @@ pub mod policy;
 
 pub use backend::{Backend, BackendBuilder};
 pub use block::{Block, BlockCoordinate};
-pub use error::{StorageError, StorageErrorInner, StorageOperation};
+pub use error::StorageError;
 pub use memory_cache::{MemoryCache, MemoryCacheBuilder};
 pub use storage_manager::StorageManager;
 pub use storage_trait::Storage;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -11,7 +11,7 @@ pub mod policy;
 
 pub use backend::{Backend, BackendBuilder};
 pub use block::{Block, BlockCoordinate};
-pub use error::{StorageError, StorageErrorInner};
+pub use error::{StorageError, StorageErrorInner, StorageOperation};
 pub use memory_cache::{MemoryCache, MemoryCacheBuilder};
 pub use storage_manager::StorageManager;
 pub use storage_trait::Storage;


### PR DESCRIPTION
1. Make `WriteBackTask` into a struct instead of a single async fn.
2. Splict `storage_manager.rs` into seperated files (submodules).
3. Functions in `storage` mod returns `Error` instead of panic. 

A single exception of *3* above is `MemoryCache::send_block_to_write_back_task`: 
```rust
panic!("Command receiver in write back task is closed unexpectedly.")
```
This will be guaranteed to be unreachable soon.

