### PR TITLE
fix: fix aws s3 concurrency issue.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ localtest.sh
 *.log
 
 tests/fstest_dir/fstest
+
+# Current cargo config
+.cargo/config

--- a/src/async_fuse/mod.rs
+++ b/src/async_fuse/mod.rs
@@ -34,7 +34,9 @@ pub async fn start_async_fuse(
         let block_size = storage_config.block_size;
         let capacity_in_blocks = memory_cache_config.capacity.overflow_div(block_size);
 
-        let backend = BackendBuilder::new(storage_param.clone(), block_size).build()?;
+        let backend = BackendBuilder::new(storage_param.clone(), block_size)
+            .build()
+            .await?;
         let lru_policy = LruPolicy::<BlockCoordinate>::new(capacity_in_blocks);
         let memory_cache = MemoryCacheBuilder::new(lru_policy, backend, block_size)
             .command_queue_limit(memory_cache_config.command_queue_limit)

--- a/src/async_fuse/test/test_util.rs
+++ b/src/async_fuse/test/test_util.rs
@@ -35,6 +35,8 @@ fn test_storage_config(is_s3: bool) -> StorageConfig {
             access_key_id: "test".to_owned(),
             secret_access_key: "test1234".to_owned(),
             bucket_name: "fuse-test-bucket".to_owned(),
+            region: None,
+            max_concurrent_requests: None,
         };
 
         StorageParams::S3(s3_config)

--- a/src/async_fuse/test/test_util.rs
+++ b/src/async_fuse/test/test_util.rs
@@ -70,7 +70,9 @@ async fn run_fs(mount_point: &Path, is_s3: bool, token: CancellationToken) -> an
         let block_size = storage_config.block_size;
         let capacity_in_blocks = memory_cache_config.capacity.overflow_div(block_size);
 
-        let backend = BackendBuilder::new(storage_param.clone(), block_size).build()?;
+        let backend = BackendBuilder::new(storage_param.clone(), block_size)
+            .build()
+            .await?;
         let lru_policy = LruPolicy::<BlockCoordinate>::new(capacity_in_blocks);
         let memory_cache = MemoryCacheBuilder::new(lru_policy, backend, block_size)
             .command_queue_limit(memory_cache_config.command_queue_limit)

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -139,6 +139,12 @@ pub struct S3StorageConfig {
     #[clap(long = "storage-s3-bucket", value_name = "VALUE", default_value_t)]
     /// The bucket name of s3 storage
     pub bucket_name: String,
+    /// The region of s3 storage
+    #[clap(long = "storage-s3-region", value_name = "VALUE")]
+    pub region: Option<String>,
+    /// S3 Max concurrent requests
+    #[clap(long = "storage-s3-max-concurrent-requests", value_name = "VALUE")]
+    pub max_concurrent_requests: Option<usize>,
 }
 
 /// CSI related config

--- a/src/config/inner.rs
+++ b/src/config/inner.rs
@@ -276,6 +276,10 @@ pub struct StorageS3Config {
     pub secret_access_key: String,
     /// Bucket name
     pub bucket_name: String,
+    /// Region
+    pub region: Option<String>,
+    /// Max concurrent requests
+    pub max_concurrent_requests: Option<usize>,
 }
 
 impl TryFrom<SuperS3StorageConfig> for StorageS3Config {
@@ -288,6 +292,8 @@ impl TryFrom<SuperS3StorageConfig> for StorageS3Config {
             access_key_id: value.access_key_id,
             secret_access_key: value.secret_access_key,
             bucket_name: value.bucket_name,
+            region: value.region,
+            max_concurrent_requests: value.max_concurrent_requests,
         })
     }
 }


### PR DESCRIPTION
Current `backend_impl` spawn task without limit, it may cause rate limit issue:

https://repost.aws/questions/QU_F-UC6-fSdOYzp-gZSDTvQ/receiving-s3-503-slow-down-responses

we need to set concurrent num in write tasks.
