### PR TITLE
refactor: Manage async tasks with task manager

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,9 @@ tracing-subscriber = "0.3"
 hashlink = "0.8.4"
 clap = { version = "4", features = ["derive"] }
 opendal = {version = "0.43.0", features = ["layers-prometheus"]}
+signal-hook = { version = "0.3.17", features = ["iterator"]}
+signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
+tokio-util = "0.7.10"
 
 [build-dependencies]
 protoc-grpcio = "3.0.0"

--- a/src/async_fuse/mod.rs
+++ b/src/async_fuse/mod.rs
@@ -51,7 +51,8 @@ pub async fn start_async_fuse(
             .command_queue_limit(memory_cache_config.command_queue_limit)
             .limit(memory_cache_config.soft_limit)
             .write_through(!memory_cache_config.write_back)
-            .build();
+            .build()
+            .await;
         StorageManager::new(memory_cache, block_size)
     };
 

--- a/src/async_fuse/test/integration_tests.rs
+++ b/src/async_fuse/test/integration_tests.rs
@@ -762,7 +762,7 @@ async fn run_s3_test() -> anyhow::Result<()> {
 async fn _run_test(mount_dir_str: &str, is_s3: bool) -> anyhow::Result<()> {
     info!("begin integration test");
     let mount_dir = Path::new(mount_dir_str);
-    let th = test_util::setup(mount_dir, is_s3).await?;
+    test_util::setup(mount_dir, is_s3).await?;
 
     test_delete_file(mount_dir).context("test_delete_file() failed")?;
     test_file_manipulation_rust_way(mount_dir)
@@ -791,7 +791,7 @@ async fn _run_test(mount_dir_str: &str, is_s3: bool) -> anyhow::Result<()> {
     test_open_file_permission(mount_dir).context("test_open_file_permission() failed")?;
     test_write_read_only_file(mount_dir).context("test_write_read_only_file() failed")?;
 
-    test_util::teardown(mount_dir, th).await?;
+    test_util::teardown(mount_dir).await?;
 
     Ok(())
 }
@@ -810,7 +810,7 @@ async fn run_s3_bench() -> anyhow::Result<()> {
 
 async fn _run_bench(mount_dir_str: &str, is_s3: bool) -> anyhow::Result<()> {
     let mount_dir = Path::new(mount_dir_str);
-    let th = test_util::setup(mount_dir, is_s3).await?;
+    test_util::setup(mount_dir, is_s3).await?;
 
     let fio_handle = std::process::Command::new("fio")
         .arg("./scripts/perf/fio-jobs.ini")
@@ -829,6 +829,6 @@ async fn _run_bench(mount_dir_str: &str, is_s3: bool) -> anyhow::Result<()> {
         ))
     };
 
-    test_util::teardown(mount_dir, th).await?;
+    test_util::teardown(mount_dir).await?;
     fio_res
 }

--- a/src/async_fuse/test/test_util.rs
+++ b/src/async_fuse/test/test_util.rs
@@ -75,7 +75,8 @@ async fn run_fs(mount_point: &Path, is_s3: bool, token: CancellationToken) -> an
             .command_queue_limit(memory_cache_config.command_queue_limit)
             .limit(memory_cache_config.soft_limit)
             .write_through(!memory_cache_config.write_back)
-            .build();
+            .build()
+            .await;
         StorageManager::new(memory_cache, block_size)
     };
 
@@ -158,7 +159,7 @@ pub async fn teardown(mount_dir: &Path) -> anyhow::Result<()> {
         )
     });
     let abs_mount_path = fs::canonicalize(mount_dir)?;
-    fs::remove_dir_all(&abs_mount_path)?;
+    fs::remove_dir_all(abs_mount_path)?;
 
     Ok(())
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -9,3 +9,4 @@ pub mod util;
 
 /// Log related module
 pub mod logger;
+pub mod task_manager;

