### PR TITLE
feat: Enhance config options with toml file and env variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ ring-io = { git = "https://github.com/datenlord/ring-io", rev = "2f0506c" }
 serde-xml-rs = "0.6"
 serde = "1.0.126"
 serde_json = "1.0.64"
+toml = "0.7.3"
 tar = "0.4.29"
 thiserror = "1.0.22"
 tiny_http = "0.10.0"
@@ -67,6 +68,7 @@ opendal = {version = "0.43.0", features = ["layers-prometheus"]}
 signal-hook = { version = "0.3.17", features = ["iterator"]}
 signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 tokio-util = "0.7.10"
+serfig = "0.1.0"
 
 [build-dependencies]
 protoc-grpcio = "3.0.0"
@@ -76,6 +78,7 @@ mock-etcd = { git = "https://github.com/datenlord/etcd-client", rev = "f697899" 
 #  Create mock api for some interface like s3 that are independent service,
 #  We don't want to start up a real service for some api when doing unit test.
 mockall = "0.11.2"
+tempfile = "3"
 
 [[bin]]
 path = "src/bin/bind_mounter.rs"

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,32 @@
+config_file = "config.toml"
+role = "node"
+node_name = "node222"
+node_ip = "127.0.0.1"
+mount_path = "/tmp/datenlord_data_dir"
+kv_server_list = [
+    "127.0.0.1:2379"
+]
+server_port = 8800
+scheduler_extender_port = 12345
+
+[storage]
+storage_type = "fs"
+block_size = 524288
+fs_storage_root = "/tmp/datenlord_backend"
+
+[storage.memory_cache_config]
+capacity = 8589934592
+command_queue_limit = 1000
+write_back = false
+soft_limit = "3,5"
+
+[storage.s3_storage_config]
+endpoint_url = ""
+access_key_id = ""
+secret_access_key = ""
+bucket_name = ""
+
+[csi_config]
+endpoint = "unix:///tmp/node.sock "
+driver_name = "io.datenlord.csi.plugin"
+worker_port = 9001

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -187,7 +187,7 @@ impl Config {
             Ok(conf)
         } else {
             Err(DatenLordError::ArgumentInvalid {
-                context: vec!["Current command line arguments are not valid.".to_owned()],
+                context: vec!["Current command line arguments are not valid, please check role/node_name/node_ip/mount_path is correct.".to_owned()],
             })
         }
     }
@@ -250,7 +250,6 @@ mod tests {
         let conf = Config::load_from_args(arg_conf).unwrap();
 
         assert_eq!(conf.role, Some("node".to_owned()));
-        assert_eq!(conf.node_name, Some("node1".to_owned()));
     }
 
     #[test]
@@ -274,7 +273,6 @@ mod tests {
         let conf = Config::load_from_args(arg_conf).unwrap();
 
         assert_eq!(conf.role, Some("node".to_owned()));
-        assert_eq!(conf.node_name, Some("node222".to_owned()));
         assert_eq!(conf.node_ip, Some("127.0.0.1".to_owned()));
         assert_eq!(conf.mount_path, Some("/tmp/datenlord_data_dir".to_owned()));
         assert_eq!(conf.server_port, 8800);

--- a/src/config/inner.rs
+++ b/src/config/inner.rs
@@ -74,21 +74,43 @@ impl TryFrom<SuperConfig> for InnerConfig {
 
     #[inline]
     fn try_from(value: SuperConfig) -> Result<Self, Self::Error> {
+        let Some(role_str) = value.role else {
+            return Err(DatenLordError::ArgumentInvalid {
+                context: vec!["role is empty".to_owned()],
+            });
+        };
         let log_level = Level::from_str(value.log_level.as_str()).map_err(|e| {
             DatenLordError::ArgumentInvalid {
                 context: vec![format!("log level {} is invalid: {}", value.log_level, e)],
             }
         })?;
-        let role = Role::from_str(value.role.as_str())?;
-        let node_name = value.node_name;
+        let role = Role::from_str(&role_str)?;
+        let Some(node_name) = value.node_name else {
+            return Err(DatenLordError::ArgumentInvalid {
+                context: vec!["node name is empty".to_owned()],
+            });
+        };
         let server_port = value.server_port;
         let scheduler_extender_port = value.scheduler_extender_port;
-        let node_ip = IpAddr::from_str(value.node_ip.as_str()).map_err(|e| {
+        let Some(node_ip_str) = value.node_ip else {
+            return Err(DatenLordError::ArgumentInvalid {
+                context: vec!["node ip is empty".to_owned()],
+            });
+        };
+        let node_ip = IpAddr::from_str(node_ip_str.as_str()).map_err(|e| {
             DatenLordError::ArgumentInvalid {
-                context: vec![format!("node ip {} is invalid: {}", value.node_ip, e)],
+                context: vec![format!(
+                    "node ip {} is invalid: {}",
+                    node_ip_str.as_str(),
+                    e
+                )],
             }
         })?;
-        let mount_path = value.mount_path;
+        let Some(mount_path) = value.mount_path else {
+            return Err(DatenLordError::ArgumentInvalid {
+                context: vec!["mount path is empty".to_owned()],
+            });
+        };
         let storage = value.storage.try_into()?;
         let kv_addrs: Vec<String> = value.kv_server_list;
         if kv_addrs.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,7 +127,8 @@ async fn parse_metadata(config: &InnerConfig) -> DatenLordResult<MetaData> {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let config = InnerConfig::try_from(config::Config::parse())?;
+    let arg_conf = config::Config::parse();
+    let config = InnerConfig::try_from(config::Config::load_from_args(arg_conf)?)?;
 
     init_logger(config.role.into(), config.log_level);
 


### PR DESCRIPTION
This PR use `serfig` to load config from `file`, `env`, and `command line`, then build then with priority(file < env < args).

- Reference issue: https://github.com/datenlord/datenlord/issues/437