### PR TITLE
feat: use config to control log level.

### DIFF
--- a/scripts/setup/start_local_node.sh
+++ b/scripts/setup/start_local_node.sh
@@ -63,4 +63,5 @@ cargo run $BUILD_FLAGS --bin=datenlord -- \
 --storage-fs-root=$STORAGE_FS_ROOT \
 --server-port=8800 \
 --storage-type=fs \
---storage-mem-cache-write-back
+--storage-mem-cache-write-back \
+--log-level=info

--- a/src/async_fuse/proactor/v0.rs
+++ b/src/async_fuse/proactor/v0.rs
@@ -151,11 +151,13 @@ mod tests {
     use std::os::unix::io::AsRawFd;
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    use tracing::level_filters::LevelFilter;
+
     use crate::common::logger::{init_logger, LogRole};
 
     #[tokio::test(flavor = "multi_thread")]
     async fn proactor_v0_test() -> anyhow::Result<()> {
-        init_logger(LogRole::Test);
+        init_logger(LogRole::Test, LevelFilter::INFO);
 
         let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
 

--- a/src/async_fuse/test/test_util.rs
+++ b/src/async_fuse/test/test_util.rs
@@ -10,6 +10,7 @@ use datenlord::config::{
     MemoryCacheConfig, SoftLimit, StorageConfig, StorageParams, StorageS3Config,
 };
 use tokio_util::sync::CancellationToken;
+use tracing::level_filters::LevelFilter;
 use tracing::{debug, info}; // warn, error
 
 use crate::async_fuse::fuse::{mount, session};
@@ -101,7 +102,7 @@ async fn run_fs(mount_point: &Path, is_s3: bool, token: CancellationToken) -> an
 
 #[allow(clippy::let_underscore_must_use)]
 pub async fn setup(mount_dir: &Path, is_s3: bool) -> anyhow::Result<()> {
-    init_logger(LogRole::Test);
+    init_logger(LogRole::Test, LevelFilter::INFO);
     debug!("setup started with mount_dir: {:?}", mount_dir);
     if mount_dir.exists() {
         debug!("mount_dir {:?} exists ,try umount", mount_dir);

--- a/src/common/logger.rs
+++ b/src/common/logger.rs
@@ -57,14 +57,14 @@ impl LogRole {
 #[allow(clippy::let_underscore_must_use)]
 #[allow(clippy::needless_pass_by_value)] // Just pass a temporary value is fine.
 #[inline]
-pub fn init_logger(role: LogRole) {
+pub fn init_logger(role: LogRole, level: Level) {
     let filter = filter::Targets::new()
         .with_target("hyper", Level::WARN)
         .with_target("h2", Level::WARN)
         .with_target("tower", Level::WARN)
         .with_target("datenlord::async_fuse::fuse", Level::INFO)
         .with_target("datenlord::metrics", Level::INFO)
-        .with_target("", Level::INFO);
+        .with_target("", level);
 
     let log_path = format!("./datenlord_{}.log", role.as_str());
     let file = std::fs::OpenOptions::new()

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -13,6 +13,9 @@ pub struct Config {
     #[clap(long = "node-ip", value_name = "VALUE")]
     /// Node ip
     pub node_ip: String,
+    #[clap(long = "log-level", value_name = "VALUE", default_value = "info")]
+    /// Log level
+    pub log_level: String,
     #[clap(long = "mount-path", value_name = "VALUE")]
     /// Set the mount point of FUSE
     pub mount_path: String,
@@ -146,6 +149,8 @@ mod tests {
     use std::num::NonZeroUsize;
     use std::str::FromStr;
 
+    use tracing::level_filters::LevelFilter;
+
     use super::*;
     use crate::config::inner::{InnerConfig, Role, StorageParams as InnerStorageParams};
     use crate::config::SoftLimit;
@@ -174,12 +179,15 @@ mod tests {
             "9001",
             "--storage-fs-root",
             "/tmp/datenlord_backend",
+            "--log-level",
+            "info",
         ];
         let config = Config::parse_from(args);
         assert_eq!(config.role, "node");
         assert_eq!(config.node_name, "node1");
         assert_eq!(config.node_ip.as_str(), "127.0.0.1");
         assert_eq!(config.mount_path.as_str(), "/tmp/datenlord_data_dir");
+        assert_eq!(config.log_level, "info");
 
         let kv_addrs = &config.kv_server_list;
         assert_eq!(kv_addrs.len(), 2);
@@ -375,6 +383,8 @@ mod tests {
             "/tmp/datenlord_data_dir",
             "--kv-server-list",
             "127.0.0.1:7890",
+            "--log-level",
+            "info",
         ];
         let config: InnerConfig = Config::parse_from(args).try_into().unwrap();
         assert_eq!(config.role, Role::Controller);
@@ -382,6 +392,7 @@ mod tests {
         assert_eq!(config.node_ip, IpAddr::from_str("127.0.0.1").unwrap());
         assert_eq!(config.mount_path.as_str(), "/tmp/datenlord_data_dir");
         assert_eq!(config.server_port, 8800);
+        assert_eq!(config.log_level, LevelFilter::INFO);
 
         let kv_addrs = config.kv_addrs;
         assert_eq!(kv_addrs.len(), 1);

--- a/src/config/inner.rs
+++ b/src/config/inner.rs
@@ -3,6 +3,7 @@ use std::num::NonZeroUsize;
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
+use tracing::level_filters::LevelFilter as Level;
 
 use crate::common::error::DatenLordError;
 use crate::config::config::{
@@ -54,6 +55,8 @@ pub struct InnerConfig {
     pub node_ip: IpAddr,
     /// Mount path
     pub mount_path: String,
+    /// Log level
+    pub log_level: Level,
     /// kv server addresses
     pub kv_addrs: Vec<String>,
     /// Service port number
@@ -71,6 +74,11 @@ impl TryFrom<SuperConfig> for InnerConfig {
 
     #[inline]
     fn try_from(value: SuperConfig) -> Result<Self, Self::Error> {
+        let log_level = Level::from_str(value.log_level.as_str()).map_err(|e| {
+            DatenLordError::ArgumentInvalid {
+                context: vec![format!("log level {} is invalid: {}", value.log_level, e)],
+            }
+        })?;
         let role = Role::from_str(value.role.as_str())?;
         let node_name = value.node_name;
         let server_port = value.server_port;
@@ -94,6 +102,7 @@ impl TryFrom<SuperConfig> for InnerConfig {
             node_name,
             node_ip,
             mount_path,
+            log_level,
             kv_addrs,
             server_port,
             scheduler_extender_port,

--- a/src/csi/mod.rs
+++ b/src/csi/mod.rs
@@ -198,6 +198,7 @@ mod test {
     // use mock_etcd::MockEtcdServer;
     use protobuf::RepeatedField;
     use tracing::debug;
+    use tracing::level_filters::LevelFilter;
 
     use super::{util, *};
     use crate::common::error::Context;
@@ -226,7 +227,7 @@ mod test {
     #[allow(clippy::let_underscore_must_use)]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_all() -> DatenLordResult<()> {
-        init_logger(LogRole::Test);
+        init_logger(LogRole::Test, LevelFilter::INFO);
         // TODO: run test case in parallel
         // Because they all depend on etcd, so cannot run in parallel now
         // let mut etcd_server = MockEtcdServer::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,7 @@ async fn parse_metadata(config: &InnerConfig) -> DatenLordResult<MetaData> {
 async fn main() -> anyhow::Result<()> {
     let config = InnerConfig::try_from(config::Config::parse())?;
 
-    init_logger(config.role.into());
+    init_logger(config.role.into(), config.log_level);
 
     match config.role {
         NodeRole::Node => {


### PR DESCRIPTION
We have modified the `init_logger` function, and set filter level manually from config.

log level(from tracing):
```rs
/// The "off" level.
///
/// Designates that trace instrumentation should be completely disabled.
pub const OFF: LevelFilter = LevelFilter(None);
/// The "error" level.
///
/// Designates very serious errors.
pub const ERROR: LevelFilter = LevelFilter::from_level(Level::ERROR);
/// The "warn" level.
///
/// Designates hazardous situations.
pub const WARN: LevelFilter = LevelFilter::from_level(Level::WARN);
/// The "info" level.
///
/// Designates useful information.
pub const INFO: LevelFilter = LevelFilter::from_level(Level::INFO);
/// The "debug" level.
///
/// Designates lower priority information.
pub const DEBUG: LevelFilter = LevelFilter::from_level(Level::DEBUG);
/// The "trace" level.
///
/// Designates very low priority, often extremely verbose, information.
pub const TRACE: LevelFilter = LevelFilter(Some(Level::TRACE));
```