### PR TITLE
refactor: decouple fs storage from metadata

### DIFF
--- a/src/async_fuse/mod.rs
+++ b/src/async_fuse/mod.rs
@@ -56,6 +56,8 @@ pub async fn start_async_fuse(
         StorageManager::new(memory_cache, block_size)
     };
 
+    let storage = Arc::new(storage);
+
     let fs: memfs::MemFs<memfs::S3MetaData> = memfs::MemFs::new(
         &args.mount_dir,
         global_cache_capacity,

--- a/src/async_fuse/test/test_util.rs
+++ b/src/async_fuse/test/test_util.rs
@@ -80,6 +80,7 @@ async fn run_fs(mount_point: &Path, is_s3: bool, token: CancellationToken) -> an
         StorageManager::new(memory_cache, block_size)
     };
 
+    let storage = Arc::new(storage);
     let fs: memfs::MemFs<memfs::S3MetaData> = memfs::MemFs::new(
         mount_point
             .as_os_str()

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,9 +85,8 @@ use clap::Parser;
 use csi::meta_data::MetaData;
 use csi::scheduler_extender::SchedulerExtender;
 use datenlord::common::task_manager::{self, TaskName, TASK_MANAGER};
-use datenlord::config;
 use datenlord::config::{InnerConfig, NodeRole, StorageConfig};
-use datenlord::metrics;
+use datenlord::{config, metrics};
 
 use crate::common::error::DatenLordResult;
 use crate::common::etcd_delegate::EtcdDelegate;

--- a/src/metrics/server.rs
+++ b/src/metrics/server.rs
@@ -5,8 +5,7 @@ use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Request, Response, Server};
 use prometheus::{Encoder, TextEncoder};
 use tokio_util::sync::CancellationToken;
-use tracing::debug;
-use tracing::info;
+use tracing::{debug, info};
 
 use super::DATENLORD_REGISTRY;
 


### PR DESCRIPTION
## Summary

This pull request refactors the `Memfs`  by decouplethe `Metadata`'s storage. This change creates a clearer separation of responsibilities, improving maintainability and facilitating future iterations.

## Changes

- Decouple `Storage` storage logic from `S3Metadata` 
- Adjusted `Memfs` to interface with the new `Metadata` structure and storage operations.

During the separation process, I've identified that **error handling** was poorly structured, which significantly hindered the developer experience. 
