### PR TITLE
chore: add `rust-toolchain.toml` and `devcontainer.json`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+{
+    "name": "DatenLord Dev Container",
+    "image": "ubuntu:jammy",
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker": {},
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": false,
+            "installOhMyZsh": false,
+            "installOhMyZshConfig": false,
+            "upgradePackages": true,
+            "username": "datenlord",
+            "userUid": "1000",
+            "userGid": "1000"
+        },
+        "ghcr.io/devcontainers/features/git:1": {}
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "vadimcn.vscode-lldb",
+                "rust-lang.rust-analyzer",
+                "tamasfe.even-better-toml",
+                "serayuzgur.crates"
+            ],
+            "settings": {
+                "files.watcherExclude": {
+                    "**/target/**": true
+                }
+            }
+        }
+    },
+    "remoteUser": "datenlord",
+    "onCreateCommand": "sudo apt-get update && sudo apt-get install -y cmake g++ libprotobuf-dev protobuf-compiler fuse curl",
+    "postCreateCommand": {
+        "rustup": "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y && ~/.cargo/bin/rustup show",
+        "fuse": "sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf"
+    }
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.74.0"
+profile = "default"


### PR DESCRIPTION
In this PR, we added `rust-toolchain.toml` file to make it easier to set up the develop environment.

In addition, we added a `devcontainer.json` file to help setting up a dev container for developers to quick start. (Thanks to @yunwei37 's contribution, which is shown in #418 ).

The `rustup-init.sh` script is just downloaded from <https://sh.rustup.rs>.