### PR TITLE
feat(cache node): enhance etcd client for cluster manager.

### DIFF
--- a/src/async_fuse/memfs/kv_engine/etcd_impl.rs
+++ b/src/async_fuse/memfs/kv_engine/etcd_impl.rs
@@ -1,18 +1,341 @@
-use std::collections::HashMap;
 use std::fmt::Debug;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::Poll;
 use std::time::Duration;
+use std::vec;
+use std::{collections::HashMap, sync::Arc};
 
+use anyhow::Context;
 use async_trait::async_trait;
+use datenlord::common::task_manager::{TaskName, TASK_MANAGER};
 use datenlord::metrics::KV_METRICS;
 use etcd_client::{
     Compare, CompareOp, DeleteOptions, GetOptions, LockOptions, PutOptions, Txn, TxnOp,
+    TxnOpResponse,
 };
+use futures::{task, Stream, StreamExt};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, warn};
 
 use super::{
     check_ttl, conv_u64_sec_2_i64, fmt, DeleteOption, KVEngine, KeyType, KvVersion, LockKeyType,
     MetaTxn, SetOption, ValueType,
 };
-use crate::common::error::{Context, DatenLordResult};
+use crate::common::error::DatenLordResult;
+
+/// Revoke the lease
+macro_rules! revoke_lease {
+    ($client:expr, $lease_id:expr) => {
+        match $client.lease_revoke($lease_id).await {
+            Ok(_) => {
+                info!("lease revoke success, lease_id={}", $lease_id);
+            }
+            Err(e) => {
+                warn!("failed to revoke lease, error={:?}", e);
+            }
+        }
+    };
+}
+
+/// The keepalive session struct
+#[derive(Clone)]
+pub struct Session {
+    /// close_tx is the sender to close the keep alive session
+    close_tx: mpsc::Sender<()>,
+    /// The session inner
+    inner: Arc<SessionInner>,
+}
+
+impl Debug for Session {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl Session {
+    /// Create a new session
+    pub async fn new(
+        client: etcd_client::Client,
+        ttl: u64,
+        lease_id: i64,
+    ) -> DatenLordResult<Arc<Self>> {
+        let closed = AtomicBool::new(false);
+        let inner = Arc::new(SessionInner {
+            closed,
+            lease_id,
+            ttl,
+            client,
+        });
+        let (close_tx, close_rx) = mpsc::channel(1);
+
+        let inner_clone = Arc::clone(&inner);
+        TASK_MANAGER
+            .spawn(TaskName::EtcdKeepAlive, |token| async move {
+                inner_clone.keepalive(close_rx, token).await;
+            })
+            .await
+            .with_context(|| "failed to spawn keep alive session task")?;
+
+        let session = Session { close_tx, inner };
+        Ok(Arc::new(session))
+    }
+
+    /// Get the lease id
+    #[must_use]
+    pub fn lease_id(&self) -> i64 {
+        self.inner.lease_id
+    }
+
+    /// Get the ttl
+    #[must_use]
+    pub fn ttl(&self) -> u64 {
+        self.inner.ttl
+    }
+
+    /// Get the `is_closed` flag
+    #[must_use]
+    pub fn is_closed(&self) -> bool {
+        self.inner.is_closed()
+    }
+
+    /// Try to close session
+    pub fn close(&self) {
+        match self.close_tx.try_send(()) {
+            Ok(o) => {
+                info!("close the keep alive session, {o:?}");
+            }
+            Err(e) => {
+                error!("failed to close the keep alive session, error={e:?}");
+            }
+        }
+        self.inner.close();
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        // Set the close flag
+        self.close();
+    }
+}
+
+/// The keepalive session inner struct
+pub struct SessionInner {
+    /// The closed flag
+    closed: AtomicBool,
+    /// Current lease id
+    lease_id: i64,
+    /// The ttl of the lease
+    ttl: u64,
+    /// The etcd client
+    #[cfg_attr(not(debug_assertions), skip)]
+    client: etcd_client::Client,
+}
+
+impl Debug for SessionInner {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Session")
+            .field("lease_id", &self.lease_id)
+            .field("ttl", &self.ttl)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SessionInner {
+    /// Get the closed flag
+    fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
+    }
+
+    /// Set close flag
+    fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+    }
+
+    /// Keep alive the lease
+    #[allow(clippy::pattern_type_mismatch)] // Raised by `tokio::select`
+    pub async fn keepalive(
+        self: Arc<Self>,
+        mut close_rx: mpsc::Receiver<()>,
+        token: CancellationToken,
+    ) {
+        let mut interval = tokio::time::interval(Duration::from_secs(self.ttl.div_ceil(3)));
+
+        // Try to clone a client, if the keeper failed, we need to revoke the lease
+        let mut client = self.client.clone();
+        let lease_id = self.lease_id;
+        let (mut keeper, mut lease_keep_alive_stream) =
+            match client.lease_keep_alive(lease_id).await {
+                Ok((keeper, lease_keep_alive_stream)) => (keeper, lease_keep_alive_stream),
+                Err(e) => {
+                    error!("failed to keep alive lease, error={e:?}");
+
+                    // revoke the lease
+                    revoke_lease!(client, lease_id);
+                    self.close();
+                    return;
+                }
+            };
+
+        // Start to keep alive the lease
+        loop {
+            if self.is_closed() {
+                debug!("lease keep alive stream closed by is_closed flag");
+
+                // revoke the lease
+                revoke_lease!(client, lease_id);
+                return;
+            }
+
+            tokio::select! {
+                _ = interval.tick() => {
+                    // Try to send a keep alive request
+                    match keeper.keep_alive().await {
+                        Ok(o) => {
+                            debug!("keep alive lease, lease_id={lease_id}, {o:?}");
+                        }
+                        Err(e) => {
+                            error!("failed to keep alive lease, error={e:?}");
+                            break;
+                        }
+                    }
+
+                    // Try to parse
+                    match lease_keep_alive_stream.message().await {
+                        Ok(Some(lease_alive_response)) => {
+                            if lease_alive_response.ttl() == 0 {
+                                error!("lease keep alive stream closed, because ttl is 0");
+                                // revoke the lease
+                                revoke_lease!(client, lease_id);
+                                break;
+                            }
+                            continue
+                        }
+                        Ok(None) => {
+                            error!("lease keep alive stream closed, because the sender is closed");
+                            // revoke the lease
+                            revoke_lease!(client, lease_id);
+                            break;
+                        }
+                        Err(e) => {
+                            error!("failed to keep alive lease, error={e:?}");
+                            break;
+                        }
+                    }
+                }
+                _ = close_rx.recv() => {
+                    info!("close the keep alive session, lease_id={lease_id}");
+                    // revoke the lease
+                    revoke_lease!(client, lease_id);
+                    break;
+                }
+                () = token.cancelled() => {
+                    debug!("lease keep alive stream closed by token canceled");
+                    // revoke the lease
+                    revoke_lease!(client, lease_id);
+                    break;
+                }
+            }
+        }
+
+        // Make sure the lease is revoked
+        self.close();
+    }
+}
+
+/// The kvengine watch stream for etcd
+/// Try to receice message from etcd, and return key and value for each event,
+/// Wrap the etcd watch stream to support the `KVEngine` trait.
+#[derive(Debug)]
+pub struct KVEngineWatchStream {
+    /// The etcd client, used to cancel the watch stream
+    watcher: etcd_client::Watcher,
+    /// The etcd watch stream
+    watch_stream: etcd_client::WatchStream,
+}
+
+impl KVEngineWatchStream {
+    /// Create a new watch stream
+    #[must_use]
+    pub fn new(watcher: etcd_client::Watcher, watch_stream: etcd_client::WatchStream) -> Self {
+        Self {
+            watcher,
+            watch_stream,
+        }
+    }
+
+    /// Cancel the watch stream, it will take over the ownership of the watch stream
+    #[inline]
+    pub async fn cancel(mut self) -> DatenLordResult<()> {
+        match self.watcher.cancel().await {
+            Ok(o) => {
+                debug!("etcd watcher task canceled, {o:?}");
+                Ok(())
+            }
+            Err(e) => {
+                error!("failed to cancel etcd watcher, error={e:?}");
+                Err(crate::common::error::DatenLordError::EtcdClientErr {
+                    source: e,
+                    context: vec!["failed to cancel etcd watcher".to_owned()],
+                })
+            }
+        }
+    }
+}
+
+// This impl is for WatchStream from etcd_client, does testing for the watch stream.
+impl Stream for KVEngineWatchStream {
+    type Item = DatenLordResult<(String, Option<ValueType>)>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Option<Self::Item>> {
+        self.get_mut()
+            .watch_stream
+            .poll_next_unpin(cx)
+            .map(|t| match t {
+                Some(Ok(resp)) => {
+                    let mut result = None;
+                    for event in resp.events() {
+                        // Get event data
+                        if let Some(kv) = event.kv() {
+                            // Get key and value
+                            let item_key = match kv.key_str() {
+                                Ok(key) => key.to_owned(),
+                                Err(e) => {
+                                    error!("failed to get key from etcd watch event, error={e:?}");
+                                    continue;
+                                }
+                            };
+                            match event.event_type() {
+                                etcd_client::EventType::Put => {
+                                    info!("put event, key={item_key}");
+                                    let item_value = match serde_json::from_slice(kv.value()) {
+                                        Ok(value) => value,
+                                        Err(e) => {
+                                            error!("failed to deserialize value from etcd watch event, error={e:?}");
+                                            continue;
+                                        }
+                                    };
+                                    result = Some(Ok((item_key, Some(item_value))));
+                                }
+                                etcd_client::EventType::Delete => {
+                                    info!("delete event, key={item_key}");
+                                    result = Some(Ok((item_key, None)));
+                                }
+                            }
+                        }
+                    }
+                    result
+                },
+                // TODO: Cancel watch when meet an error.
+                Some(Err(e)) => Some(Err(From::from(e))),
+                None => None,
+            })
+    }
+}
 
 #[derive(Clone)]
 /// Wrap the etcd client to support the `KVEngine` trait.
