### PR TITLE
fix(ci): update ubuntu with 22.04 tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN apt-get update && apt-get install -y cmake g++ libprotobuf-dev protobuf-compiler
 RUN cargo build --release
 
-FROM ubuntu as datenlord
+FROM ubuntu:22.04 as datenlord
 LABEL maintainers="DatenLord Authors"
 LABEL description="DatenLord Distributed Storage"
 


### PR DESCRIPTION
Current e2e test will fail in `scripts/ci/cron-test.sh` -> `scripts/perf/datenlord-perf-test.sh`, it is caused by latest ubuntu stragety.

error log:
```bash
error: externally-managed-environment
 
× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.11/README.venv for more information.
 
note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

Fix https://github.com/datenlord/datenlord/actions/runs/8983275226/job/24723864993?pr=483