--- a/src/common/task_manager/gc.rs
+++ b/src/common/task_manager/gc.rs
@@ -1,0 +1,272 @@
+//! The GC task implementation.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::future::BoxFuture;
+use futures::{Future, FutureExt};
+use tokio::select;
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info};
+
+use super::{SpawnError, TaskName};
+
+/// The default limitation of the channel of handles.
+pub const DEFAULT_HANDLE_QUEUE_LIMIT: usize = 5000;
+
+/// The default period of GC tasks.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// A handle for spawning task into GC task.
+#[derive(Debug, Clone)]
+pub struct GcHandle {
+    /// Name of the GC task.
+    name: TaskName,
+    /// The status of task manager.
+    status: Arc<AtomicBool>,
+    /// The listener
+    token: CancellationToken,
+    /// A sender of spawned tasks.
+    tx: mpsc::Sender<BoxFuture<'static, ()>>,
+}
+
+impl GcHandle {
+    /// Create a GC handle.
+    pub fn new(
+        name: TaskName,
+        status: Arc<AtomicBool>,
+        token: CancellationToken,
+        tx: mpsc::Sender<BoxFuture<'static, ()>>,
+    ) -> Self {
+        Self {
+            name,
+            status,
+            token,
+            tx,
+        }
+    }
+
+    /// Checks if the task manager is shutdown.
+    pub fn is_shutdown(&self) -> bool {
+        self.status.load(Ordering::Acquire)
+    }
+
+    /// Spawn a task, and send its handle to GC task for managing.
+    #[inline]
+    pub async fn spawn<F, Fu>(&self, f: F) -> Result<(), SpawnError>
+    where
+        F: FnOnce(CancellationToken) -> Fu,
+        Fu: Future<Output = ()> + Send + 'static,
+    {
+        if self.is_shutdown() {
+            return Err(SpawnError(self.name));
+        }
+
+        let token = self.token.clone();
+        let future = f(token).boxed();
+
+        self.tx
+            .send(future)
+            .await
+            .map_err(|_e| SpawnError(self.name))?;
+        Ok(())
+    }
+}
+
+/// The GC task.
+#[derive(Debug)]
+pub(super) struct GcTask {
+    /// Name of the task.
+    name: TaskName,
+    /// Tasks managed by the GC task.
+    tasks: JoinSet<()>,
+    /// A receiver to retrieve spawned tasks.
+    rx: mpsc::Receiver<BoxFuture<'static, ()>>,
+    /// The interval of a GC period.
+    timeout: Duration,
+}
+
+impl GcTask {
+    /// Create a GC task.
+    pub fn new(
+        name: TaskName,
+        rx: mpsc::Receiver<BoxFuture<'static, ()>>,
+        timeout: Duration,
+    ) -> Self {
+        Self {
+            name,
+            tasks: JoinSet::new(),
+            rx,
+            timeout,
+        }
+    }
+
+    /// Run the GC task, consume the task itself.
+    #[allow(clippy::pattern_type_mismatch)] // for `tokio::select!`
+    pub async fn run(mut self, token: CancellationToken) -> Self {
+        loop {
+            select! {
+                res = self.rx.recv() => {
+                    if let Some(future) = res {
+                        self.tasks.spawn(future);
+                    } else {
+                        info!("All senders of handles are closed, so GC task `{:?}` is exiting.", self.name);
+                        break;
+                    }
+                },
+                Some(res) = self.tasks.join_next() => {
+                    if let Err(e) = res {
+                        error!("Sub task in `{:?}` failed: {}", self.name, e);
+                    }
+                },
+                () = token.cancelled() => {
+                    info!("Shutdown signal received, so GC task `{:?}` is exiting.", self.name);
+                    break;
+                }
+            }
+        }
+
+        // Clean up
+        self.rx.close();
+        // Retrieve all tasks.
+        while let Some(future) = self.rx.recv().await {
+            self.tasks.spawn(future);
+        }
+
+        loop {
+            select! {
+                () = tokio::time::sleep(self.timeout) => {
+                    let len = self.tasks.len();
+                    if len != 0 {
+                        error!("`{:?}` gives up to wait {} tasks to quit.", self.name, len);
+                        self.tasks.shutdown().await;
+                    }
+                    break;
+                },
+                res = self.tasks.join_next() => {
+                    if let Some(res) = res {
+                        if let Err(e) = res {
+                            error!("Sub task in `{:?}` failed: {}", self.name, e);
+                        }
+                    } else {
+                        info!("GC task `{:?}` exits.", self.name);
+                        break;
+                    }
+                }
+            }
+        }
+
+        self
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::default_numeric_fallback)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::{mpsc, oneshot};
+
+    use super::{
+        CancellationToken, GcHandle, GcTask, SpawnError, TaskName, DEFAULT_HANDLE_QUEUE_LIMIT,
+    };
+
+    fn make_gc_task() -> (Arc<AtomicBool>, GcTask, GcHandle) {
+        let name = TaskName::Root;
+        let timeout = Duration::from_millis(100);
+        let (tx, rx) = mpsc::channel(DEFAULT_HANDLE_QUEUE_LIMIT);
+        let task = GcTask::new(name, rx, timeout);
+
+        let status = Arc::default();
+        let token = CancellationToken::new();
+        let handle = GcHandle::new(name, Arc::clone(&status), token, tx);
+
+        (status, task, handle)
+    }
+
+    #[tokio::test]
+    async fn test_gc_task() {
+        let (status, gc_task, gc_handle) = make_gc_task();
+
+        let handle = tokio::spawn(gc_task.run(gc_handle.token.clone()));
+
+        let (tx, mut rx) = mpsc::channel(4);
+
+        for _ in 0..4 {
+            let tx = tx.clone();
+            gc_handle
+                .spawn(|_| async move {
+                    tx.send(0).await.unwrap();
+                })
+                .await
+                .unwrap();
+        }
+
+        drop(tx);
+
+        // Shutdown the GC task.
+        status.store(true, Ordering::Release);
+        gc_handle.token.cancel();
+
+        let mut values = vec![];
+        while let Some(val) = rx.recv().await {
+            values.push(val);
+        }
+
+        assert_eq!(values, [0, 0, 0, 0]);
+
+        let gc_task = handle.await.unwrap();
+
+        assert!(gc_task.tasks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_spawn_after_shutdown() {
+        let (status, gc_task, gc_handle) = make_gc_task();
+
+        let handle = tokio::spawn(gc_task.run(gc_handle.token.clone()));
+
+        // Shutdown the GC task.
+        status.store(true, Ordering::Release);
+        gc_handle.token.cancel();
+
+        let _: GcTask = handle.await.unwrap();
+
+        let err = gc_handle.spawn(|_| async {}).await.unwrap_err();
+        assert_eq!(err, SpawnError(TaskName::Root));
+    }
+
+    #[tokio::test]
+    async fn test_timeout() {
+        let (status, gc_task, gc_handle) = make_gc_task();
+
+        let handle = tokio::spawn(gc_task.run(gc_handle.token.clone()));
+
+        let (tx, rx) = oneshot::channel();
+
+        gc_handle
+            .spawn(|token| async move {
+                token.cancelled().await;
+                // This makes no progress in a period of GC task. Thus this task will be
+                // aborted.
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                tx.send(0).unwrap();
+            })
+            .await
+            .unwrap();
+
+        // Shutdown the GC task.
+        status.store(true, Ordering::Release);
+        gc_handle.token.cancel();
+
+        handle.await.unwrap();
+
+        // The timeout task is aborted, so the `rx` will never receive anything.
+        let _: oneshot::error::RecvError = rx.await.unwrap_err();
+    }
+}

--- a/src/common/task_manager/gc.rs
+++ b/src/common/task_manager/gc.rs
@@ -35,6 +35,7 @@ pub struct GcHandle {
 
 impl GcHandle {
     /// Create a GC handle.
+    #[inline]
     pub fn new(
         name: TaskName,
         status: Arc<AtomicBool>,
@@ -50,6 +51,8 @@ impl GcHandle {
     }
 
     /// Checks if the task manager is shutdown.
+    #[inline]
+    #[must_use]
     pub fn is_shutdown(&self) -> bool {
         self.status.load(Ordering::Acquire)
     }

--- a/src/common/task_manager/manager.rs
+++ b/src/common/task_manager/manager.rs
@@ -16,7 +16,7 @@ use tracing::{error, info, instrument};
 use super::gc::GcHandle;
 use super::task::{Task, TaskName, EDGES, GC_TASKS};
 
-/// The task manager.
+/// The global task manager.
 pub static TASK_MANAGER: Lazy<TaskManager> = Lazy::new(TaskManager::default);
 
 /// Spawn error, occurs when spawnint a task after shutdown.

--- a/src/common/task_manager/manager.rs
+++ b/src/common/task_manager/manager.rs
@@ -160,7 +160,7 @@ impl TaskManager {
             task_node.token().cancel();
             for result in task_node.join_all().await {
                 if let Err(e) = result {
-                    error!("Background task failed with error: {e}.");
+                    error!("Background task {task_name:?} failed with error: {e}.");
                 }
             }
 

--- a/src/common/task_manager/manager.rs
+++ b/src/common/task_manager/manager.rs
@@ -1,0 +1,193 @@
+//! The task manager implementation.
+
+use std::collections::{HashMap, VecDeque};
+use std::fmt::Debug;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use futures::{Future, StreamExt};
+use parking_lot::Mutex;
+use signal_hook_tokio::Signals;
+use thiserror::Error;
+use tokio::task::AbortHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, instrument};
+
+use super::task::{Task, TaskName, EDGES};
+
+/// Spawn error, occurs when spawnint a task after shutdown.
+#[derive(Debug, Error, PartialEq, Eq)]
+#[error("Failed to spawn task: {0:?}")]
+pub struct SpawnError(pub TaskName);
+
+/// The task manager, which will shutdown all async tasks in proper order.
+#[derive(Debug)]
+pub struct TaskManager {
+    /// Tasks in task manager.
+    tasks: Mutex<HashMap<TaskName, Task>>,
+    /// The status of task manager, `true` for shutting down.
+    status: Arc<AtomicBool>,
+}
+
+impl TaskManager {
+    /// Create a new task manager. The relationships between task nodes are
+    /// defined in [`EDGES`] and will be initialized immediately.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        let mut tasks = HashMap::new();
+        let status = Arc::default();
+        for (prev, next) in EDGES {
+            tasks
+                .entry(prev)
+                .or_insert_with(|| Task::new(prev, Arc::clone(&status)))
+                .add_dependency(next);
+            tasks
+                .entry(next)
+                .or_insert_with(|| Task::new(next, Arc::clone(&status)))
+                .inc_predecessor_count();
+        }
+
+        Self {
+            tasks: Mutex::new(tasks),
+            status,
+        }
+    }
+
+    /// Dumps all edges of the dependency graph.
+    #[cfg(test)]
+    pub(super) fn edges(&self) -> Vec<(TaskName, TaskName)> {
+        let mut result = vec![];
+        let tasks = self.tasks.lock();
+
+        for (&task_name, task_node) in tasks.iter() {
+            result.extend(
+                task_node
+                    .dependencies()
+                    .iter()
+                    .map(|&dependency| (task_name, dependency)),
+            );
+        }
+        result
+    }
+
+    #[cfg(test)]
+    pub(super) fn predecessor_counts(&self) -> HashMap<TaskName, usize> {
+        let tasks = self.tasks.lock();
+
+        tasks
+            .iter()
+            .map(|(&name, task)| (name, task.predecessor_count()))
+            .collect()
+    }
+
+    /// Spawn a new task with task name. The task will be managed in the task
+    /// manager.
+    ///
+    /// # Errors
+    /// Returns `Err` if the task manager is shutting down.
+    ///
+    /// # Panics
+    /// Panics if this method is called from the outside of a tokio runtime.
+    #[inline]
+    pub fn spawn<F, Fu>(&self, name: TaskName, f: F) -> Result<AbortHandle, SpawnError>
+    where
+        F: FnOnce(CancellationToken) -> Fu,
+        Fu: Future<Output = ()> + Send + 'static,
+    {
+        let mut tasks = self.tasks.lock();
+        if self.is_shutdown() {
+            return Err(SpawnError(name));
+        }
+        let node = tasks
+            .get_mut(&name)
+            .unwrap_or_else(|| unreachable!("Task {name:?} is not in the manager."));
+
+        let handle = node.spawn(f);
+
+        Ok(handle)
+    }
+
+    /// The status of task manager, `true` for shutting down.
+    #[inline]
+    pub fn is_shutdown(&self) -> bool {
+        self.status.load(Ordering::Acquire)
+    }
+
+    /// Shutdown the task manager.
+    ///
+    /// After `shutdown` being called, no new task should be spawned via task
+    /// manager.
+    #[inline]
+    #[instrument(skip(self))]
+    pub async fn shutdown(&self) {
+        let mut queue = VecDeque::from([TaskName::Root]);
+
+        self.status.store(true, Ordering::Release);
+
+        let mut tasks = std::mem::take(&mut *self.tasks.lock());
+
+        while let Some(task_name) = queue.pop_front() {
+            let Some(mut task_node) = tasks.remove(&task_name) else {
+                continue;
+            };
+
+            info!("Shutdown task node: {task_name:?}");
+
+            // Notify all pending tasks to shutdown. And wait all of them to finish or quit.
+            task_node.token().cancel();
+            for result in task_node.join_all().await {
+                if let Err(e) = result {
+                    error!("Background task failed with error: {e}.");
+                }
+            }
+
+            for dependency_name in task_node.dependencies() {
+                let Some(dependency_node) = tasks.get_mut(dependency_name) else {
+                    continue;
+                };
+                dependency_node.dec_predecessor_count();
+                if dependency_node.predecessor_count() == 0 {
+                    queue.push_back(*dependency_name);
+                }
+            }
+        }
+    }
+}
+
+impl Default for TaskManager {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Wait for signal `SIGTERM`, `SIGQUIT` and `SIGINT`, and shutdown the task
+/// manager.
+#[inline]
+pub fn wait_for_shutdown(
+    manager: Arc<TaskManager>,
+) -> anyhow::Result<impl Future<Output = ()> + Send> {
+    use signal_hook::consts::TERM_SIGNALS;
+
+    let mut signals = Signals::new(TERM_SIGNALS)?;
+    let handle = signals.handle();
+
+    let future = async move {
+        if let Some(signal) = signals.next().await {
+            assert!(
+                TERM_SIGNALS.contains(&signal),
+                "The signal hook is not to handle signal {signal}."
+            );
+            info!("Signal {signal} raised, start to shutdown.");
+        } else {
+            info!("The signal stream is closed.");
+        }
+
+        handle.close();
+
+        manager.shutdown().await;
+    };
+
+    Ok(future)
+}

--- a/src/common/task_manager/mod.rs
+++ b/src/common/task_manager/mod.rs
@@ -10,5 +10,6 @@ mod task;
 #[cfg(test)]
 mod tests;
 
+pub use gc::GcHandle;
 pub use manager::{wait_for_shutdown, SpawnError, TaskManager, TASK_MANAGER};
 pub use task::TaskName;

--- a/src/common/task_manager/mod.rs
+++ b/src/common/task_manager/mod.rs
@@ -10,5 +10,5 @@ mod task;
 #[cfg(test)]
 mod tests;
 
-pub use manager::{wait_for_shutdown, SpawnError, TaskManager};
+pub use manager::{wait_for_shutdown, SpawnError, TaskManager, TASK_MANAGER};
 pub use task::TaskName;

--- a/src/common/task_manager/mod.rs
+++ b/src/common/task_manager/mod.rs
@@ -1,0 +1,13 @@
+//! Task manager for managing async tasks and gracefully shutdown.
+
+// TODO: Remove this when the task manager is completed.
+#![allow(dead_code)]
+
+mod manager;
+mod task;
+
+#[cfg(test)]
+mod tests;
+
+pub use manager::{wait_for_shutdown, SpawnError, TaskManager};
+pub use task::TaskName;

--- a/src/common/task_manager/mod.rs
+++ b/src/common/task_manager/mod.rs
@@ -3,6 +3,7 @@
 // TODO: Remove this when the task manager is completed.
 #![allow(dead_code)]
 
+mod gc;
 mod manager;
 mod task;
 

--- a/src/common/task_manager/task.rs
+++ b/src/common/task_manager/task.rs
@@ -1,0 +1,128 @@
+//! Task node and edges definitions.
+
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use clippy_utilities::OverflowArithmetic;
+use futures::Future;
+use tokio::task::{AbortHandle, JoinError, JoinHandle};
+use tokio_util::sync::CancellationToken;
+
+/// Name of the tasks
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TaskName {
+    /// The root node of tasks.
+    /// Exactly a dummy node.
+    Root,
+    /// The metrics server.
+    Metrics,
+    /// The tasks for flushing blocks.
+    BlockFlush,
+    /// FUSE operation handlers.
+    FuseRequest,
+    /// Async FUSE session.
+    AsyncFuse,
+    /// gRPC servers for CSI.
+    Rpc,
+    /// The write back task.
+    WriteBack,
+    /// The scheduler extender.
+    SchedulerExtender,
+}
+
+/// A task node in task manager.
+#[derive(Debug)]
+pub(super) struct Task {
+    /// The name of this task node.
+    name: TaskName,
+    /// The cancellation token to send a signal to all the tasks in this node.
+    token: CancellationToken,
+    /// The status of task manager, `true` for shutting down.
+    status: Arc<AtomicBool>,
+    /// Handles of tasks in this node.
+    handles: Vec<JoinHandle<()>>,
+    /// Dependencies of this node.
+    depends_on: Vec<TaskName>,
+    /// The count of predecessors.
+    predecessor_count: usize,
+}
+
+impl Task {
+    /// Create a task node with `name`.
+    pub fn new(name: TaskName, status: Arc<AtomicBool>) -> Self {
+        Self {
+            name,
+            token: CancellationToken::new(),
+            status,
+            handles: vec![],
+            depends_on: vec![],
+            predecessor_count: 0,
+        }
+    }
+
+    /// Add a dependency of this node.
+    pub fn add_dependency(&mut self, name: TaskName) {
+        self.depends_on.push(name);
+    }
+
+    /// Increase the `predecessor_count`.
+    pub fn inc_predecessor_count(&mut self) {
+        self.predecessor_count = self.predecessor_count.overflow_add(1);
+    }
+
+    /// Decrease the `predecessor_count`.
+    pub fn dec_predecessor_count(&mut self) {
+        self.predecessor_count = self.predecessor_count.overflow_sub(1);
+    }
+
+    /// Returns the `predecessor_count`.
+    pub fn predecessor_count(&self) -> usize {
+        self.predecessor_count
+    }
+
+    /// Get the notifier of this node.
+    pub fn token(&self) -> CancellationToken {
+        self.token.clone()
+    }
+
+    /// Await all tasks in this node.
+    pub async fn join_all(&mut self) -> Vec<Result<(), JoinError>> {
+        let handles = std::mem::take(&mut self.handles);
+        futures::future::join_all(handles).await
+    }
+
+    /// Returns the dependencies of this node.
+    pub fn dependencies(&self) -> &[TaskName] {
+        &self.depends_on
+    }
+
+    /// Spawn an async task in this task node.
+    ///
+    /// # Panics
+    /// Panics if this method is called from the outside of a tokio runtime.
+    pub fn spawn<F, Fu>(&mut self, f: F) -> AbortHandle
+    where
+        F: FnOnce(CancellationToken) -> Fu,
+        Fu: Future<Output = ()> + Send + 'static,
+    {
+        let token = self.token.clone();
+
+        let handle = tokio::spawn(f(token));
+        let abort_handle = handle.abort_handle();
+        self.handles.push(handle);
+        abort_handle
+    }
+}
+
+/// Edges of the dependency graph of the tasks.
+pub(super) const EDGES: [(TaskName, TaskName); 9] = [
+    (TaskName::Root, TaskName::Metrics),
+    (TaskName::Root, TaskName::BlockFlush),
+    (TaskName::Root, TaskName::SchedulerExtender),
+    (TaskName::BlockFlush, TaskName::AsyncFuse),
+    (TaskName::BlockFlush, TaskName::FuseRequest),
+    (TaskName::FuseRequest, TaskName::AsyncFuse),
+    (TaskName::FuseRequest, TaskName::WriteBack),
+    (TaskName::AsyncFuse, TaskName::Rpc),
+    (TaskName::AsyncFuse, TaskName::WriteBack),
+];

--- a/src/common/task_manager/tests.rs
+++ b/src/common/task_manager/tests.rs
@@ -1,6 +1,7 @@
-#![allow(clippy::unwrap_used)]
+#![allow(clippy::unwrap_used, clippy::default_numeric_fallback)]
 
 use std::collections::HashSet;
+use std::iter;
 use std::sync::Arc;
 
 use itertools::Itertools;
@@ -13,15 +14,15 @@ use crate::common::task_manager::manager::SpawnError;
 use crate::common::task_manager::task::{TaskName, EDGES};
 use crate::common::task_manager::wait_for_shutdown;
 
-#[test]
-fn test_dependency_graph() {
+#[tokio::test]
+async fn test_dependency_graph() {
     let task_manager = TaskManager::new();
-    let edges_dumped: HashSet<_> = task_manager.edges().into_iter().collect();
+    let edges_dumped: HashSet<_> = task_manager.edges().await.into_iter().collect();
     let edges_expected: HashSet<_> = EDGES.into_iter().collect();
 
     assert_eq!(edges_dumped, edges_expected);
 
-    let predecessor_counts_dumped = task_manager.predecessor_counts();
+    let predecessor_counts_dumped = task_manager.predecessor_counts().await;
 
     let mut predecessor_counts_expected = EDGES.iter().counts_by(|&(_, task_name)| task_name);
     predecessor_counts_expected.insert(TaskName::Root, 0);
@@ -30,39 +31,47 @@ fn test_dependency_graph() {
 }
 
 /// Create a future, that waits for a signal from `token`, then sends a
-/// `value` via `sender`.
-async fn test_task(token: CancellationToken, value: i32, sender: mpsc::Sender<i32>) {
+/// `value` via `tx`.
+async fn test_task(token: CancellationToken, value: i32, tx: mpsc::Sender<i32>) {
     token.cancelled().await;
-    sender.send(value).await.unwrap();
+    tx.send(value).await.unwrap();
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn spawn_tasks(task_manager: &TaskManager, sender: mpsc::Sender<i32>) -> anyhow::Result<()> {
+async fn spawn_tasks(task_manager: &TaskManager, tx: mpsc::Sender<i32>) -> anyhow::Result<()> {
     // The order of shutdown:
     // {Root} -> {Metrics, BlockFlush, SchedulerExtender} -> {FuseRequest} ->
     // {AsyncFuse} -> {Rpc, WriteBack}
-    task_manager.spawn(TaskName::Metrics, |token| {
-        test_task(token, 0, sender.clone())
-    })?;
-    task_manager.spawn(TaskName::BlockFlush, |token| {
-        test_task(token, 0, sender.clone())
-    })?;
-    task_manager.spawn(TaskName::SchedulerExtender, |token| {
-        test_task(token, 0, sender.clone())
-    })?;
+    task_manager
+        .spawn(TaskName::Metrics, |token| test_task(token, 0, tx.clone()))
+        .await?;
+    task_manager
+        .spawn(TaskName::BlockFlush, |token| {
+            test_task(token, 0, tx.clone())
+        })
+        .await?;
+    task_manager
+        .spawn(TaskName::SchedulerExtender, |token| {
+            test_task(token, 0, tx.clone())
+        })
+        .await?;
 
-    task_manager.spawn(TaskName::FuseRequest, |token| {
-        test_task(token, 1, sender.clone())
-    })?;
+    task_manager
+        .spawn(TaskName::FuseRequest, |token| {
+            test_task(token, 1, tx.clone())
+        })
+        .await?;
 
-    task_manager.spawn(TaskName::AsyncFuse, |token| {
-        test_task(token, 2, sender.clone())
-    })?;
+    task_manager
+        .spawn(TaskName::AsyncFuse, |token| test_task(token, 2, tx.clone()))
+        .await?;
 
-    task_manager.spawn(TaskName::Rpc, |token| test_task(token, 3, sender.clone()))?;
-    task_manager.spawn(TaskName::WriteBack, |token| {
-        test_task(token, 3, sender.clone())
-    })?;
+    task_manager
+        .spawn(TaskName::Rpc, |token| test_task(token, 3, tx.clone()))
+        .await?;
+    task_manager
+        .spawn(TaskName::WriteBack, |token| test_task(token, 3, tx.clone()))
+        .await?;
 
     Ok(())
 }
@@ -71,13 +80,13 @@ fn spawn_tasks(task_manager: &TaskManager, sender: mpsc::Sender<i32>) -> anyhow:
 async fn test_shutdown() {
     let task_manager = Arc::new(TaskManager::new());
 
-    let (sender, mut receiver) = mpsc::channel(1);
+    let (tx, mut rx) = mpsc::channel(1);
 
-    spawn_tasks(&task_manager, sender).unwrap();
+    spawn_tasks(&task_manager, tx).await.unwrap();
 
     let collector = tokio::spawn(async move {
         let mut result = vec![];
-        while let Some(res) = receiver.recv().await {
+        while let Some(res) = rx.recv().await {
             result.push(res);
         }
         result
@@ -96,13 +105,13 @@ async fn test_shutdown() {
 async fn test_wait_for_shutdown() {
     let task_manager = Arc::new(TaskManager::new());
 
-    let (sender, mut receiver) = mpsc::channel(1);
+    let (tx, mut rx) = mpsc::channel(1);
 
-    spawn_tasks(&task_manager, sender).unwrap();
+    spawn_tasks(&task_manager, tx).await.unwrap();
 
     let collector = tokio::spawn(async move {
         let mut result = vec![];
-        while let Some(res) = receiver.recv().await {
+        while let Some(res) = rx.recv().await {
             result.push(res);
         }
         result
@@ -120,19 +129,60 @@ async fn test_wait_for_shutdown() {
     assert_eq!(result, result_expected);
 }
 
-#[test]
-#[should_panic(expected = "there is no reactor running")]
-fn test_spawn_without_async_runtime() {
-    let task_manager = Arc::new(TaskManager::new());
-    task_manager.spawn(TaskName::Root, |_| async {}).unwrap();
-}
-
 #[tokio::test]
 async fn test_spawn_after_shutdown() {
     let task_manager = Arc::new(TaskManager::new());
     Arc::clone(&task_manager).shutdown().await;
     let err = task_manager
         .spawn(TaskName::Root, |_| async {})
+        .await
         .unwrap_err();
     assert_eq!(err, SpawnError(TaskName::Root));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_gc_handle() {
+    let task_manager = Arc::new(TaskManager::new());
+
+    let block_flush_handle = task_manager
+        .get_gc_handle(TaskName::BlockFlush)
+        .await
+        .unwrap();
+    let fuse_request_handle = task_manager
+        .get_gc_handle(TaskName::FuseRequest)
+        .await
+        .unwrap();
+
+    let (tx, mut rx) = mpsc::channel(1);
+
+    for _ in 0..5 {
+        block_flush_handle
+            .spawn(|token| test_task(token, 0, tx.clone()))
+            .await
+            .unwrap();
+        fuse_request_handle
+            .spawn(|token| test_task(token, 1, tx.clone()))
+            .await
+            .unwrap();
+    }
+
+    drop(tx);
+
+    let collector = tokio::spawn(async move {
+        let mut result = vec![];
+        while let Some(res) = rx.recv().await {
+            result.push(res);
+        }
+        result
+    });
+
+    task_manager.shutdown().await;
+
+    let result = collector.await.unwrap();
+
+    let result_expected = iter::repeat(0)
+        .take(5)
+        .chain(iter::repeat(1).take(5))
+        .collect_vec();
+    assert_eq!(result, result_expected);
 }

--- a/src/common/task_manager/tests.rs
+++ b/src/common/task_manager/tests.rs
@@ -1,0 +1,138 @@
+#![allow(clippy::unwrap_used)]
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use itertools::Itertools;
+use nix::sys::signal::Signal::SIGTERM;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use super::TaskManager;
+use crate::common::task_manager::manager::SpawnError;
+use crate::common::task_manager::task::{TaskName, EDGES};
+use crate::common::task_manager::wait_for_shutdown;
+
+#[test]
+fn test_dependency_graph() {
+    let task_manager = TaskManager::new();
+    let edges_dumped: HashSet<_> = task_manager.edges().into_iter().collect();
+    let edges_expected: HashSet<_> = EDGES.into_iter().collect();
+
+    assert_eq!(edges_dumped, edges_expected);
+
+    let predecessor_counts_dumped = task_manager.predecessor_counts();
+
+    let mut predecessor_counts_expected = EDGES.iter().counts_by(|&(_, task_name)| task_name);
+    predecessor_counts_expected.insert(TaskName::Root, 0);
+
+    assert_eq!(predecessor_counts_dumped, predecessor_counts_expected);
+}
+
+/// Create a future, that waits for a signal from `token`, then sends a
+/// `value` via `sender`.
+async fn test_task(token: CancellationToken, value: i32, sender: mpsc::Sender<i32>) {
+    token.cancelled().await;
+    sender.send(value).await.unwrap();
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn spawn_tasks(task_manager: &TaskManager, sender: mpsc::Sender<i32>) -> anyhow::Result<()> {
+    // The order of shutdown:
+    // {Root} -> {Metrics, BlockFlush, SchedulerExtender} -> {FuseRequest} ->
+    // {AsyncFuse} -> {Rpc, WriteBack}
+    task_manager.spawn(TaskName::Metrics, |token| {
+        test_task(token, 0, sender.clone())
+    })?;
+    task_manager.spawn(TaskName::BlockFlush, |token| {
+        test_task(token, 0, sender.clone())
+    })?;
+    task_manager.spawn(TaskName::SchedulerExtender, |token| {
+        test_task(token, 0, sender.clone())
+    })?;
+
+    task_manager.spawn(TaskName::FuseRequest, |token| {
+        test_task(token, 1, sender.clone())
+    })?;
+
+    task_manager.spawn(TaskName::AsyncFuse, |token| {
+        test_task(token, 2, sender.clone())
+    })?;
+
+    task_manager.spawn(TaskName::Rpc, |token| test_task(token, 3, sender.clone()))?;
+    task_manager.spawn(TaskName::WriteBack, |token| {
+        test_task(token, 3, sender.clone())
+    })?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_shutdown() {
+    let task_manager = Arc::new(TaskManager::new());
+
+    let (sender, mut receiver) = mpsc::channel(1);
+
+    spawn_tasks(&task_manager, sender).unwrap();
+
+    let collector = tokio::spawn(async move {
+        let mut result = vec![];
+        while let Some(res) = receiver.recv().await {
+            result.push(res);
+        }
+        result
+    });
+
+    task_manager.shutdown().await;
+
+    let result = collector.await.unwrap();
+
+    let result_expected: &[i32] = &[0, 0, 0, 1, 2, 3, 3];
+    // All tasks will be shutted down in a certain order.
+    assert_eq!(result, result_expected);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_wait_for_shutdown() {
+    let task_manager = Arc::new(TaskManager::new());
+
+    let (sender, mut receiver) = mpsc::channel(1);
+
+    spawn_tasks(&task_manager, sender).unwrap();
+
+    let collector = tokio::spawn(async move {
+        let mut result = vec![];
+        while let Some(res) = receiver.recv().await {
+            result.push(res);
+        }
+        result
+    });
+
+    let waiting = tokio::spawn(wait_for_shutdown(task_manager).unwrap());
+
+    nix::sys::signal::raise(SIGTERM).unwrap();
+    waiting.await.unwrap();
+
+    let result = collector.await.unwrap();
+
+    let result_expected: &[i32] = &[0, 0, 0, 1, 2, 3, 3];
+    // All tasks will be shutted down in a certain order.
+    assert_eq!(result, result_expected);
+}
+
+#[test]
+#[should_panic(expected = "there is no reactor running")]
+fn test_spawn_without_async_runtime() {
+    let task_manager = Arc::new(TaskManager::new());
+    task_manager.spawn(TaskName::Root, |_| async {}).unwrap();
+}
+
+#[tokio::test]
+async fn test_spawn_after_shutdown() {
+    let task_manager = Arc::new(TaskManager::new());
+    Arc::clone(&task_manager).shutdown().await;
+    let err = task_manager
+        .spawn(TaskName::Root, |_| async {})
+        .unwrap_err();
+    assert_eq!(err, SpawnError(TaskName::Root));
+}

--- a/src/common/task_manager/tests.rs
+++ b/src/common/task_manager/tests.rs
@@ -12,7 +12,7 @@ use tokio_util::sync::CancellationToken;
 use super::TaskManager;
 use crate::common::task_manager::manager::SpawnError;
 use crate::common::task_manager::task::{TaskName, EDGES};
-use crate::common::task_manager::wait_for_shutdown;
+use crate::common::task_manager::{wait_for_shutdown, TASK_MANAGER};
 
 #[tokio::test]
 async fn test_dependency_graph() {
@@ -103,11 +103,11 @@ async fn test_shutdown() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_wait_for_shutdown() {
-    let task_manager = Arc::new(TaskManager::new());
+    let task_manager = &*TASK_MANAGER;
 
     let (tx, mut rx) = mpsc::channel(1);
 
-    spawn_tasks(&task_manager, tx).await.unwrap();
+    spawn_tasks(task_manager, tx).await.unwrap();
 
     let collector = tokio::spawn(async move {
         let mut result = vec![];


### PR DESCRIPTION
In this PR, we managed asynchronous tasks with the `TaskManager` introduced in #478. 