### PR TITLE
feat: Introduce Metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 hashlink = "0.8.4"
 clap = { version = "4", features = ["derive"] }
-opendal = "0.43.0"
+opendal = {version = "0.43.0", features = ["layers-prometheus"]}
 
 [build-dependencies]
 protoc-grpcio = "3.0.0"

--- a/src/async_fuse/memfs/kv_engine/etcd_impl.rs
+++ b/src/async_fuse/memfs/kv_engine/etcd_impl.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use datenlord::metrics::KV_METRICS;
 use etcd_client::{
     Compare, CompareOp, DeleteOptions, GetOptions, LockOptions, PutOptions, Txn, TxnOp,
 };
@@ -85,6 +86,7 @@ impl KVEngine for EtcdKVEngine {
     /// - `timeout_sec` should be >=1s
     /// - `timeout_sec` should be >=1s
     async fn lock(&self, key: &LockKeyType, timeout_sec: Duration) -> DatenLordResult<Vec<u8>> {
+        let _timer = KV_METRICS.start_kv_lock_timer();
         let mut client = self.client.clone();
         let timeout_sec = check_ttl(conv_u64_sec_2_i64(timeout_sec.as_secs()))
             .with_context(|| "timeout_sec should be >=1s, please fix the call".to_owned())?;
@@ -119,6 +121,7 @@ impl KVEngine for EtcdKVEngine {
 
     /// Get the value by the key.
     async fn get(&self, key: &KeyType) -> DatenLordResult<Option<ValueType>> {
+        let _timer = KV_METRICS.start_kv_operation_timer("get");
         let mut client = self.client.clone();
         let resp = client
             .get(key.to_string_key(), None)
@@ -141,6 +144,7 @@ impl KVEngine for EtcdKVEngine {
         value: &ValueType,
         option: Option<SetOption>,
     ) -> DatenLordResult<Option<ValueType>> {
+        let _timer = KV_METRICS.start_kv_operation_timer("set");
         let option = match option {
             Some(option) => {
                 let mut set_option = PutOptions::new();
@@ -175,6 +179,7 @@ impl KVEngine for EtcdKVEngine {
         key: &KeyType,
         option: Option<DeleteOption>,
     ) -> DatenLordResult<Option<ValueType>> {
+        let _timer = KV_METRICS.start_kv_operation_timer("delete");
         let option = match option {
             Some(option) => {
                 let mut delete_option = DeleteOptions::new();
@@ -203,6 +208,7 @@ impl KVEngine for EtcdKVEngine {
     }
 
     async fn range(&self, prefix: &KeyType) -> DatenLordResult<Vec<ValueType>> {
+        let _timer = KV_METRICS.start_kv_operation_timer("range");
         let result = self.range_raw_key(prefix.to_string_key()).await?;
         Ok(result)
     }
@@ -234,6 +240,8 @@ impl EtcdTxn {
 #[async_trait]
 impl MetaTxn for EtcdTxn {
     async fn get(&mut self, key_arg: &KeyType) -> DatenLordResult<Option<ValueType>> {
+        let _timer = KV_METRICS.start_kv_operation_timer("get");
+
         // first check if the key is in buffer (write op)
         let key = key_arg.to_string_key().into_bytes();
         assert!(
@@ -285,6 +293,8 @@ impl MetaTxn for EtcdTxn {
     }
 
     async fn commit(&mut self) -> DatenLordResult<bool> {
+        let _timer = KV_METRICS.start_kv_operation_timer("txn");
+
         if self.version_map.is_empty() && self.buffer.is_empty() {
             return Ok(true);
         }

--- a/src/async_fuse/mod.rs
+++ b/src/async_fuse/mod.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use clippy_utilities::OverflowArithmetic;
+use datenlord::metrics;
 
 use self::memfs::kv_engine::KVEngineType;
 use crate::async_fuse::fuse::session;
@@ -12,10 +13,6 @@ use crate::AsyncFuseArgs;
 
 pub mod fuse;
 pub mod memfs;
-/// Datenlord metrics
-// Caused by prometheus macros
-#[allow(clippy::ignored_unit_patterns)]
-pub mod metrics;
 pub mod proactor;
 pub mod util;
 

--- a/src/common/logger.rs
+++ b/src/common/logger.rs
@@ -63,6 +63,7 @@ pub fn init_logger(role: LogRole) {
         .with_target("h2", Level::WARN)
         .with_target("tower", Level::WARN)
         .with_target("datenlord::async_fuse::fuse", Level::WARN)
+        .with_target("datenlord::metrics", Level::INFO)
         .with_target("", Level::INFO);
 
     let log_path = format!("./datenlord_{}.log", role.as_str());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,3 +66,4 @@
 pub mod common;
 /// Configurations
 pub mod config;
+pub mod metrics;

--- a/src/metrics/cache.rs
+++ b/src/metrics/cache.rs
@@ -1,0 +1,1 @@
+//! Metrics for file caches.

--- a/src/metrics/cache.rs
+++ b/src/metrics/cache.rs
@@ -1,1 +1,60 @@
 //! Metrics for file caches.
+
+use once_cell::sync::Lazy;
+use prometheus::{register_counter_vec_with_registry, CounterVec, Registry};
+
+use super::DATENLORD_REGISTRY;
+
+/// The file caches related metrics.
+pub static CACHE_METRICS: Lazy<CacheMetrics> = Lazy::new(|| CacheMetrics::new(&DATENLORD_REGISTRY));
+
+/// The file caches related metrics.
+#[derive(Debug)]
+pub struct CacheMetrics {
+    /// The counters of total of cache hits. With label: `[name]`.
+    cache_hit_count: CounterVec,
+    /// The counters of total of cache misses. With label: `[name]`
+    cache_miss_count: CounterVec,
+}
+
+impl CacheMetrics {
+    /// Creates an instance of `CacheMetrics`, which will create two
+    /// `CounterVec`s and register them into the specified registry.
+    ///
+    /// # Panics
+    /// This method panics if it called multiple times on the same registry.
+    #[allow(clippy::expect_used)] // We can ensure that this method won't panic if we followed the hints above
+    #[allow(clippy::ignored_unit_patterns)] // Raised by `register_counter_vec_with_registry`
+    fn new(registry: &Registry) -> Self {
+        let cache_hit_count = register_counter_vec_with_registry!(
+            "cache_hit_count",
+            "The total of cache hits",
+            &["name"],
+            registry,
+        )
+        .expect("Metrics name must be unique.");
+
+        let cache_miss_count = register_counter_vec_with_registry!(
+            "cache_miss_count",
+            "The total of cache misses",
+            &["name"],
+            registry,
+        )
+        .expect("Metrics name must be unique.");
+
+        Self {
+            cache_hit_count,
+            cache_miss_count,
+        }
+    }
+
+    /// Increase the hit count with `name`.
+    pub fn cache_hit_count_inc(&self, name: &str) {
+        self.cache_hit_count.with_label_values(&[name]).inc();
+    }
+
+    /// Increase the miss count with `name`.
+    pub fn cache_miss_count_inc(&self, name: &str) {
+        self.cache_miss_count.with_label_values(&[name]).inc();
+    }
+}

--- a/src/metrics/file_system.rs
+++ b/src/metrics/file_system.rs
@@ -1,0 +1,1 @@
+//! Metrics for file system.

--- a/src/metrics/file_system.rs
+++ b/src/metrics/file_system.rs
@@ -1,1 +1,69 @@
 //! Metrics for file system.
+
+use once_cell::sync::Lazy;
+use prometheus::{
+    linear_buckets, register_histogram_vec_with_registry, HistogramTimer, HistogramVec, Registry,
+};
+
+use super::{LossyCast, DATENLORD_REGISTRY};
+
+/// The file system related metrics.
+pub static FILESYSTEM_METRICS: Lazy<FileSystemMetrics> =
+    Lazy::new(|| FileSystemMetrics::new(&DATENLORD_REGISTRY));
+
+/// The file system related metrics.
+#[derive(Debug)]
+pub struct FileSystemMetrics {
+    /// The durations of fuse operations. With label: `[op]`.
+    fuse_operation_duration_seconds: HistogramVec,
+    /// The retry counts of KV transaction. With label: `[op]`
+    kv_txn_retry_counts: HistogramVec,
+}
+
+impl FileSystemMetrics {
+    /// Creates an instance of `FileSystemMetrics`, which will create two
+    /// `HistogramVec`s and register them into the specified registry.
+    ///
+    /// # Panics
+    /// This method panics if it called multiple times on the same registry.
+    #[allow(clippy::expect_used)] // We can ensure that this method won't panic if we followed the hints above
+    #[allow(clippy::ignored_unit_patterns)] // Raised by `register_histogram_vec_with_registry`
+    fn new(registry: &Registry) -> Self {
+        let fuse_operation_duration_seconds = register_histogram_vec_with_registry!(
+            "fuse_operation_duration_seconds",
+            "The durations of fuse operations",
+            &["op"],
+            linear_buckets(0.005, 0.005, 20).expect("`count` and `width` is not zero"),
+            registry,
+        )
+        .expect("Metrics name must be unique");
+
+        let kv_txn_retry_counts = register_histogram_vec_with_registry!(
+            "kv_txn_retry_counts",
+            "The retry counts of KV transaction",
+            &["op"],
+            linear_buckets(0.0, 3.0, 5).expect("`count` and `width` is not zero"),
+            registry,
+        )
+        .expect("Metrics name must be unique");
+
+        Self {
+            fuse_operation_duration_seconds,
+            kv_txn_retry_counts,
+        }
+    }
+
+    /// Starts a timer to measure the FUSE operations' duration.
+    pub fn start_storage_operation_timer(&self, op: &str) -> HistogramTimer {
+        self.fuse_operation_duration_seconds
+            .with_label_values(&[op])
+            .start_timer()
+    }
+
+    /// Observes a value of the retry counts of KV transaction.
+    pub fn observe_storage_operation_throughput<T: LossyCast<f64>>(&self, val: T, op: &str) {
+        self.kv_txn_retry_counts
+            .with_label_values(&[op])
+            .observe(val.lossy_cast());
+    }
+}

--- a/src/metrics/kv.rs
+++ b/src/metrics/kv.rs
@@ -1,0 +1,66 @@
+//! KV related metrics.
+
+use once_cell::sync::Lazy;
+use prometheus::{
+    linear_buckets, register_histogram_vec_with_registry, register_histogram_with_registry,
+    Histogram, HistogramTimer, HistogramVec, Registry,
+};
+
+use super::DATENLORD_REGISTRY;
+
+/// The KV related metrics.
+pub static KV_METRICS: Lazy<KVMetrics> = Lazy::new(|| KVMetrics::new(&DATENLORD_REGISTRY));
+
+/// The KV related metrics.
+#[derive(Debug)]
+pub struct KVMetrics {
+    /// The latency of KV operations.
+    kv_latency_seconds: HistogramVec,
+    /// The latency of KV lock acquiring.
+    kv_lock_latency_seconds: Histogram,
+}
+
+impl KVMetrics {
+    /// Creates an instance of `KVMetrics`, which will create two
+    /// `Histogram`s and register them into the specified registry.
+    ///
+    /// # Panics
+    /// This method panics if it called multiple times on the same registry.
+    #[allow(clippy::expect_used)] // We can ensure that this method won't panic if we followed the hints above
+    #[allow(clippy::ignored_unit_patterns)] // Raised by `register_histogram_with_registry`
+    fn new(registry: &Registry) -> Self {
+        let kv_latency_seconds = register_histogram_vec_with_registry!(
+            "kv_latency_seconds",
+            "The latency of KV operations",
+            &["type"],
+            linear_buckets(0.005, 0.005, 20).expect("`count` and `width` is not zero"),
+            registry,
+        )
+        .expect("Metrics name must be unique");
+
+        let kv_lock_latency_seconds = register_histogram_with_registry!(
+            "kv_lock_latency_seconds",
+            "The latency of KV lock acquiring",
+            linear_buckets(0.0, 3.0, 5).expect("`count` and `width` is not zero"),
+            registry,
+        )
+        .expect("Metrics name must be unique");
+
+        Self {
+            kv_latency_seconds,
+            kv_lock_latency_seconds,
+        }
+    }
+
+    /// Starts a timer to measure KV operation latency.
+    pub fn start_kv_operation_timer(&self, op_type: &str) -> HistogramTimer {
+        self.kv_latency_seconds
+            .with_label_values(&[op_type])
+            .start_timer()
+    }
+
+    /// Starts a timer to measure KV lock acquiring latency.
+    pub fn start_kv_lock_timer(&self) -> HistogramTimer {
+        self.kv_lock_latency_seconds.start_timer()
+    }
+}

--- a/src/metrics/lock.rs
+++ b/src/metrics/lock.rs
@@ -1,0 +1,1 @@
+//! Metrics for locks.

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -4,6 +4,7 @@
 
 mod cache;
 mod file_system;
+mod kv;
 mod lock;
 mod server;
 mod storage;
@@ -13,6 +14,8 @@ use once_cell::sync::Lazy;
 use prometheus::Registry;
 
 pub use self::cache::CACHE_METRICS;
+pub use self::file_system::FILESYSTEM_METRICS;
+pub use self::kv::KV_METRICS;
 pub use self::server::start_metrics_server;
 pub use self::utils::LossyCast;
 

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,0 +1,20 @@
+//! Datenlord metrics.
+
+#![allow(dead_code)]
+
+mod cache;
+mod file_system;
+mod lock;
+mod server;
+mod storage;
+mod utils;
+
+use once_cell::sync::Lazy;
+use prometheus::Registry;
+
+pub use self::cache::CACHE_METRICS;
+pub use self::server::start_metrics_server;
+pub use self::utils::LossyCast;
+
+/// The global metrics registry used by `DatenLord`.
+pub static DATENLORD_REGISTRY: Lazy<Registry> = Lazy::new(Registry::new);

--- a/src/metrics/server.rs
+++ b/src/metrics/server.rs
@@ -1,34 +1,19 @@
+//! The metrics server.
+
 use hyper::header::CONTENT_TYPE;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Request, Response, Server};
-use lazy_static::lazy_static;
-use prometheus::{opts, register_counter, Counter, Encoder, TextEncoder};
-use tracing::debug;
+use prometheus::{Encoder, TextEncoder};
+use tracing::{error, info};
 
-lazy_static! {
-    /// Datenlord cache hit metrics
-    pub static ref CACHE_HITS: Counter = register_counter!(opts!(
-        "datenlord_cache_hits",
-        "Approximate number of Cache hits since last server start"
-    ))
-    .unwrap();
-    /// Datenlord cache miss metrics
-    pub static ref CACHE_MISSES: Counter = register_counter!(opts!(
-        "datenlord_cache_misses",
-        "Approximate number of Cache misses since last server start"
-    ))
-    .unwrap();
-}
+use super::DATENLORD_REGISTRY;
 
 /// Serve prometheus requests, return metrics response
-///
-/// # Errors
-/// Returns [`hyper::Error`]
 #[allow(clippy::unused_async)] // Hyper requires an async function
-pub async fn serve_req(_req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+async fn serve_req(_req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
     let encoder = TextEncoder::new();
 
-    let metric_families = prometheus::gather();
+    let metric_families = DATENLORD_REGISTRY.gather();
     let mut buffer = vec![];
     encoder
         .encode(&metric_families, &mut buffer)
@@ -39,18 +24,23 @@ pub async fn serve_req(_req: Request<Body>) -> Result<Response<Body>, hyper::Err
         .header(CONTENT_TYPE, encoder.format_type())
         .body(Body::from(buffer))
         .unwrap_or_else(|_| panic!("Fail to build prometheus response"));
+
     Ok(response)
 }
 
 /// Start a server to process prometheus request
+#[inline]
 pub fn start_metrics_server() {
     tokio::task::spawn(async move {
         let addr = ([0, 0, 0, 0], 9897).into();
         let serve_future = Server::bind(&addr).serve(make_service_fn(|_| async {
             Ok::<_, hyper::Error>(service_fn(serve_req))
         }));
+
+        info!("Metrics server is listening on: {addr}");
+
         if let Err(err) = serve_future.await {
-            debug!("Metric server error: {}", err);
+            error!("Metric server error: {}", err);
         }
     });
 }

--- a/src/metrics/storage.rs
+++ b/src/metrics/storage.rs
@@ -1,0 +1,1 @@
+//! Metrics for storage (besides of cache).

--- a/src/metrics/storage.rs
+++ b/src/metrics/storage.rs
@@ -1,1 +1,4 @@
 //! Metrics for storage (besides of cache).
+//!
+//! This module is unused for now, and the metrics of storage
+//! are delegated to `opendal::layers::PrometheusLayer`.

--- a/src/metrics/utils.rs
+++ b/src/metrics/utils.rs
@@ -1,0 +1,24 @@
+//! Utils for metrics.
+
+/// To convert a value into another type, which may lose precision.
+pub trait LossyCast<T: Copy>: Copy {
+    /// Lossy cast `self` to the target, wrapping on overflow.
+    fn lossy_cast(self) -> T;
+}
+
+/// Implement `LossyCast` to f64.
+macro_rules! impl_lossy_cast_to_f64 {
+    ($($ty:ident),* $(,)?) => {
+        $(
+            #[allow(clippy::as_conversions)]
+            impl LossyCast<f64> for $ty {
+                #[inline]
+                fn lossy_cast(self) -> f64 {
+                    self as f64
+                }
+            }
+        )*
+    }
+}
+
+impl_lossy_cast_to_f64!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize);


### PR DESCRIPTION
In this PR, we introduced `metrics` modules for DatenLord, with metrics listed below:

- `cache`
- `file_system`
- `kv`

The metrics for `Backend` are delegated to `opendal::layers::PrometheusLayer` for now.

A trait called `LossyCast` is introduced, for casting from integer types to floating types with potentially lossy precision.

Refactored `retry_txn` macro to return the retry times.