### PR TITLE
feat: make FUSE device IO asynchronous

### DIFF
--- a/src/async_fuse/fuse/file_system.rs
+++ b/src/async_fuse/fuse/file_system.rs
@@ -31,32 +31,32 @@ pub trait FileSystem {
         req: &Request<'_>,
         parent: INum,
         name: &str,
-        reply: ReplyEntry,
+        reply: ReplyEntry<'_>,
     ) -> nix::Result<usize>;
 
     /// Forget about an inode
     async fn forget(&self, req: &Request<'_>, nlookup: u64);
 
     /// Get file attributes.
-    async fn getattr(&self, req: &Request<'_>, reply: ReplyAttr) -> nix::Result<usize>;
+    async fn getattr(&self, req: &Request<'_>, reply: ReplyAttr<'_>) -> nix::Result<usize>;
 
     /// Set file attributes.
     async fn setattr(
         &self,
         req: &Request<'_>,
         param: SetAttrParam,
-        reply: ReplyAttr,
+        reply: ReplyAttr<'_>,
     ) -> nix::Result<usize>;
 
     /// Read symbolic link.
-    async fn readlink(&self, req: &Request<'_>, reply: ReplyData) -> nix::Result<usize>;
+    async fn readlink(&self, req: &Request<'_>, reply: ReplyData<'_>) -> nix::Result<usize>;
 
     /// Create file node.
     async fn mknod(
         &self,
         req: &Request<'_>,
         param: CreateParam,
-        reply: ReplyEntry,
+        reply: ReplyEntry<'_>,
     ) -> nix::Result<usize>;
 
     /// Create a directory
@@ -66,7 +66,7 @@ pub trait FileSystem {
         parent: INum,
         name: &str,
         mode: u32,
-        reply: ReplyEntry,
+        reply: ReplyEntry<'_>,
     ) -> nix::Result<usize>;
 
     /// Remove a file
@@ -75,7 +75,7 @@ pub trait FileSystem {
         req: &Request<'_>,
         parent: INum,
         name: &str,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize>;
 
     /// Remove a directory
@@ -84,7 +84,7 @@ pub trait FileSystem {
         req: &Request<'_>,
         parent: INum,
         name: &str,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize>;
 
     /// Create a symbolic link
@@ -94,7 +94,7 @@ pub trait FileSystem {
         parent: INum,
         name: &str,
         target_path: &Path,
-        reply: ReplyEntry,
+        reply: ReplyEntry<'_>,
     ) -> nix::Result<usize>;
 
     /// Rename a file
@@ -102,7 +102,7 @@ pub trait FileSystem {
         &self,
         req: &Request<'_>,
         param: RenameParam,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize>;
 
     /// Create a hard link
@@ -111,11 +111,12 @@ pub trait FileSystem {
         _req: &Request<'_>,
         _newparent: u64,
         _newname: &str,
-        reply: ReplyEntry,
+        reply: ReplyEntry<'_>,
     ) -> nix::Result<usize>;
 
     /// Open a file
-    async fn open(&self, req: &Request<'_>, flags: u32, reply: ReplyOpen) -> nix::Result<usize>;
+    async fn open(&self, req: &Request<'_>, flags: u32, reply: ReplyOpen<'_>)
+        -> nix::Result<usize>;
 
     /// Read data
     async fn read(
@@ -124,7 +125,7 @@ pub trait FileSystem {
         fh: u64,
         offset: i64,
         size: u32,
-        reply: ReplyData,
+        reply: ReplyData<'_>,
     ) -> nix::Result<usize>;
 
     /// Write data
@@ -135,7 +136,7 @@ pub trait FileSystem {
         offset: i64,
         data: Vec<u8>,
         flags: u32,
-        reply: ReplyWrite,
+        reply: ReplyWrite<'_>,
     ) -> nix::Result<usize>;
 
     /// Flush method
@@ -144,7 +145,7 @@ pub trait FileSystem {
         req: &Request<'_>,
         fh: u64,
         lock_owner: u64,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize>;
 
     /// Release an open file
@@ -155,7 +156,7 @@ pub trait FileSystem {
         flags: u32, // same as the open flags
         lock_owner: u64,
         flush: bool,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize>;
 
     /// Synchronize file contents
@@ -164,11 +165,16 @@ pub trait FileSystem {
         req: &Request<'_>,
         fh: u64,
         datasync: bool,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize>;
 
     /// Open a directory
-    async fn opendir(&self, req: &Request<'_>, flags: u32, reply: ReplyOpen) -> nix::Result<usize>;
+    async fn opendir(
+        &self,
+        req: &Request<'_>,
+        flags: u32,
+        reply: ReplyOpen<'_>,
+    ) -> nix::Result<usize>;
 
     /// Read directory
     async fn readdir(
@@ -176,7 +182,7 @@ pub trait FileSystem {
         req: &Request<'_>,
         fh: u64,
         offset: i64,
-        mut reply: ReplyDirectory,
+        mut reply: ReplyDirectory<'_>,
     ) -> nix::Result<usize>;
 
     /// Release an open directory
@@ -185,7 +191,7 @@ pub trait FileSystem {
         req: &Request<'_>,
         fh: u64,
         flags: u32,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize>;
 
     /// Synchronize directory contents
@@ -194,11 +200,11 @@ pub trait FileSystem {
         req: &Request<'_>,
         fh: u64,
         datasync: bool,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize>;
 
     /// Get file system statistics
-    async fn statfs(&self, req: &Request<'_>, reply: ReplyStatFs) -> nix::Result<usize>;
+    async fn statfs(&self, req: &Request<'_>, reply: ReplyStatFs<'_>) -> nix::Result<usize>;
 
     /// Set an extended attribute
     async fn setxattr(
@@ -208,7 +214,7 @@ pub trait FileSystem {
         _value: &[u8],
         _flags: u32,
         _position: u32,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize>;
 
     /// Get an extended attribute
@@ -217,7 +223,7 @@ pub trait FileSystem {
         _req: &Request<'_>,
         _name: &str,
         _size: u32,
-        reply: ReplyXAttr,
+        reply: ReplyXAttr<'_>,
     ) -> nix::Result<usize>;
 
     /// Get an extended attribute
@@ -225,7 +231,7 @@ pub trait FileSystem {
         &self,
         _req: &Request<'_>,
         _size: u32,
-        reply: ReplyXAttr,
+        reply: ReplyXAttr<'_>,
     ) -> nix::Result<usize>;
 
     /// Remove an extended attribute
@@ -233,12 +239,16 @@ pub trait FileSystem {
         &self,
         _req: &Request<'_>,
         _name: &str,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize>;
 
     /// Check file access permissions
-    async fn access(&self, _req: &Request<'_>, _mask: u32, reply: ReplyEmpty)
-        -> nix::Result<usize>;
+    async fn access(
+        &self,
+        _req: &Request<'_>,
+        _mask: u32,
+        reply: ReplyEmpty<'_>,
+    ) -> nix::Result<usize>;
 
     /// Create and open a file
     async fn create(
@@ -248,7 +258,7 @@ pub trait FileSystem {
         _name: &str,
         _mode: u32,
         _flags: u32,
-        reply: ReplyCreate,
+        reply: ReplyCreate<'_>,
     ) -> nix::Result<usize>;
 
     /// Test for a POSIX file lock
@@ -256,7 +266,7 @@ pub trait FileSystem {
         &self,
         _req: &Request<'_>,
         _lk_param: FileLockParam,
-        reply: ReplyLock,
+        reply: ReplyLock<'_>,
     ) -> nix::Result<usize>;
 
     /// Acquire, modify or release a POSIX file lock
@@ -265,7 +275,7 @@ pub trait FileSystem {
         _req: &Request<'_>,
         _lk_param: FileLockParam,
         _sleep: bool,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize>;
 
     /// Map block index within file to block index within device
@@ -274,9 +284,8 @@ pub trait FileSystem {
         _req: &Request<'_>,
         _blocksize: u32,
         _idx: u64,
-        reply: ReplyBMap,
+        reply: ReplyBMap<'_>,
     ) -> nix::Result<usize>;
-
     /// Set fuse fd into `FileSystem`
     async fn set_fuse_fd(&self, fuse_fd: RawFd);
 }

--- a/src/async_fuse/fuse/protocol.rs
+++ b/src/async_fuse/fuse/protocol.rs
@@ -221,7 +221,6 @@ pub mod setattr_flags {
 use std::mem;
 
 use clippy_utilities::{Cast, OverflowArithmetic};
-use nix::request_code_read;
 pub use setattr_flags::*;
 
 /// Flags returned by the OPEN request
@@ -1437,19 +1436,6 @@ pub struct FuseNotifyRetrieveIn {
     pub dummy4: u64,
 }
 
-/// A device ioctl command.
-///
-/// It's defined as below in `fuse.h`:
-///
-/// ```c
-/// #define FUSE_DEV_IOC_CLONE    _IOR(229, 0, uint32_t)
-/// ```
-///
-/// <https://github.com/torvalds/linux/blob/00c570f4ba43ae73b41fa0a2269c3b0ac20386ef/include/uapi/linux/fuse.h#L759>
-///
-/// This constant is unused now, but reserved for the future.
-#[allow(dead_code)]
-const FUSE_DEV_IOC_CLONE: u64 = request_code_read!(229, 0, mem::size_of::<u32>());
 /// FUSE lseek request input `fuse_lseek_in`
 // #[cfg(feature = "abi-7-24")]
 #[derive(Debug)]

--- a/src/async_fuse/memfs/mod.rs
+++ b/src/async_fuse/memfs/mod.rs
@@ -210,7 +210,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         req: &Request<'_>,
         parent: INum,
         name: &str,
-        reply: ReplyEntry,
+        reply: ReplyEntry<'_>,
     ) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("lookup");
         debug!("lookup(parent={}, name={:?}, req={:?})", parent, name, req,);
@@ -230,7 +230,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
     }
 
     /// Get file attributes.
-    async fn getattr(&self, req: &Request<'_>, reply: ReplyAttr) -> nix::Result<usize> {
+    async fn getattr(&self, req: &Request<'_>, reply: ReplyAttr<'_>) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("getattr");
         let ino = req.nodeid();
         debug!("getattr(ino={}, req={:?})", ino, req);
@@ -259,7 +259,12 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
     /// anything in fh. There are also some flags (`direct_io`, `keep_cache`)
     /// which the filesystem may set, to change the way the file is opened.
     /// See `fuse_file_info` structure in `fuse_common.h` for more details.
-    async fn open(&self, req: &Request<'_>, flags: u32, reply: ReplyOpen) -> nix::Result<usize> {
+    async fn open(
+        &self,
+        req: &Request<'_>,
+        flags: u32,
+        reply: ReplyOpen<'_>,
+    ) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("open");
         let ino = req.nodeid();
         debug!("open(ino={}, flags={}, req={:?})", ino, flags, req);
@@ -314,7 +319,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         &self,
         req: &Request<'_>,
         param: SetAttrParam,
-        reply: ReplyAttr,
+        reply: ReplyAttr<'_>,
     ) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("setattr");
         let ino = req.nodeid();
@@ -348,7 +353,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         &self,
         req: &Request<'_>,
         param: CreateParam,
-        reply: ReplyEntry,
+        reply: ReplyEntry<'_>,
     ) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("mknod");
         debug!("mknod param = {:?}, req = {:?}", param, req);
@@ -369,7 +374,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         parent: INum,
         name: &str,
         mode: u32,
-        reply: ReplyEntry,
+        reply: ReplyEntry<'_>,
     ) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("mkdir");
         debug!(
@@ -416,7 +421,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         req: &Request<'_>,
         parent: INum,
         name: &str,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("unlink");
         debug!("unlink(parent={}, name={:?}, req={:?}", parent, name, req,);
@@ -453,7 +458,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         req: &Request<'_>,
         parent: INum,
         dir_name: &str,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("rmdir");
         // check the dir_name is valid
@@ -499,7 +504,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         &self,
         req: &Request<'_>,
         param: RenameParam,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("rename");
         let context = ReqContext {
@@ -529,7 +534,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         _fh: u64,
         offset: i64,
         size: u32,
-        reply: ReplyData,
+        reply: ReplyData<'_>,
     ) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("read");
         let ino = req.nodeid();
@@ -579,7 +584,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         offset: i64,
         data: Vec<u8>,
         _flags: u32,
-        reply: ReplyWrite,
+        reply: ReplyWrite<'_>,
     ) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("write");
         let ino = req.nodeid();
@@ -625,7 +630,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         req: &Request<'_>,
         fh: u64,
         lock_owner: u64,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("flush");
         let ino = req.nodeid();
@@ -661,7 +666,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         flags: u32, // same as the open flags
         lock_owner: u64,
         flush: bool,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("release");
         let ino = req.nodeid();
@@ -689,7 +694,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         req: &Request<'_>,
         _fh: u64,
         _datasync: bool,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("fsync");
         let ino = req.nodeid();
@@ -707,7 +712,12 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
     /// makes it impossible to implement standard conforming
     /// directory stream operations in case the contents of the directory can
     /// change between opendir and releasedir.
-    async fn opendir(&self, req: &Request<'_>, flags: u32, reply: ReplyOpen) -> nix::Result<usize> {
+    async fn opendir(
+        &self,
+        req: &Request<'_>,
+        flags: u32,
+        reply: ReplyOpen<'_>,
+    ) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("opendir");
         let ino = req.nodeid();
         debug!("opendir(ino={}, flags={}, req={:?})", ino, flags, req,);
@@ -746,7 +756,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         req: &Request<'_>,
         fh: u64,
         offset: i64,
-        mut reply: ReplyDirectory,
+        mut reply: ReplyDirectory<'_>,
     ) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("readdir");
         let ino = req.nodeid();
@@ -781,7 +791,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         req: &Request<'_>,
         fh: u64,
         flags: u32,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("releasedir");
         let ino = req.nodeid();
@@ -808,18 +818,18 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         req: &Request<'_>,
         _fh: u64,
         _datasync: bool,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("fsyncdir");
 
-        // Similarity to rmdir, we don't store dir information in the persistent storage,
-        // so we don't need to flush it
+        // Similarity to rmdir, we don't store dir information in the persistent
+        // storage, so we don't need to flush it
         reply.ok().await
     }
 
     /// Get file system statistics.
     /// The `f_favail`, `f_fsid` and `f_flag` fields are ignored
-    async fn statfs(&self, req: &Request<'_>, reply: ReplyStatFs) -> nix::Result<usize> {
+    async fn statfs(&self, req: &Request<'_>, reply: ReplyStatFs<'_>) -> nix::Result<usize> {
         let ino = if req.nodeid() == 0 {
             FUSE_ROOT_ID
         } else {
@@ -849,7 +859,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
     }
 
     /// Read symbolic link.
-    async fn readlink(&self, req: &Request<'_>, reply: ReplyData) -> nix::Result<usize> {
+    async fn readlink(&self, req: &Request<'_>, reply: ReplyData<'_>) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("readlink");
         let ino = req.nodeid();
         debug!("readlink(ino={}, req={:?})", ino, req,);
@@ -870,7 +880,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         parent: INum,
         name: &str,
         target_path: &Path,
-        reply: ReplyEntry,
+        reply: ReplyEntry<'_>,
     ) -> nix::Result<usize> {
         let _timer = FILESYSTEM_METRICS.start_storage_operation_timer("symlink");
         debug!(
@@ -928,7 +938,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         _req: &Request<'_>,
         _newparent: u64,
         _newname: &str,
-        reply: ReplyEntry,
+        reply: ReplyEntry<'_>,
     ) -> nix::Result<usize> {
         reply.error_code(Errno::ENOSYS).await
     }
@@ -941,7 +951,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         _value: &[u8],
         _flags: u32,
         _position: u32,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize> {
         reply.error_code(Errno::ENOSYS).await
     }
@@ -955,7 +965,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         _req: &Request<'_>,
         _name: &str,
         _size: u32,
-        reply: ReplyXAttr,
+        reply: ReplyXAttr<'_>,
     ) -> nix::Result<usize> {
         reply.error_code(Errno::ENOSYS).await
     }
@@ -968,7 +978,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         &self,
         _req: &Request<'_>,
         _size: u32,
-        reply: ReplyXAttr,
+        reply: ReplyXAttr<'_>,
     ) -> nix::Result<usize> {
         reply.error_code(Errno::ENOSYS).await
     }
@@ -978,7 +988,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         &self,
         _req: &Request<'_>,
         _name: &str,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize> {
         reply.error_code(Errno::ENOSYS).await
     }
@@ -991,7 +1001,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         &self,
         _req: &Request<'_>,
         _mask: u32,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize> {
         reply.error_code(Errno::ENOSYS).await
     }
@@ -1014,7 +1024,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         _name: &str,
         _mode: u32,
         _flags: u32,
-        reply: ReplyCreate,
+        reply: ReplyCreate<'_>,
     ) -> nix::Result<usize> {
         reply.error_code(Errno::ENOSYS).await
     }
@@ -1024,7 +1034,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         &self,
         _req: &Request<'_>,
         _lk_param: FileLockParam,
-        reply: ReplyLock,
+        reply: ReplyLock<'_>,
     ) -> nix::Result<usize> {
         reply.error_code(Errno::ENOSYS).await
     }
@@ -1042,7 +1052,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         _req: &Request<'_>,
         _lk_param: FileLockParam,
         _sleep: bool,
-        reply: ReplyEmpty,
+        reply: ReplyEmpty<'_>,
     ) -> nix::Result<usize> {
         reply.error_code(Errno::ENOSYS).await
     }
@@ -1055,7 +1065,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         _req: &Request<'_>,
         _blocksize: u32,
         _idx: u64,
-        reply: ReplyBMap,
+        reply: ReplyBMap<'_>,
     ) -> nix::Result<usize> {
         reply.error_code(Errno::ENOSYS).await
     }

--- a/src/storage/block.rs
+++ b/src/storage/block.rs
@@ -1,14 +1,14 @@
 //! Utilities for blocks.
 
 use std::fmt::Formatter;
+use std::io::IoSlice;
 use std::sync::Arc;
 
 use aligned_utils::bytes::AlignedBytes;
 use clippy_utilities::OverflowArithmetic;
-use nix::sys::uio::IoVec;
 
 use super::StorageError;
-use crate::async_fuse::fuse::fuse_reply::{AsIoVec, CouldBeAsIoVecList};
+use crate::async_fuse::fuse::fuse_reply::{AsIoSlice, CouldBeAsIoSliceList};
 use crate::async_fuse::fuse::protocol::INum;
 
 /// Page Size
@@ -239,11 +239,11 @@ impl Block {
     }
 }
 
-impl CouldBeAsIoVecList for Block {}
+impl CouldBeAsIoSliceList for Block {}
 
-impl AsIoVec for Block {
-    fn as_io_vec(&self) -> IoVec<&[u8]> {
-        IoVec::from_slice(self.as_slice())
+impl AsIoSlice for Block {
+    fn as_io_slice(&self) -> IoSlice {
+        IoSlice::new(self.as_slice())
     }
 
     fn can_convert(&self) -> bool {
@@ -265,7 +265,7 @@ mod tests {
     use clippy_utilities::OverflowArithmetic;
 
     use super::{Arc, Block};
-    use crate::async_fuse::fuse::fuse_reply::AsIoVec;
+    use crate::async_fuse::fuse::fuse_reply::AsIoSlice;
 
     const BLOCK_SIZE_IN_BYTES: usize = 8;
     const BLOCK_CONTENT: &[u8; BLOCK_SIZE_IN_BYTES] = b"foo bar ";

--- a/src/storage/storage_manager/test/concurrency.rs
+++ b/src/storage/storage_manager/test/concurrency.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, SystemTime};
 use clippy_utilities::OverflowArithmetic;
 use crossbeam_utils::atomic::AtomicCell;
 
-use crate::async_fuse::fuse::fuse_reply::AsIoVec;
+use crate::async_fuse::fuse::fuse_reply::AsIoSlice;
 use crate::storage::policy::LruPolicy;
 use crate::storage::{
     Block, BlockCoordinate, MemoryCacheBuilder, MemoryStorage, Storage, StorageManager,


### PR DESCRIPTION
In this PR, we avoided to use raw FUSE fd to interact with FUSE kernel module, by wrapping the raw fd with `std::fs::File`. And separated threads are used to receive FUSE requests, for avoiding invoking `spawn_blocking` always.

`IoVec` is deprecated, we use `std::io::IoSlice` now.

Besides, in this PR, we use `worker fd` for each FUSE request handlers, reducing potential resources race.