### PR TITLE
fix: skip req for log.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,8 @@ jobs:
       - name: Print Integration Test Logs
         run: cat datenlord_test.log
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: codecov.info
-          fail_ci_if_error: true
+          verbose: true

--- a/src/async_fuse/fuse/session.rs
+++ b/src/async_fuse/fuse/session.rs
@@ -502,7 +502,7 @@ impl<F: FileSystem + Send + Sync + 'static> Session<F> {
 /// This calls the appropriate filesystem operation method for the
 /// request and sends back the returned reply to the kernel
 #[allow(clippy::too_many_lines)]
-#[instrument(name="request",skip(req, file, fs), fields(fuse_id =req.unique(),ino=req.nodeid()),ret)]
+#[instrument(name="request",skip(req, file, fs), fields(fuse_id =req.unique(),ino=req.nodeid(), len=req.len()),ret)]
 async fn dispatch<'a>(
     req: &'a Request<'a>,
     file: &mut File,
@@ -675,6 +675,7 @@ async fn dispatch<'a>(
                 .await
         }
         Operation::Write { arg, data } => {
+            info!("operation:write: {:?}", arg);
             assert_eq!(data.len(), arg.size.cast::<usize>());
             let reply = ReplyWrite::new(req.unique(), file);
             fs.write(

--- a/src/async_fuse/memfs/mod.rs
+++ b/src/async_fuse/memfs/mod.rs
@@ -575,7 +575,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
     /// call will reflect the return value of self operation. fh will
     /// contain the value set by the open method, or will be undefined if
     /// the open method did not set any value.
-    #[instrument(skip(self, data), err, ret)]
+    #[instrument(skip(self, data, req), err, ret)]
     async fn write(
         &self,
         req: &Request<'_>,

--- a/src/common/logger.rs
+++ b/src/common/logger.rs
@@ -62,7 +62,7 @@ pub fn init_logger(role: LogRole) {
         .with_target("hyper", Level::WARN)
         .with_target("h2", Level::WARN)
         .with_target("tower", Level::WARN)
-        .with_target("datenlord::async_fuse::fuse", Level::WARN)
+        .with_target("datenlord::async_fuse::fuse", Level::INFO)
         .with_target("datenlord::metrics", Level::INFO)
         .with_target("", Level::INFO);
 


### PR DESCRIPTION
Current debug mode will print a lot of `data` in fuse request, when we write/flush a `1G` file, it will produce over `16G` log file.

We need to skip the `req` in MemFs::write by tracing::instrument.