@@ -62,24 +385,30 @@ impl EtcdKVEngine {
 
 #[async_trait]
 impl KVEngine for EtcdKVEngine {
+    type Session = Session;
+    type KVEngineWatchStream = KVEngineWatchStream;
+
     async fn new(end_points: Vec<String>) -> DatenLordResult<Self> {
         let client = etcd_client::Client::connect(end_points, None).await?;
         Ok(Self { client })
     }
 
-    async fn new_meta_txn(&self) -> Box<dyn MetaTxn + Send> {
+    async fn new_meta_txn(&self) -> Box<dyn MetaTxn<Session = Self::Session> + Send> {
         Box::new(EtcdTxn::new(self.client.clone()))
     }
 
-    async fn lease_grant(&self, ttl: i64) -> DatenLordResult<i64> {
+    /// Create a lease with keepalive
+    async fn create_session(&self, ttl: u64) -> DatenLordResult<Arc<Session>> {
+        let _timer = KV_METRICS.start_kv_operation_timer("create_session");
         let mut client = self.client.clone();
-        let timeout_sec = check_ttl(ttl)
-            .with_context(|| "timeout_sec should be >=1s, please fix the call".to_owned())?;
-        Ok(client
-            .lease_grant(timeout_sec, None)
+        let resp = client
+            .lease_grant(conv_u64_sec_2_i64(ttl), None)
             .await
-            .with_context(|| "failed to get lease at `MetaTxn::lock`".to_owned())?
-            .id())
+            .with_context(|| "failed to get lease at `KVEngine::create_session`".to_owned())?;
+
+        let session = Session::new(client.clone(), ttl, resp.id()).await;
+
+        return session;
     }
 
     /// Distribute lock - lock
@@ -151,8 +480,16 @@ impl KVEngine for EtcdKVEngine {
                 if option.prev_kv {
                     set_option = set_option.with_prev_key();
                 }
-                if let Some(lease) = option.lease {
-                    set_option = set_option.with_lease(lease);
+                if let Some(session) = option.session {
+                    if session.is_closed() {
+                        return Err(crate::common::error::DatenLordError::EtcdClientErr {
+                            source: etcd_client::Error::LeaseKeepAliveError(
+                                "session is invalid".to_owned(),
+                            ),
+                            context: vec![],
+                        });
+                    }
+                    set_option = set_option.with_lease(session.lease_id());
                 }
                 Some(set_option)
             }
@@ -207,10 +544,24 @@ impl KVEngine for EtcdKVEngine {
         }
     }
 
+    /// Range get, return all key-value pairs start with prefix
     async fn range(&self, prefix: &KeyType) -> DatenLordResult<Vec<ValueType>> {
         let _timer = KV_METRICS.start_kv_operation_timer("range");
         let result = self.range_raw_key(prefix.to_string_key()).await?;
         Ok(result)
+    }
+
+    /// Watch the key, return a receiver to receive the value
+    async fn watch(&self, prefix: &KeyType) -> DatenLordResult<KVEngineWatchStream> {
+        let mut client = self.client.clone();
+        // Try to watch the key prefix
+        let opt = etcd_client::WatchOptions::new().with_prefix();
+        let (watcher, watch_stream) = client
+            .watch(prefix.to_string_key(), Some(opt.clone()))
+            .await
+            .with_context(|| "Failed to create watcher".to_owned())?;
+
+        return Ok(KVEngineWatchStream::new(watcher, watch_stream));
     }
 }
 
@@ -239,6 +590,8 @@ impl EtcdTxn {
 
 #[async_trait]
 impl MetaTxn for EtcdTxn {
+    type Session = Session;
+
     async fn get(&mut self, key_arg: &KeyType) -> DatenLordResult<Option<ValueType>> {
         let _timer = KV_METRICS.start_kv_operation_timer("get");
 
@@ -290,6 +643,122 @@ impl MetaTxn for EtcdTxn {
     fn delete(&mut self, key: &KeyType) {
         let key = key.to_string_key().into_bytes();
         self.buffer.insert(key, None);
+    }
+
+    /// Try to campaign the master with simple txn
+    /// Old(reference to etcd client v3):
+    /// Create a key with prefix, and compare key (sorted by revision) with the key created by the same session.
+    /// If current key is the smallest, then the session is the master, and campaign success.
+    ///
+    /// New(For datenlord cache scenario):
+    /// A small batch of nodes in cluster, we just need a simple txn to get the master key.
+    /// The thundering herd is not the main problem, which will cause a bunch of etcd raft logs.
+    /// Use String as val can be easily compared.
+    async fn campaign(
+        &self,
+        key: &KeyType,
+        val: String,
+        session: Arc<Session>,
+    ) -> DatenLordResult<(bool, String)> {
+        if session.is_closed() {
+            return Err(crate::common::error::DatenLordError::EtcdClientErr {
+                source: etcd_client::Error::LeaseKeepAliveError("session is invalid".to_owned()),
+                context: vec![],
+            });
+        }
+
+        let mut client = self.client.clone();
+
+        // Try to get the key, if key is existed
+        // We need to return the data from etcd,
+        // If the key is not existed, we need to set the key.
+        let txn = Txn::new()
+            // Check the key is existed and key is not equal to current value, which means the key is ready to be campaign.
+            .when(vec![
+                Compare::create_revision(key.to_string_key(), CompareOp::NotEqual, 0),
+                Compare::value(key.to_string_key(), CompareOp::NotEqual, val.clone()),
+            ])
+            // Campaign failed
+            .and_then(vec![TxnOp::get(
+                key.to_string_key(),
+                Some(GetOptions::new().with_serializable()),
+            )])
+            // Campaign succeed
+            .or_else(vec![TxnOp::put(
+                key.to_string_key(),
+                val.clone(),
+                Some(PutOptions::new().with_lease(session.lease_id())),
+            )]);
+
+        let (campaign_status, responses) = match client.txn(txn).await {
+            Ok(resp) => {
+                // Check the txn branch is `then` or `else`
+                // If succeeded, means the campaign is failed and can not set current data to etcd
+                // If failed, means the campaign is success, and put the current data to etcd
+                (!resp.succeeded(), resp.op_responses())
+            }
+            Err(e) => {
+                error!("failed to campaign, error={e:?}");
+                return Err(crate::common::error::DatenLordError::EtcdClientErr {
+                    source: e,
+                    context: vec!["failed to do txn operation at `MetaTxn::campaign`".to_owned()],
+                });
+            }
+        };
+
+        // Campaign success, return the current data
+        if campaign_status {
+            return Ok((true, val.clone()));
+        }
+
+        // If the campaign is failed, we need to check the response
+        if let Some(response) = responses.first() {
+            match *response {
+                TxnOpResponse::Put(_) => {
+                    // we can directly return current data
+                    return Ok((true, val.clone()));
+                }
+                TxnOpResponse::Get(ref resp) => {
+                    debug!("failed to campaign, return the existing key");
+                    if let Some(kv) = resp.kvs().first() {
+                        let item_value = match kv.value_str() {
+                            Ok(value) => value.to_owned(),
+                            Err(err) => {
+                                return Err(crate::common::error::DatenLordError::EtcdClientErr {
+                                    source: err,
+                                    context: vec![
+                                        "failed to get key from etcd txn get event".to_owned()
+                                    ],
+                                });
+                            }
+                        };
+
+                        return Ok((false, item_value));
+                    }
+                    return Err(crate::common::error::DatenLordError::EtcdClientErr {
+                        source: etcd_client::Error::InvalidArgs(
+                            "failed to get kvs from etcd txn get event".to_owned(),
+                        ),
+                        context: vec![],
+                    });
+                }
+                TxnOpResponse::Delete(_) | TxnOpResponse::Txn(_) => {
+                    return Err(crate::common::error::DatenLordError::EtcdClientErr {
+                        source: etcd_client::Error::InvalidArgs(
+                            "failed to campaign, the responses op is not match".to_owned(),
+                        ),
+                        context: vec![],
+                    });
+                }
+            }
+        }
+
+        return Err(crate::common::error::DatenLordError::EtcdClientErr {
+            source: etcd_client::Error::InvalidArgs(
+                "failed to campaign, the responses length is not match".to_owned(),
+            ),
+            context: vec![],
+        });
     }
 
     async fn commit(&mut self) -> DatenLordResult<bool> {
@@ -528,5 +997,165 @@ mod test {
             assert!(child_names.contains(&dir_entry.name()));
             assert_eq!(dir_entry.file_type(), FileType::Dir);
         }
+    }
+
+    #[tokio::test]
+    async fn test_watch() {
+        let client = EtcdKVEngine::new_for_local_test(vec![ETCD_ADDRESS.to_owned()])
+            .await
+            .unwrap();
+        // Create a new key
+        let key = KeyType::String("test_watch".to_owned());
+        let mut watch_stream = client.watch(&key).await.unwrap();
+        for _ in 0_i32..5_i32 {
+            let client_clone = client.clone();
+            tokio::spawn(async move {
+                let key = KeyType::String("test_watch".to_owned());
+                let value = ValueType::String("test_watch_value".to_owned());
+                // Wait for watch message is ready()
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                client_clone.set(&key, &value, None).await.unwrap();
+            });
+            let value = ValueType::String("test_watch_value".to_owned());
+            let watch_result = watch_stream.next().await.unwrap().unwrap();
+            assert_eq!(watch_result.0, key.to_string_key());
+            assert_eq!(watch_result.1.unwrap(), value);
+
+            // Update a key
+            let client_clone = client.clone();
+            tokio::spawn(async move {
+                let key = KeyType::String("test_watch".to_owned());
+                let value = ValueType::String("test_watch_value2".to_owned());
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                client_clone.set(&key, &value, None).await.unwrap();
+            });
+            let key = KeyType::String("test_watch".to_owned());
+            let value = ValueType::String("test_watch_value2".to_owned());
+            let watch_result = watch_stream.next().await.unwrap().unwrap();
+            assert_eq!(watch_result.0, key.to_string_key());
+            assert_eq!(watch_result.1.unwrap(), value);
+
+            // Delete a key
+            let client_clone = client.clone();
+            tokio::spawn(async move {
+                let key = KeyType::String("test_watch".to_owned());
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                client_clone.delete(&key, None).await.unwrap();
+            });
+            let watch_result = watch_stream.next().await.unwrap().unwrap();
+            assert!(watch_result.1.is_none());
+        }
+
+        // Close stream
+        watch_stream.cancel().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_create_session() {
+        let client = EtcdKVEngine::new_for_local_test(vec![ETCD_ADDRESS.to_owned()])
+            .await
+            .unwrap();
+        // Test keep alive
+        let session = client.create_session(5).await.unwrap();
+        // Set a temp key for this lease
+        let key = KeyType::String("test_create_session".to_owned());
+        let value = ValueType::String("test_create_session_value".to_owned());
+        let session_opt = Arc::clone(&session);
+        client
+            .set(
+                &key,
+                &value,
+                Some(SetOption::new().with_session(session_opt)),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(client.get(&key).await.unwrap().unwrap(), value);
+
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        assert_eq!(client.get(&key).await.unwrap().unwrap(), value);
+
+        // Test cancel keepalive
+        drop(session);
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        assert!(client.get(&key).await.unwrap().is_none());
+    }
+
+    /// Utils function to get the lease id from etcd by key
+    async fn get_lease_id_from_key(
+        etcd_address_vec: Vec<String>,
+        key: &KeyType,
+    ) -> DatenLordResult<i64> {
+        let mut client = etcd_client::Client::connect(etcd_address_vec.clone(), None)
+            .await
+            .with_context(|| {
+                format!("failed to connect to etcd, the etcd address={etcd_address_vec:?}")
+            })?;
+
+        let resp = client
+            .get(key.to_string_key(), None)
+            .await
+            .with_context(|| format!("failed to get from etcd engine, key={key:?}"))?;
+
+        let kvs = resp.kvs();
+        match kvs.get(0) {
+            Some(kv) => Ok(kv.lease()),
+            None => Ok(0),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_campaign() {
+        let client = EtcdKVEngine::new_for_local_test(vec![ETCD_ADDRESS.to_owned()])
+            .await
+            .unwrap();
+        let txn = client.new_meta_txn().await;
+
+        let key = KeyType::String("test_campaign".to_owned());
+        let val = "test_campaign_val".to_owned();
+        let val2 = "test_campaign_val2".to_owned();
+
+        let campaign_session_1 = client.create_session(5).await.unwrap();
+        // Campaign the key
+        let (campaign_status, campaign_val) = txn
+            .campaign(&key, val.clone(), Arc::clone(&campaign_session_1))
+            .await
+            .unwrap();
+        assert!(campaign_status);
+        assert_eq!(campaign_val, val);
+        let result_lease_id = get_lease_id_from_key(vec![ETCD_ADDRESS.to_owned()], &key)
+            .await
+            .unwrap();
+        assert_eq!(result_lease_id, campaign_session_1.lease_id());
+
+        let campaign_session_2 = client.create_session(5).await.unwrap();
+        // Recampaign the key
+        let (campaign_status, campaign_val) = txn
+            .campaign(&key, val.clone(), Arc::clone(&campaign_session_2))
+            .await
+            .unwrap();
+        assert!(campaign_status);
+        assert_eq!(campaign_val, val);
+        // Check the lease id from etcd
+        let result_lease_id = get_lease_id_from_key(vec![ETCD_ADDRESS.to_owned()], &key)
+            .await
+            .unwrap();
+        assert_ne!(result_lease_id, campaign_session_1.lease_id());
+        assert_eq!(result_lease_id, campaign_session_2.lease_id());
+
+        let campaign_session_3 = client.create_session(5).await.unwrap();
+        // Campaign the key with different value, campaign failed
+        let (campaign_status, campaign_val) = txn
+            .campaign(&key, val2.clone(), Arc::clone(&campaign_session_3))
+            .await
+            .unwrap();
+        assert!(!campaign_status);
+        assert_eq!(campaign_val, val);
+        let result_lease_id = get_lease_id_from_key(vec![ETCD_ADDRESS.to_owned()], &key)
+            .await
+            .unwrap();
+        assert_ne!(result_lease_id, campaign_session_1.lease_id());
+        assert_ne!(result_lease_id, campaign_session_3.lease_id());
+        assert_eq!(result_lease_id, campaign_session_2.lease_id());
     }
 }

--- a/src/async_fuse/memfs/kv_engine/key_type.rs
+++ b/src/async_fuse/memfs/kv_engine/key_type.rs
@@ -28,6 +28,14 @@ pub enum KeyType {
     /// Just a string key for testing the KVEngine.
     #[cfg(test)]
     String(String),
+    /// Distributed cache node key
+    CacheNode(String),
+    /// Distributed hash ring key
+    CacheRing,
+    /// Distributed cache node master key
+    CacheNodeMaster,
+    /// Distribute cache cluster config
+    CacheClusterConfig,
 }
 
 // ::<KeyType>::get() -> ValueType
@@ -41,6 +49,8 @@ pub enum LockKeyType {
     VolumeInfoLock,
     /// ETCD file node list lock
     FileNodeListLock(INum),
+    /// Distributed cache node master key
+    CacheNodeMaster,
 }
 
 impl Display for KeyType {
@@ -56,6 +66,10 @@ impl Display for KeyType {
             KeyType::FileNodeList(ref inum) => write!(f, "FileNodeList({inum})"),
             #[cfg(test)]
             KeyType::String(ref s) => write!(f, "String({s})"),
+            KeyType::CacheNode(ref s) => write!(f, "CacheNode({s})"),
+            KeyType::CacheRing => write!(f, "CacheRing/"), // CacheRing
+            KeyType::CacheNodeMaster => write!(f, "CacheNodeMaster"), // CacheNodeMaster
+            KeyType::CacheClusterConfig => write!(f, "CacheClusterConfig/"), // CacheClusterConfig
         }
     }
 }
@@ -71,6 +85,9 @@ impl Display for LockKeyType {
             }
             LockKeyType::FileNodeListLock(ref inum) => {
                 write!(f, "FileNodeListLock({inum:?})")
+            }
+            LockKeyType::CacheNodeMaster => {
+                write!(f, "CacheNodeMaster")
             }
         }
     }
@@ -100,6 +117,10 @@ impl KeyType {
             KeyType::NodeIpPort(_) => "NodeIpPort",
             KeyType::VolumeInfo(_) => "VolumeInfo",
             KeyType::FileNodeList(_) => "FileNodeList",
+            KeyType::CacheNode(_) => "CacheNode",
+            KeyType::CacheRing => "CacheRing",
+            KeyType::CacheNodeMaster => "CacheNodeMaster",
+            KeyType::CacheClusterConfig => "CacheClusterConfig",
         }
     }
 
@@ -128,6 +149,18 @@ impl KeyType {
             KeyType::FileNodeList(ref inum) => {
                 write!(f, "{inum}").unwrap();
             }
+            KeyType::CacheNode(ref s) => {
+                write!(f, "{s}").unwrap();
+            }
+            KeyType::CacheRing => {
+                write!(f, "").unwrap();
+            }
+            KeyType::CacheNodeMaster => {
+                write!(f, "").unwrap();
+            }
+            KeyType::CacheClusterConfig => {
+                write!(f, "").unwrap();
+            }
         }
     }
 }
@@ -151,6 +184,7 @@ impl LockKeyType {
             LockKeyType::IdAllocatorLock(_) => "IdAllocLock",
             LockKeyType::VolumeInfoLock => "VolumeInfoLock",
             LockKeyType::FileNodeListLock(_) => "FileNodeListLock",
+            LockKeyType::CacheNodeMaster => "CacheNodeMaster",
         }
     }
 
@@ -165,6 +199,9 @@ impl LockKeyType {
             }
             LockKeyType::FileNodeListLock(ref inum) => {
                 write!(f, "{inum}").unwrap();
+            }
+            LockKeyType::CacheNodeMaster => {
+                write!(f, "").unwrap();
             }
         }
     }

--- a/src/async_fuse/memfs/kv_engine/value_type.rs
+++ b/src/async_fuse/memfs/kv_engine/value_type.rs
@@ -21,6 +21,8 @@ pub enum ValueType {
     Raw(Vec<u8>),
     /// String value
     String(String),
+    /// Json value
+    Json(serde_json::Value),
 }
 
 impl ValueType {

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -249,6 +249,12 @@ pub enum DatenLordError {
         /// Context of the error
         context: Vec<String>,
     },
+    /// Cache cluster error
+    #[error("Cache cluster error, context is {:#?}.", .context)]
+    CacheClusterErr {
+        /// Context of the error
+        context: Vec<String>,
+    },
     // /// Error when doing s3 operation.
     // #[error("S3 error: {0}")]
     // S3Error(s3_wrapper::S3Error),
@@ -340,7 +346,8 @@ impl DatenLordError {
                 TransactionRetryLimitExceededErr,
                 InternalErr,
                 Unimplemented,
-                InconsistentFS
+                InconsistentFS,
+                CacheClusterErr
             ]
         );
         self
@@ -402,7 +409,8 @@ impl From<DatenLordError> for RpcStatusCode {
             | DatenLordError::InternalErr { .. }
             | DatenLordError::KVEngineErr { .. }
             | DatenLordError::JoinErr { .. }
-            | DatenLordError::InconsistentFS { .. } => Self::INTERNAL,
+            | DatenLordError::InconsistentFS { .. }
+            | DatenLordError::CacheClusterErr { .. } => Self::INTERNAL,
             DatenLordError::GrpcioErr { source, .. } => match source {
                 grpcio::Error::RpcFailure(ref status) => status.code(),
                 grpcio::Error::Codec(..)

--- a/src/common/task_manager/task.rs
+++ b/src/common/task_manager/task.rs
@@ -32,6 +32,8 @@ pub enum TaskName {
     WriteBack,
     /// The scheduler extender.
     SchedulerExtender,
+    /// The task for etcd keep alive
+    EtcdKeepAlive,
 }
 
 /// The task handle(s) of the current task node.
@@ -181,10 +183,11 @@ impl Task {
 }
 
 /// Edges of the dependency graph of the tasks.
-pub(super) const EDGES: [(TaskName, TaskName); 9] = [
+pub(super) const EDGES: [(TaskName, TaskName); 10] = [
     (TaskName::Root, TaskName::Metrics),
     (TaskName::Root, TaskName::BlockFlush),
     (TaskName::Root, TaskName::SchedulerExtender),
+    (TaskName::Root, TaskName::EtcdKeepAlive),
     (TaskName::BlockFlush, TaskName::AsyncFuse),
     (TaskName::BlockFlush, TaskName::FuseRequest),
     (TaskName::FuseRequest, TaskName::AsyncFuse),

--- a/src/storage/cache_proxy/config.rs
+++ b/src/storage/cache_proxy/config.rs
@@ -1,0 +1,22 @@
+/// Config for the distribute cache
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Key-value store addresses
+    pub kv_addrs: Vec<String>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Config {
+    /// Create a new config
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            kv_addrs: Vec::new(),
+        }
+    }
+}

--- a/src/storage/cache_proxy/mod.rs
+++ b/src/storage/cache_proxy/mod.rs
@@ -1,7 +1,10 @@
-/// This module contains the cache proxy implementation.
+/// This module contains the distribute cache implementation.
 
 /// Hash ring module
 pub mod ring;
 
 /// Node module
 pub mod node;
+
+/// Config module, config the distribute cache
+pub mod config;

--- a/src/storage/cache_proxy/ring.rs
+++ b/src/storage/cache_proxy/ring.rs
@@ -12,7 +12,7 @@ use tracing::warn;
 use crate::async_fuse::util::usize_to_u64;
 
 /// The default slot size
-/// We use u64::MAX as the default slot size
+/// We use `u64::MAX` as the default slot size
 /// And we do not need to worry about the overflow
 const DEFAULT_SLOT_SIZE: u64 = std::u64::MAX;
 
@@ -127,7 +127,7 @@ impl Default for DefaultHashBuilder {
 pub struct Ring<T, S = DefaultHashBuilder>
 where
     T: NodeType,
-    S: BuildHasher,
+    S: BuildHasher + Clone,
 {
     /// The hash builder
     #[serde(skip)]
@@ -158,9 +158,10 @@ where
 impl<T, S> Ring<T, S>
 where
     T: NodeType,
-    S: BuildHasher,
+    S: BuildHasher + Clone,
 {
     /// Create a new hash ring with a given hash builder and capacity
+    #[must_use]
     pub fn new(hash_builder: S) -> Self {
         Self {
             hash_builder,
@@ -170,22 +171,34 @@ where
         }
     }
 
+    /// Update the ring with a given ring
+    /// It will node update the hash builder
+    pub fn update(&mut self, ring: &Ring<T, S>) {
+        self.slots = ring.slots.clone();
+        self.capacity = ring.capacity;
+        self.version = ring.version;
+    }
+
     /// Get the slot length
+    #[must_use]
     pub fn len_slots(&self) -> usize {
         self.slots.len()
     }
 
     /// Get the slot at a given index
+    #[must_use]
     pub fn capacity(&self) -> u64 {
         self.capacity
     }
 
     /// Get version
+    #[must_use]
     pub fn version(&self) -> u64 {
         self.version
     }
 
     /// Check if the ring is empty
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.slots.is_empty()
     }
@@ -199,7 +212,7 @@ where
 impl<T, S: BuildHasher> Ring<T, S>
 where
     T: NodeType,
-    S: BuildHasher,
+    S: BuildHasher + Clone,
 {
     /// Add a node to a slot
     /// We will create a new slot and update slot mapping, then add to the ring


### PR DESCRIPTION
Now there are some nodes and an etcd server, the roles of these nodes are divided into master and slave, master needs to observe the list of all nodes and then update the result of hashing. slave needs to observe whether the master on the etcd is online or not, if not then it will try to compete to become the master, i.e.

In addition, all the keys registered with etcd are with lease, you need to take the initiative to renew the lease. In addition, when the client renews the lease, the lease may be disconnected, and then the client needs to re-apply for the lease and continue to renew the lease, and these states need to be marked. 

In this PR, we try to define some node roles in cache nodes, and try to enhance current etcd client to support keepalive and campaign.

Design Doc: https://datenlord.feishu.cn/docx/LoavdI51IopRuPx8Kyuc2DiRnr6