### PR TITLE
chore: rename user_id and group_id to uid and gid.

### DIFF
--- a/src/async_fuse/memfs/metadata.rs
+++ b/src/async_fuse/memfs/metadata.rs
@@ -39,9 +39,9 @@ pub(crate) mod error {
 #[derive(Debug, Clone)]
 pub struct ReqContext {
     /// The uid of the user who sends the request
-    pub user_id: u32,
+    pub uid: u32,
     /// The gid of the user who sends the request
-    pub group_id: u32,
+    pub gid: u32,
 }
 
 /// MetaData of fs

--- a/src/async_fuse/memfs/mod.rs
+++ b/src/async_fuse/memfs/mod.rs
@@ -225,8 +225,8 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
             return reply.error(e).await;
         }
         let context = ReqContext {
-            user_id: req.uid(),
-            group_id: req.gid(),
+            uid: req.uid(),
+            gid: req.gid(),
         };
         let lookup_res = self.metadata.lookup_helper(context, parent, name).await;
         match lookup_res {
@@ -269,8 +269,8 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         debug!("open(ino={}, flags={}, req={:?})", ino, flags, req);
 
         let context = ReqContext {
-            user_id: req.uid(),
-            group_id: req.gid(),
+            uid: req.uid(),
+            gid: req.gid(),
         };
 
         match self.metadata.open(context, ino, flags).await {
@@ -342,8 +342,8 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
             warn!("setattr() encountered valid=0, the req={:?}", req);
         };
         let context = ReqContext {
-            user_id: req.uid(),
-            group_id: req.gid(),
+            uid: req.uid(),
+            gid: req.gid(),
         };
         let set_res = self.metadata.setattr_helper(context, ino, &param).await;
         match set_res {
@@ -433,8 +433,8 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         }
 
         let context = ReqContext {
-            user_id: req.uid(),
-            group_id: req.gid(),
+            uid: req.uid(),
+            gid: req.gid(),
         };
 
         match self.metadata.unlink(context, parent, name).await {
@@ -468,8 +468,8 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         }
 
         let context = ReqContext {
-            user_id: req.uid(),
-            group_id: req.gid(),
+            uid: req.uid(),
+            gid: req.gid(),
         };
 
         let rmdir_res = self
@@ -513,8 +513,8 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         reply: ReplyEmpty,
     ) -> nix::Result<usize> {
         let context = ReqContext {
-            user_id: req.uid(),
-            group_id: req.gid(),
+            uid: req.uid(),
+            gid: req.gid(),
         };
         match self.metadata.rename(context, param).await {
             Ok(()) => reply.ok().await,
@@ -724,8 +724,8 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         let ino = req.nodeid();
         debug!("opendir(ino={}, flags={}, req={:?})", ino, flags, req,);
         let context = ReqContext {
-            user_id: req.uid(),
-            group_id: req.gid(),
+            uid: req.uid(),
+            gid: req.gid(),
         };
         let o_flags = fs_util::parse_oflag(flags);
         match self.metadata.opendir(context, ino, flags).await {
@@ -767,8 +767,8 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         );
 
         let context = ReqContext {
-            user_id: req.uid(),
-            group_id: req.gid(),
+            uid: req.uid(),
+            gid: req.gid(),
         };
         match self
             .metadata
@@ -844,8 +844,8 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         };
         debug!("statfs(ino={}, req={:?})", ino, req);
         let context = ReqContext {
-            user_id: req.uid(),
-            group_id: req.gid(),
+            uid: req.uid(),
+            gid: req.gid(),
         };
         match self.metadata.statfs(context, ino).await {
             Ok(statvfs) => {

--- a/src/async_fuse/memfs/node.rs
+++ b/src/async_fuse/memfs/node.rs
@@ -61,8 +61,8 @@ pub trait Node: Sized {
         inum: INum,
         child_dir_name: &str,
         mode: Mode,
-        user_id: u32,
-        group_id: u32,
+        uid: u32,
+        gid: u32,
         txn: &mut T,
     ) -> DatenLordResult<Self>;
     /// Open file in a directory

--- a/src/async_fuse/memfs/s3_node.rs
+++ b/src/async_fuse/memfs/s3_node.rs
@@ -236,14 +236,14 @@ impl S3Node {
     }
 
     /// Check if given uid and gid can access this node
-    pub fn open_pre_check(&self, flags: OFlag, user_id: u32, group_id: u32) -> DatenLordResult<()> {
+    pub fn open_pre_check(&self, flags: OFlag, uid: u32, gid: u32) -> DatenLordResult<()> {
         let attr = self.get_attr();
         let access_mode = match flags & (OFlag::O_RDONLY | OFlag::O_WRONLY | OFlag::O_RDWR) {
             OFlag::O_RDONLY => 4,
             OFlag::O_WRONLY => 2,
             _ => 6,
         };
-        attr.check_perm(user_id, group_id, access_mode)
+        attr.check_perm(uid, gid, access_mode)
     }
 }
 
@@ -408,8 +408,8 @@ impl Node for S3Node {
         inum: INum,
         child_dir_name: &str,
         mode: Mode,
-        user_id: u32,
-        group_id: u32,
+        uid: u32,
+        gid: u32,
         txn: &mut T,
     ) -> DatenLordResult<Self> {
         // get new directory attribute
@@ -417,8 +417,8 @@ impl Node for S3Node {
             ino: inum,
             kind: SFlag::S_IFDIR,
             perm: fs_util::parse_mode_bits(mode.bits()),
-            uid: user_id,
-            gid: group_id,
+            uid,
+            gid,
             nlink: 1,
             ..FileAttr::now()
         }));
@@ -467,8 +467,8 @@ impl Node for S3Node {
         child_file_name: &str,
         oflags: OFlag,
         mode: Mode,
-        user_id: u32,
-        group_id: u32,
+        uid: u32,
+        gid: u32,
         txn: &mut T,
     ) -> DatenLordResult<Self> {
         debug_assert!(oflags.contains(OFlag::O_CREAT));
@@ -480,8 +480,8 @@ impl Node for S3Node {
             perm: fs_util::parse_mode_bits(mode.bits()),
             size: 0,
             blocks: 0,
-            uid: user_id,
-            gid: group_id,
+            uid,
+            gid,
             nlink: 1,
             ..FileAttr::now()
         }));

--- a/src/async_fuse/test/integration_tests.rs
+++ b/src/async_fuse/test/integration_tests.rs
@@ -32,12 +32,12 @@ fn test_create_file(mount_dir: &Path) -> anyhow::Result<()> {
     assert_eq!(file_metadata.mode() & 0o777, 0o644);
     // check the file owner
     let file_owner = file_metadata.uid();
-    let create_user_id = unistd::getuid();
-    assert_eq!(file_owner, create_user_id.as_raw());
+    let create_uid = unistd::getuid();
+    assert_eq!(file_owner, create_uid.as_raw());
     // check the file group
     let file_group = file_metadata.gid();
-    let create_group_id = unistd::getgid();
-    assert_eq!(file_group, create_group_id.as_raw());
+    let create_gid = unistd::getgid();
+    assert_eq!(file_group, create_gid.as_raw());
     // check nlink == 1
     assert_eq!(file_metadata.nlink(), 1);
     fs::remove_file(&file_path)?; // immediate deletion

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,7 @@
     clippy::impl_trait_in_params,  // Allow impl AsRef<Path>, it's common in Rust
     clippy::missing_assert_message, // Allow assert! without message, mainly in test code
     clippy::semicolon_outside_block, // We need to choose between this and `semicolon_inside_block`, we choose outside
+    clippy::similar_names, // Allow similar names, due to the existence of uid and gid
 )]
 
 pub mod async_fuse;


### PR DESCRIPTION
In this PR, we fixed the issue #449 to enhance code readability and conciseness.