### PR TITLE
feat(cache node): support file async rpc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,9 @@ signal-hook = { version = "0.3.17", features = ["iterator"]}
 signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 tokio-util = "0.7.10"
 serfig = "0.1.0"
+bytes = "1.1"
+flume = "0.11.0"
+num_enum = "0.7.3"
 
 [build-dependencies]
 protoc-grpcio = "3.0.0"

--- a/src/storage/cache/mod.rs
+++ b/src/storage/cache/mod.rs
@@ -1,0 +1,5 @@
+/// RPC module for cache
+pub mod rpc;
+
+/// Unit tests for cache module
+pub mod tests;

--- a/src/storage/cache/rpc/client.rs
+++ b/src/storage/cache/rpc/client.rs
@@ -1,0 +1,804 @@
+use std::{
+    cell::UnsafeCell,
+    fmt::Debug,
+    future::IntoFuture,
+    pin::Pin,
+    sync::{atomic::AtomicU64, Arc},
+    task::{Context, Poll},
+};
+
+use bytes::BytesMut;
+use futures::{pin_mut, Future};
+use tokio::{
+    io::{AsyncRead, AsyncWriteExt, ReadBuf},
+    net::TcpStream,
+    sync::oneshot,
+    time::{Instant, Interval},
+};
+use tracing::debug;
+
+use crate::write_all_timeout;
+
+use super::{
+    common::{self, ClientTimeoutOptions},
+    error::RpcError,
+    message::{ReqType, RespType},
+    packet::{Decode, Encode, Packet, PacketsKeeper, ReqHeader, RespHeader, REQ_HEADER_SIZE},
+    utils::u64_to_usize,
+};
+
+/// TODO: combine `RpcClientConnectionInner` and `RpcClientConnection`
+struct RpcClientConnectionInner<P>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+{
+    /// The TCP stream for the connection.
+    stream: UnsafeCell<TcpStream>,
+    /// Options for the timeout of the connection
+    timeout_options: ClientTimeoutOptions,
+    /// Stream auto increment sequence number, used to mark the request and response
+    seq: AtomicU64,
+    /// The instant of the connection, used to calculate the keep alive timeout
+    clock_instant: Instant,
+    /// Received keep alive timestamp, will mark the valid keep alive response.
+    /// If the keep alive response is not received in right mestamp, the connection will be closed,
+    /// If we receive other response, we will update the received_keepalive_timestamp too, just treat it as a keep alive response.
+    received_keepalive_timestamp: AtomicU64,
+    /// Send packet task
+    packets_keeper: PacketsKeeper<P>,
+    /// Response buffer, try to reuse same buffer to reduce memory allocation
+    /// In case of the response is too large, we need to consider the buffer size
+    /// Init size is 4MB
+    /// Besides, we want to reduce memory copy, and read/write the response to the same data buffer
+    resp_buf: UnsafeCell<BytesMut>,
+    /// Request encode buffer
+    req_buf: UnsafeCell<BytesMut>,
+    /// The Client ID for the connection
+    client_id: u64,
+    /// The receiver for the closed signal.
+    is_closed_receiver: UnsafeCell<oneshot::Receiver<()>>,
+}
+
+// TODO: Add markable id for this client
+impl<P> Debug for RpcClientConnectionInner<P>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RpcClientConnectionInner")
+            .field("client id", &self.client_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<P> RpcClientConnectionInner<P>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+{
+    /// Create a new connection.
+    pub fn new(
+        stream: TcpStream,
+        timeout_options: ClientTimeoutOptions,
+        client_id: u64,
+        is_closed_receiver: oneshot::Receiver<()>,
+    ) -> Self {
+        let task_timeout = timeout_options.task_timeout.as_secs();
+        let is_closed_receiver_future = is_closed_receiver.into_future();
+        Self {
+            stream: UnsafeCell::new(stream),
+            timeout_options,
+            seq: AtomicU64::new(0),
+            clock_instant: Instant::now(),
+            received_keepalive_timestamp: AtomicU64::new(0),
+            packets_keeper: PacketsKeeper::new(task_timeout),
+            resp_buf: UnsafeCell::new(BytesMut::with_capacity(
+                common::DEFAULT_TCP_RESPONSE_BUFFER_SIZE,
+            )),
+            req_buf: UnsafeCell::new(BytesMut::with_capacity(
+                common::DEFAULT_TCP_REQUEST_BUFFER_SIZE,
+            )),
+            client_id,
+            is_closed_receiver: UnsafeCell::new(is_closed_receiver_future),
+        }
+    }
+
+    /// Recv request header from the stream
+    async fn recv_header(&self) -> Result<RespHeader, RpcError> {
+        // Try to read to buffer
+        match self.recv_len(REQ_HEADER_SIZE).await {
+            Ok(()) => {}
+            Err(err) => {
+                debug!("Failed to receive request header: {:?}", err);
+                return Err(err);
+            }
+        }
+
+        let buffer: &mut BytesMut = self.get_resp_buf_mut();
+        let req_header = RespHeader::decode(buffer)?;
+        debug!("Received response header: {:?}", req_header);
+
+        Ok(req_header)
+    }
+
+    /// Receive response body from the server.
+    async fn recv_len(&self, len: u64) -> Result<(), RpcError> {
+        let req_buffer: &mut BytesMut = self.get_resp_buf_mut();
+        req_buffer.resize(u64_to_usize(len), 0);
+
+        let recv_len_future = RecvLenFuture::new(self, len, req_buffer);
+
+        // Block here until the client is dropped or stream error.
+        match recv_len_future.await {
+            Ok(size) => {
+                debug!("Received response body size: {:?}", size);
+                Ok(())
+            }
+            Err(err) => {
+                debug!("Failed to receive response header: {:?}", err);
+                Err(RpcError::InternalError(err.to_string()))
+            }
+        }
+    }
+
+    /// Send a request to the server.
+    /// We need to make sure
+    /// Current send packet need to be in one task, so if we need to send ping and packet
+    /// we need to make sure only one operation is running, like select.
+    async fn send_data(&self, req_header: &dyn Encode, packet: Option<P>) -> Result<(), RpcError> {
+        let buf = self.get_req_buf_mut();
+        buf.clear();
+        // encode just need to append to buffer, do not clear buffer
+        req_header.encode(buf);
+        // Append the body to the buffer
+        if let Some(body) = packet {
+            // encode just need to append to buffer, do not clear buffer
+            body.encode(buf);
+        }
+        debug!("{:?} Sent data with length: {:?}", self, buf.len());
+        let writer = self.get_stream_mut();
+        match write_all_timeout!(writer, buf, self.timeout_options.write_timeout).await {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                debug!("{:?} Failed to send data: {:?}", self, err);
+                Err(RpcError::InternalError(err.to_string()))
+            }
+        }
+    }
+
+    /// Get the next sequence number.
+    fn next_seq(&self) -> u64 {
+        self.seq.fetch_add(1, std::sync::atomic::Ordering::AcqRel)
+    }
+
+    /// Send keep alive message to the server
+    async fn ping(&self) -> Result<(), RpcError> {
+        // Send keep alive message
+        let current_seq = self.next_seq();
+        let current_timestamp = self.clock_instant.elapsed().as_secs();
+        // Check keepalive is valid
+        let received_keepalive_timestamp = self
+            .received_keepalive_timestamp
+            .load(std::sync::atomic::Ordering::Acquire);
+        if current_timestamp - received_keepalive_timestamp
+            > self.timeout_options.keep_alive_timeout.as_secs()
+        {
+            debug!("{:?} keep alive timeout, close the connection", self);
+            return Err(RpcError::InternalError("Keep alive timeout".to_owned()));
+        }
+
+        // Set to packet task
+        let keep_alive_msg = ReqHeader {
+            seq: current_seq,
+            op: ReqType::KeepAliveRequest.into(),
+            len: 0,
+        };
+
+        if let Ok(()) = self.send_data(&keep_alive_msg, None).await {
+            debug!("{:?} Success to sent keep alive message", self);
+            Ok(())
+        } else {
+            debug!("{:?} Failed to send keep alive message", self);
+            Err(RpcError::InternalError(
+                "Failed to send keep alive message".to_owned(),
+            ))
+        }
+    }
+
+    /// Send packet by the client.
+    async fn send_packet(&self, mut req_packet: P) -> Result<(), RpcError> {
+        let current_seq = self.next_seq();
+        req_packet.set_seq(current_seq);
+        debug!("{:?} Try to send request: {:?}", self, current_seq);
+
+        // Send may be used in different threads, so we need to create local buffer to store the request data
+        let req_len = req_packet.get_req_len(); // Try to get request buffer
+        let req_header = ReqHeader {
+            seq: req_packet.seq(),
+            op: req_packet.op(),
+            len: req_len,
+        };
+
+        // concate req_header and req_buffer
+        let req_seq = req_packet.seq();
+        if let Ok(()) = self.send_data(&req_header, Some(req_packet)).await {
+            debug!("{:?} Sent request success: {:?}", self, req_seq);
+            Ok(())
+        } else {
+            debug!("{:?} Failed to send request: {:?}", self, req_seq);
+            Err(RpcError::InternalError("Failed to send request".to_owned()))
+        }
+    }
+
+    /// Receive loop for the client.
+    async fn recv_loop(&self) {
+        // Check and clean keeper timeout unused task
+        // The timeout data will be cleaned by the get function
+        // We don't need to clean the timeout data radically
+        let mut tickers = Box::pin(tokio::time::interval(
+            self.timeout_options.task_timeout.div_f32(2.0),
+        ));
+        loop {
+            // Clean timeout tasks, will block here
+            let recv_header_f = self.recv_header();
+            pin_mut!(recv_header_f);
+            let selector = ReceiveHeaderFuture::new(self, &mut tickers, &mut recv_header_f);
+            match selector.await {
+                Ok(header) => {
+                    // Try to receive the response from the server
+                    let header_seq = header.seq;
+                    debug!("{:?} Received keep alive response or other response.", self);
+                    let current_timestamp = self.clock_instant.elapsed().as_secs();
+                    self.received_keepalive_timestamp
+                        .store(current_timestamp, std::sync::atomic::Ordering::Release);
+                    // Update the received keep alive seq
+                    if let Ok(resp_type) = RespType::try_from(header.op) {
+                        if let RespType::FileBlockResponse = resp_type {
+                            debug!("{:?} Received response header: {:?}", self, header);
+                            // Try to read to buffer
+                            match self.recv_len(header.len).await {
+                                Ok(()) => {}
+                                Err(err) => {
+                                    debug!(
+                                        "{:?} Failed to receive request header: {:?}",
+                                        self, err
+                                    );
+                                    break;
+                                }
+                            }
+
+                            // Take the packet task and recv the response
+                            let resp_buffer: &mut BytesMut = self.get_resp_buf_mut();
+                            match self.packets_keeper.take_task(header_seq, resp_buffer).await {
+                                Ok(()) => {
+                                    debug!("{:?} Received response: {:?}", self, header_seq);
+                                }
+                                Err(err) => {
+                                    debug!("{:?} Failed to update task: {:?}", self, err);
+                                }
+                            }
+                        }
+                    } else {
+                        debug!("{:?} Invalid response type: {:?}", self, header.op);
+                        break;
+                    }
+                }
+                Err(err) => {
+                    debug!("{:?} Failed to receive request header: {:?}", self, err);
+                    break;
+                }
+            }
+        }
+
+        // Purge all the tasks
+        self.packets_keeper.purge_outdated_tasks().await;
+    }
+
+    /// Get stream with mutable reference
+    #[allow(clippy::mut_from_ref)]
+    fn get_stream_mut(&self) -> &mut TcpStream {
+        // Current implementation is safe because the stream is only accessed by one thread
+        unsafe { &mut *self.stream.get() }
+    }
+
+    /// Get resp buffer with mutable reference
+    #[allow(clippy::mut_from_ref)]
+    fn get_resp_buf_mut(&self) -> &mut BytesMut {
+        unsafe { &mut *self.resp_buf.get() }
+    }
+
+    /// Get req buffer with mutable reference
+    #[allow(clippy::mut_from_ref)]
+    fn get_req_buf_mut(&self) -> &mut BytesMut {
+        unsafe { &mut *self.req_buf.get() }
+    }
+
+    /// Get the closed receiver for the connection with mutable reference.
+    #[allow(clippy::mut_from_ref)]
+    fn get_is_closed_receiver_mut(&self) -> &mut oneshot::Receiver<()> {
+        unsafe { &mut *self.is_closed_receiver.get() }
+    }
+}
+
+unsafe impl<P> Send for RpcClientConnectionInner<P> where P: Packet + Clone + Send + Sync + 'static {}
+
+unsafe impl<P> Sync for RpcClientConnectionInner<P> where P: Packet + Clone + Send + Sync + 'static {}
+
+/// The RPC client definition.
+#[derive(Debug)]
+pub struct RpcClient<P>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+{
+    /// The timeout options for the client.
+    /// TODO:
+    #[allow(dead_code)]
+    timeout_options: ClientTimeoutOptions,
+    /// Inner connection for the client.
+    inner_connection: Arc<RpcClientConnectionInner<P>>,
+    /// Client ID for the connection
+    /// TODO:
+    #[allow(dead_code)]
+    client_id: AtomicU64,
+    /// Is closed flag sender, this struct is associated with the inner_connection,
+    /// if this client is dropped, the inner_connection receiver will receive the closed signal.
+    #[allow(dead_code)]
+    is_closed_sender: oneshot::Sender<()>,
+}
+
+impl<P> RpcClient<P>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+{
+    /// Create a new RPC client.
+    ///
+    /// We don't manage the stream is dead or clean
+    /// The client will be closed if the keep alive message is not received in 100 times
+    /// When the stream is broken, the client will be closed, and we need to recreate a new client
+    pub fn new(stream: TcpStream, timeout_options: ClientTimeoutOptions) -> Self {
+        let client_id = AtomicU64::new(0);
+        // let (is_closed_sender, is_closed_receiver) = flume::unbounded::<()>();
+        let (is_closed_sender, is_closed_receiver) = oneshot::channel::<()>();
+        let inner_connection = RpcClientConnectionInner::new(
+            stream,
+            timeout_options.clone(),
+            client_id.load(std::sync::atomic::Ordering::Acquire),
+            is_closed_receiver,
+        );
+
+        Self {
+            timeout_options,
+            inner_connection: Arc::new(inner_connection),
+            client_id,
+            is_closed_sender,
+        }
+    }
+
+    /// Start client receiver
+    pub fn start_recv(&self) {
+        // Create a receiver loop
+        let inner_connection_clone = Arc::clone(&self.inner_connection);
+        tokio::spawn(async move {
+            inner_connection_clone.recv_loop().await;
+        });
+    }
+
+    /// Send a request to the server.
+    /// Try to send data to channel, if the channel is full, return an error.
+    /// Contains the rezquest header and body.
+    /// WARN: this function does not support concurrent call
+    pub async fn send_request(&self, req: P) -> Result<(), RpcError> {
+        self.inner_connection
+            .send_packet(req)
+            .await
+            .map_err(|err| RpcError::InternalError(err.to_string()))
+    }
+
+    /// Manually send ping by the send request
+    /// The inner can not start two loop, because the stream is unsafe
+    /// we need to start the loop in the client or higher level manually
+    /// WARN: this function does not support concurrent call
+    pub async fn ping(&self) -> Result<(), RpcError> {
+        self.inner_connection.ping().await
+    }
+}
+
+/// `RecvLenFuture` TCP Stream reader future for receive data
+/// We need to keep block the stream until the data is received
+/// or the stream is closed or client is dropped
+/// The future will be used to receive the response from the server
+struct RecvLenFuture<'a, P>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+{
+    /// The inner connection for the client.
+    client: &'a RpcClientConnectionInner<P>,
+    /// The length of the data to receive.
+    len: u64,
+    /// The buffer to store the received data.
+    req_buffer: &'a mut BytesMut,
+}
+
+impl<'a, P> RecvLenFuture<'a, P>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+{
+    /// Create a new receive length future.
+    fn new(
+        client: &'a RpcClientConnectionInner<P>,
+        len: u64,
+        req_buffer: &'a mut BytesMut,
+    ) -> Self {
+        Self {
+            client,
+            len,
+            req_buffer,
+        }
+    }
+}
+
+impl<P> Future for RecvLenFuture<'_, P>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+{
+    type Output = Result<(), RpcError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        // Resize the buffer to accommodate the incoming data
+        this.req_buffer.resize(u64_to_usize(this.len), 0);
+
+        let mut reader = this.client.get_stream_mut();
+        let mut read_buf = ReadBuf::new(this.req_buffer);
+
+        let buf_poll_status = match Pin::new(&mut reader).poll_read(cx, &mut read_buf) {
+            Poll::Ready(Ok(size)) => {
+                debug!("Received response body size: {:?}", size);
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(err)) => {
+                debug!("Failed to receive response header: {:?}", err);
+                Poll::Ready(Err(RpcError::InternalError(err.to_string())))
+            }
+            Poll::Pending => Poll::Pending,
+        };
+
+        // Recv closed data from the client channel
+        let is_closed_receiver_future = this.client.get_is_closed_receiver_mut();
+        match Pin::new(is_closed_receiver_future).poll(cx) {
+            Poll::Ready(Ok(())) => {
+                debug!("Client is closed, stop the receive loop");
+                Poll::Ready(Err(RpcError::InternalError("Client is closed".to_owned())))
+            }
+            Poll::Ready(Err(err)) => {
+                debug!("Failed to receive closed signal: {:?}", err);
+                Poll::Ready(Err(RpcError::InternalError(err.to_string())))
+            }
+            Poll::Pending => buf_poll_status,
+        }
+    }
+}
+
+/// The receive stream for the client.
+/// The stream will be used to receive the response from the server,
+/// and clean outdated tasks when the task is timeout.
+struct ReceiveHeaderFuture<'a, P, F>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+    F: Future<Output = Result<RespHeader, RpcError>> + Unpin,
+{
+    /// The inner connection for the client.
+    client_inner: &'a RpcClientConnectionInner<P>,
+    /// The interval for period task.
+    interval: &'a mut Pin<Box<Interval>>,
+    /// The recv_future in the client.
+    recv_future: Pin<&'a mut F>,
+}
+
+impl<'a, P, F> ReceiveHeaderFuture<'a, P, F>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+    F: Future<Output = Result<RespHeader, RpcError>> + Unpin,
+{
+    /// Create a new receive header stream.
+    fn new(
+        client_inner: &'a RpcClientConnectionInner<P>,
+        interval: &'a mut Pin<Box<Interval>>,
+        recv_future: &'a mut F,
+    ) -> Self {
+        Self {
+            client_inner,
+            interval,
+            recv_future: Pin::new(recv_future),
+        }
+    }
+}
+
+impl<'a, P, F> Future for ReceiveHeaderFuture<'a, P, F>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+    F: Future<Output = Result<RespHeader, RpcError>> + Unpin,
+{
+    type Output = Result<RespHeader, RpcError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let self_mut: &mut ReceiveHeaderFuture<'a, P, F> = self.get_mut();
+        let client_inner = self_mut.client_inner;
+
+        // clean timeout tasks
+        let mut tick_ready = false;
+        while self_mut.interval.as_mut().poll_tick(cx).is_ready() {
+            // consume all ticks in once call
+            tick_ready = true;
+        }
+        while tick_ready {
+            let clean_future = client_inner.packets_keeper.clean_timeout_tasks();
+            pin_mut!(clean_future);
+            match clean_future.poll(cx) {
+                Poll::Ready(()) => tick_ready = false,
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+
+        // recv header data
+        self_mut.recv_future.as_mut().poll(cx)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+    use async_trait::async_trait;
+    use bytes::BufMut;
+    use tokio::net::TcpListener;
+
+    use crate::{async_fuse::util::usize_to_u64, storage::cache::rpc::utils::get_u64_from_buf};
+
+    use super::*;
+    use std::{mem, time::Duration};
+
+    /// Request struct for test
+    #[derive(Debug, Default, Clone)]
+    pub struct TestRequest {
+        pub id: u64,
+    }
+
+    impl Encode for TestRequest {
+        fn encode(&self, buf: &mut BytesMut) {
+            buf.put_u64(self.id.to_le());
+        }
+    }
+
+    impl Decode for TestRequest {
+        fn decode(buf: &[u8]) -> Result<Self, RpcError> {
+            if buf.len() < 8 {
+                return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+            }
+            let id = get_u64_from_buf(buf, 0)?;
+            Ok(TestRequest { id })
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct TestPacket {
+        pub seq: u64,
+        pub op: u8,
+        pub request: TestRequest,
+        pub timestamp: u64,
+    }
+
+    impl Encode for TestPacket {
+        fn encode(&self, buf: &mut BytesMut) {
+            self.request.encode(buf);
+        }
+    }
+
+    #[async_trait]
+    impl Packet for TestPacket {
+        fn seq(&self) -> u64 {
+            self.seq
+        }
+
+        fn set_seq(&mut self, seq: u64) {
+            self.seq = seq;
+        }
+
+        fn op(&self) -> u8 {
+            self.op
+        }
+
+        fn set_op(&mut self, op: u8) {
+            self.op = op;
+        }
+
+        fn set_timestamp(&mut self, timestamp: u64) {
+            self.timestamp = timestamp;
+        }
+
+        fn get_timestamp(&self) -> u64 {
+            self.timestamp
+        }
+
+        fn set_resp_data(&mut self, _data: &[u8]) -> Result<(), RpcError> {
+            Ok(())
+        }
+
+        async fn set_result(self, _status: Result<(), RpcError>) {}
+
+        fn get_req_len(&self) -> u64 {
+            usize_to_u64(mem::size_of_val(&self.request))
+        }
+    }
+
+    // Helper function to setup a mock server
+    async fn setup_mock_server(addr: String, response: Vec<u8>) -> String {
+        let listener = TcpListener::bind(addr).await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                socket.write_all(&response).await.unwrap(); // Send a predefined response
+                socket.flush().await.unwrap();
+            }
+        });
+        addr
+    }
+
+    #[tokio::test]
+    async fn test_new_connection() {
+        // setup();
+        let local_addr = setup_mock_server("127.0.0.1:50050".to_owned(), vec![]).await;
+        let stream = TcpStream::connect(local_addr).await.unwrap();
+        let timeout_options = ClientTimeoutOptions {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            task_timeout: Duration::from_secs(60),
+            keep_alive_timeout: Duration::from_secs(30),
+        };
+        let client_id = 123;
+        let (sender, receiver) = oneshot::channel::<()>();
+        let connection = RpcClientConnectionInner::<TestPacket>::new(
+            stream,
+            timeout_options,
+            client_id,
+            receiver,
+        );
+        assert_eq!(connection.client_id, client_id);
+
+        sender.send(()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_recv_header() {
+        // setup();
+        let mut buf = BytesMut::new();
+        RespHeader {
+            seq: 1,
+            op: RespType::KeepAliveResponse.into(),
+            len: 0,
+        }
+        .encode(&mut buf);
+        let addr = setup_mock_server("127.0.0.1:50052".to_owned(), buf.to_vec()).await;
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let timeout_options = ClientTimeoutOptions {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            task_timeout: Duration::from_secs(60),
+            keep_alive_timeout: Duration::from_secs(30),
+        };
+        let (sender, receiver) = oneshot::channel::<()>();
+        let connection =
+            RpcClientConnectionInner::<TestPacket>::new(stream, timeout_options, 123, receiver);
+        let header = connection.recv_header().await.unwrap();
+        assert_eq!(header.seq, 1);
+        let resp_op: u8 = RespType::KeepAliveResponse.into();
+        assert_eq!(header.op, resp_op);
+        sender.send(()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_recv_len() {
+        // setup();
+        // Create a 10 len vector
+        let response = vec![0; 10];
+        let addr = setup_mock_server("127.0.0.1:50053".to_owned(), response).await;
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let timeout_options = ClientTimeoutOptions {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            task_timeout: Duration::from_secs(60),
+            keep_alive_timeout: Duration::from_secs(30),
+        };
+        let (sender, receiver) = oneshot::channel::<()>();
+        let connection =
+            RpcClientConnectionInner::<TestPacket>::new(stream, timeout_options, 123, receiver);
+        connection.recv_len(10).await.unwrap();
+
+        sender.send(()).unwrap();
+    }
+
+    struct TestData;
+    impl Encode for TestData {
+        fn encode(&self, buf: &mut BytesMut) {
+            let data = b"Hello, world!";
+            buf.extend_from_slice(data);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_data() {
+        // setup();
+        let addr = setup_mock_server("127.0.0.1:50054".to_owned(), vec![]).await;
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let timeout_options = ClientTimeoutOptions {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            task_timeout: Duration::from_secs(60),
+            keep_alive_timeout: Duration::from_secs(30),
+        };
+        let (sender, receiver) = oneshot::channel::<()>();
+        let connection =
+            RpcClientConnectionInner::<TestPacket>::new(stream, timeout_options, 123, receiver);
+        let req_header = ReqHeader {
+            seq: 1,
+            op: ReqType::KeepAliveRequest.into(),
+            len: 0,
+        };
+
+        connection.send_data(&req_header, None).await.unwrap();
+
+        sender.send(()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_next_seq() {
+        // setup();
+        let addr = setup_mock_server("127.0.0.1:50055".to_owned(), vec![]).await;
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let timeout_options = ClientTimeoutOptions {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            task_timeout: Duration::from_secs(60),
+            keep_alive_timeout: Duration::from_secs(30),
+        };
+        let client_id = 123;
+        let (sender, receiver) = oneshot::channel::<()>();
+        let connection = RpcClientConnectionInner::<TestPacket>::new(
+            stream,
+            timeout_options,
+            client_id,
+            receiver,
+        );
+        let seq1 = connection.next_seq();
+        let seq2 = connection.next_seq();
+        assert_eq!(seq1 + 1, seq2);
+
+        sender.send(()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_ping() {
+        // setup();
+        let mut buf = BytesMut::new();
+        RespHeader {
+            seq: 1,
+            op: RespType::KeepAliveResponse.into(),
+            len: 0,
+        }
+        .encode(&mut buf);
+        let addr = setup_mock_server("127.0.0.1:50056".to_owned(), buf.to_vec()).await;
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let timeout_options = ClientTimeoutOptions {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            task_timeout: Duration::from_secs(60),
+            keep_alive_timeout: Duration::from_secs(30),
+        };
+        let (sender, receiver) = oneshot::channel::<()>();
+        let connection =
+            RpcClientConnectionInner::<TestPacket>::new(stream, timeout_options, 123, receiver);
+        connection.ping().await.unwrap();
+
+        sender.send(()).unwrap();
+    }
+}

--- a/src/storage/cache/rpc/common.rs
+++ b/src/storage/cache/rpc/common.rs
@@ -1,0 +1,51 @@
+use std::time::Duration;
+
+/// Default tcp request memory buffer for the connection
+pub const DEFAULT_TCP_REQUEST_BUFFER_SIZE: usize = 1024 * 1024 * 8;
+/// Default tcp request memory buffer for the connection
+pub const DEFAULT_TCP_RESPONSE_BUFFER_SIZE: usize = 1024 * 1024 * 8;
+
+/// Options for the timeout of the connection
+#[derive(Debug, Clone)]
+pub struct ServerTimeoutOptions {
+    /// The timeout for reading data from the connection
+    pub read_timeout: Duration,
+    /// The timeout for writing data to the connection
+    pub write_timeout: Duration,
+    /// The timeout for closing idle (maybe dead) connection
+    pub idle_timeout: Duration,
+}
+
+impl Default for ServerTimeoutOptions {
+    fn default() -> Self {
+        Self {
+            read_timeout: Duration::from_secs(20),
+            write_timeout: Duration::from_secs(20),
+            idle_timeout: Duration::from_secs(120),
+        }
+    }
+}
+
+/// Options for the timeout of the connection
+#[derive(Debug, Clone)]
+pub struct ClientTimeoutOptions {
+    /// The timeout for reading data from the connection
+    pub read_timeout: Duration,
+    /// The timeout for writing data to the connection
+    pub write_timeout: Duration,
+    /// The timeout for recving packet task
+    pub task_timeout: Duration,
+    /// The timeout for keep-alive connection
+    pub keep_alive_timeout: Duration,
+}
+
+impl Default for ClientTimeoutOptions {
+    fn default() -> Self {
+        Self {
+            read_timeout: Duration::from_secs(20),
+            write_timeout: Duration::from_secs(20),
+            task_timeout: Duration::from_secs(120),
+            keep_alive_timeout: Duration::from_secs(60),
+        }
+    }
+}

--- a/src/storage/cache/rpc/error.rs
+++ b/src/storage/cache/rpc/error.rs
@@ -1,0 +1,25 @@
+use std::fmt;
+
+/// Error types for the RPC server and client
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RpcError {
+    /// The request is invalid.
+    InvalidRequest(String),
+    /// The response is invalid.
+    InvalidResponse(String),
+    /// The server/client meet an internal error.
+    InternalError(String),
+    /// The request is timeout
+    Timeout(String),
+}
+
+impl fmt::Display for RpcError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::InvalidRequest(ref msg) => write!(f, "Invalid request: {msg}"),
+            Self::InvalidResponse(ref msg) => write!(f, "Invalid response: {msg}"),
+            Self::InternalError(ref msg) => write!(f, "Internal error: {msg}"),
+            Self::Timeout(ref msg) => write!(f, "Timeout: {msg}"),
+        }
+    }
+}

--- a/src/storage/cache/rpc/message.rs
+++ b/src/storage/cache/rpc/message.rs
@@ -1,0 +1,396 @@
+use std::mem;
+
+use async_trait::async_trait;
+use bytes::{BufMut, BytesMut};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use tracing::error;
+
+use crate::async_fuse::util::usize_to_u64;
+
+use super::{
+    error::RpcError,
+    packet::{Decode, Encode, Packet},
+    utils::get_u64_from_buf,
+};
+
+/// The request type of the request.
+#[derive(Debug, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum ReqType {
+    /// The keep alive request.
+    KeepAliveRequest = 0,
+    /// The file block request.
+    FileBlockRequest = 1,
+}
+
+/// The operation type of the response.
+#[derive(Debug, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum RespType {
+    /// The keep alive response.
+    KeepAliveResponse = 0,
+    /// The file block response.
+    FileBlockResponse = 1,
+}
+
+/// Common data structures shared between the client and server.
+#[derive(Debug, Default, Clone)]
+pub struct FileBlockRequest {
+    /// The file ID.
+    pub file_id: u64,
+    /// The block ID.
+    pub block_id: u64,
+    /// The block size.
+    pub block_size: u64,
+    /// The block version
+    pub block_version: u64,
+    /// The hashring version
+    /// The latest hashring version
+    /// We will return current hashring version in rpc server,
+    /// client will check if the hashring version is old as the latest one.
+    pub hash_ring_version: u64,
+}
+
+impl Encode for FileBlockRequest {
+    /// Encode the file block request into a byte buffer.
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.file_id.to_le());
+        buf.put_u64(self.block_id.to_le());
+        buf.put_u64(self.block_size.to_le());
+        buf.put_u64(self.block_version.to_le());
+        buf.put_u64(self.hash_ring_version.to_le());
+    }
+}
+
+impl Decode for FileBlockRequest {
+    /// Decode the byte buffer into a file block request.
+    fn decode(buf: &[u8]) -> Result<Self, RpcError> {
+        if buf.len() < 32 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let file_id = get_u64_from_buf(buf, 0)?;
+        let block_id = get_u64_from_buf(buf, 8)?;
+        let block_size = get_u64_from_buf(buf, 16)?;
+        let block_version = get_u64_from_buf(buf, 24)?;
+        let hash_ring_version = get_u64_from_buf(buf, 32)?;
+
+        Ok(FileBlockRequest {
+            file_id,
+            block_id,
+            block_size,
+            block_version,
+            hash_ring_version,
+        })
+    }
+}
+
+/// The response to a file block request.
+#[derive(Debug, Default, Clone)]
+pub struct FileBlockResponse {
+    /// The file ID.
+    pub file_id: u64,
+    /// The block ID.
+    pub block_id: u64,
+    /// The block size.
+    pub block_size: u64,
+    /// The block version
+    pub block_version: u64,
+    /// The hashring version
+    /// The latest hashring version
+    /// We will return current hashring version in rpc server,
+    /// client will check if the hashring version is old as the latest one.
+    pub hash_ring_version: u64,
+    /// The status of the response.
+    pub status: StatusCode,
+    /// The data of the block.
+    pub data: Vec<u8>,
+}
+impl Encode for FileBlockResponse {
+    /// Encode the file block response into a byte buffer.
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.file_id.to_le());
+        buf.put_u64(self.block_id.to_le());
+        buf.put_u64(self.block_size.to_le());
+        buf.put_u64(self.block_version.to_le());
+        buf.put_u64(self.hash_ring_version.to_le());
+        buf.put_u8(self.status.into());
+        buf.put_slice(&self.data);
+    }
+}
+
+impl Decode for FileBlockResponse {
+    //// Decode the byte buffer into a file block response.
+    fn decode(buf: &[u8]) -> Result<Self, RpcError> {
+        if buf.len() < 41 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let file_id = get_u64_from_buf(buf, 0)?;
+        let block_id = get_u64_from_buf(buf, 8)?;
+        let block_size = get_u64_from_buf(buf, 16)?;
+        let block_version = get_u64_from_buf(buf, 24)?;
+        let hash_ring_version = get_u64_from_buf(buf, 32)?;
+        let status = match buf.get(40) {
+            Some(&status) => match StatusCode::try_from(status) {
+                Ok(status) => status,
+                Err(_) => return Err(RpcError::InternalError("Invalid status code".to_owned())),
+            },
+            None => return Err(RpcError::InternalError("Invalid status code".to_owned())),
+        };
+        let data = buf.get(41..).unwrap_or(&[]).to_vec();
+        let data_len = usize_to_u64(data.len());
+        if data_len != block_size {
+            return Err(RpcError::InternalError(format!(
+                "Insufficient block size: {block_size}, data len is : {data_len}"
+            )));
+        }
+
+        Ok(FileBlockResponse {
+            file_id,
+            block_id,
+            block_size,
+            block_version,
+            hash_ring_version,
+            status,
+            data,
+        })
+    }
+}
+
+/// The status code of the response.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+
+pub enum StatusCode {
+    /// The request is successful.
+    Success = 0,
+    /// The request is not found.
+    NotFound = 1,
+    /// The request is invalid.
+    InternalError = 2,
+    /// The request is out dated.
+    VersionMismatch = 3,
+}
+
+impl Default for StatusCode {
+    /// Get the default status code.
+    fn default() -> Self {
+        Self::Success
+    }
+}
+
+/// The file block packet for client
+/// This struct impl packet trait and support file request and response
+#[derive(Debug, Clone)]
+pub struct FileBlockPacket {
+    /// The sequence number of the packet.
+    pub seq: u64,
+    /// The operation type of the packet.
+    pub op: u8,
+    /// The timestamp of the packet.
+    pub timestamp: u64,
+    /// The file block request struct.
+    pub request: FileBlockRequest,
+    /// The buffer of the packet, used to store response data.
+    pub response: Option<FileBlockResponse>,
+    /// The sender to send response back to caller.
+    pub done_tx: flume::Sender<Result<FileBlockResponse, FileBlockRequest>>,
+}
+
+impl FileBlockPacket {
+    /// Create a new file block packet.
+    #[must_use]
+    pub fn new(
+        block_request: FileBlockRequest,
+        done_tx: flume::Sender<Result<FileBlockResponse, FileBlockRequest>>,
+    ) -> Self {
+        Self {
+            // Will be auto set by client
+            seq: 0,
+            // Set operation
+            op: ReqType::FileBlockRequest.into(),
+            request: block_request,
+            timestamp: 0,
+            response: None,
+            done_tx,
+        }
+    }
+}
+
+impl Encode for FileBlockPacket {
+    /// Encode the file block packet into a byte buffer.
+    fn encode(&self, buffer: &mut BytesMut) {
+        self.request.encode(buffer);
+    }
+}
+
+#[async_trait]
+impl Packet for FileBlockPacket {
+    /// Get the sequence number of the packet.
+    fn seq(&self) -> u64 {
+        self.seq
+    }
+
+    /// Set the sequence number of the packet.
+    fn set_seq(&mut self, seq: u64) {
+        self.seq = seq;
+    }
+
+    /// Get the operation type of the packet.
+    fn op(&self) -> u8 {
+        self.op
+    }
+
+    /// Set the operation type of the packet.
+    fn set_op(&mut self, op: u8) {
+        self.op = op;
+    }
+
+    /// Get the timestamp of the packet.
+    fn set_timestamp(&mut self, timestamp: u64) {
+        self.timestamp = timestamp;
+    }
+
+    /// get the timestamp of the packet.
+    fn get_timestamp(&self) -> u64 {
+        self.timestamp
+    }
+
+    /// Set response data to current packet
+    fn set_resp_data(&mut self, data: &[u8]) -> Result<(), RpcError> {
+        self.response = Some(FileBlockResponse::decode(data)?);
+        Ok(())
+    }
+
+    /// Get the response data of the packet.
+    async fn set_result(self, status: Result<(), RpcError>) {
+        match status {
+            Ok(()) => {
+                if let Some(resp) = self.response {
+                    match self.done_tx.send_async(Ok(resp)).await {
+                        Ok(()) => {}
+                        Err(err) => {
+                            error!("Failed to set result: {:?}", err);
+                        }
+                    }
+                } else {
+                    error!("Failed to set result: response is None");
+                    match self.done_tx.send_async(Err(self.request.clone())).await {
+                        Ok(()) => {}
+                        Err(err) => {
+                            error!("Failed to set result: {:?}", err);
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                error!("Failed to set result: {:?}", err);
+                match self.done_tx.send_async(Err(self.request.clone())).await {
+                    Ok(()) => {}
+                    Err(err) => {
+                        error!("Failed to set result: {:?}", err);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Get request size to construct request header
+    fn get_req_len(&self) -> u64 {
+        usize_to_u64(mem::size_of_val(&self.request))
+    }
+}
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod test {
+    use crate::storage::cache::rpc::utils::u64_to_usize;
+
+    use super::*;
+
+    #[test]
+    fn test_file_block_request_encode_decode() {
+        let file_id = 123;
+        let block_id = 456;
+        let block_size = 789;
+        let block_version = 10;
+        let hash_ring_version = 20;
+
+        let request = FileBlockRequest {
+            file_id,
+            block_id,
+            block_size,
+            block_version,
+            hash_ring_version,
+        };
+
+        let mut buffer = BytesMut::new();
+        request.encode(&mut buffer);
+
+        let decoded_request = FileBlockRequest::decode(&buffer).unwrap();
+
+        assert_eq!(decoded_request.file_id, file_id);
+        assert_eq!(decoded_request.block_id, block_id);
+        assert_eq!(decoded_request.block_size, block_size);
+        assert_eq!(decoded_request.block_version, block_version);
+        assert_eq!(decoded_request.hash_ring_version, hash_ring_version);
+    }
+
+    #[test]
+    fn test_file_block_response_encode_decode() {
+        let file_id = 123;
+        let block_id = 456;
+        let block_size = 5;
+        let block_version = 10;
+        let hash_ring_version = 20;
+        let status = StatusCode::Success;
+        let data = vec![1, 2, 3, 4, 5];
+
+        let response = FileBlockResponse {
+            file_id,
+            block_id,
+            block_size,
+            block_version,
+            hash_ring_version,
+            status,
+            data: data.clone(),
+        };
+
+        let mut buffer = BytesMut::new();
+        response.encode(&mut buffer);
+
+        let decoded_response = FileBlockResponse::decode(&buffer).unwrap();
+
+        assert_eq!(decoded_response.file_id, file_id);
+        assert_eq!(decoded_response.block_id, block_id);
+        assert_eq!(decoded_response.block_size, block_size);
+        assert_eq!(decoded_response.block_version, block_version);
+        assert_eq!(decoded_response.hash_ring_version, hash_ring_version);
+        assert_eq!(decoded_response.status, status);
+        assert_eq!(decoded_response.data, data);
+    }
+
+    #[test]
+    fn test_file_block_packet_encode() {
+        let file_id = 123;
+        let block_id = 456;
+        let block_size = 5;
+        let block_version = 10;
+        let hash_ring_version = 20;
+
+        let request = FileBlockRequest {
+            file_id,
+            block_id,
+            block_size,
+            block_version,
+            hash_ring_version,
+        };
+
+        let (done_tx, _) = flume::unbounded();
+        let packet = FileBlockPacket::new(request, done_tx);
+
+        let mut buffer = BytesMut::new();
+        packet.encode(&mut buffer);
+
+        let expected_buffer_len = u64_to_usize(packet.get_req_len());
+        assert_eq!(buffer.len(), expected_buffer_len);
+    }
+}

--- a/src/storage/cache/rpc/mod.rs
+++ b/src/storage/cache/rpc/mod.rs
@@ -1,0 +1,26 @@
+/// This module contains the RPC server and client for the cache service.
+
+/// The client module contains the client implementation for the cache service.
+pub mod client;
+
+/// The common module contains the shared structures and functions for the cache service.
+pub mod common;
+
+/// The error module contains the error types for the cache service.
+pub mod error;
+
+/// The message module contains the data structures shared between the client and server.
+pub mod message;
+
+/// The server module contains the server implementation for the cache service.
+pub mod server;
+
+/// The workerpool module contains the worker pool implementation for the cache service.
+pub mod workerpool;
+
+/// The packet module contains the packet encoding and decoding functions for the cache service.
+pub mod packet;
+
+/// The utils module contains the utility functions for the cache service.
+#[macro_use]
+pub mod utils;

--- a/src/storage/cache/rpc/packet.rs
+++ b/src/storage/cache/rpc/packet.rs
@@ -1,0 +1,514 @@
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
+
+use async_trait::async_trait;
+use bytes::{BufMut, BytesMut};
+use tokio::{sync::Mutex, time::Instant};
+use tracing::debug;
+
+use super::{
+    error::RpcError,
+    utils::{get_u64_from_buf, get_u8_from_buf, u64_to_usize},
+};
+
+/// The size of the request header.
+pub const REQ_HEADER_SIZE: u64 = 17;
+/// The size of the response header.
+pub const RESP_HEADER_SIZE: u64 = 17;
+
+/// The Encode trait is used to encode a message structure into a byte buffer.
+pub trait Encode {
+    /// Encode the message into a byte buffer, this operation will append to buffer
+    /// If you need to encode from start, you should clear the buffer first
+    fn encode(&self, buf: &mut BytesMut);
+}
+
+/// The Decode trait is used to message a byte buffer into a data structure.
+pub trait Decode {
+    /// Decode the byte buffer into a data structure
+    fn decode(buf: &[u8]) -> Result<Self, RpcError>
+    where
+        Self: Sized;
+}
+
+/// The message module contains the data structures shared between the client and server.
+/// Assume the cluster only contains one version server, so we won't consider the compatibility
+#[derive(Debug)]
+pub struct ReqHeader {
+    /// The sequence number of the request.
+    pub seq: u64,
+    /// The operation type of the request.
+    /// 0: keepalive
+    /// other is defined by the user
+    pub op: u8,
+    /// The length of the request.
+    pub len: u64,
+}
+
+impl Encode for ReqHeader {
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.seq.to_le());
+        buf.put_u8(self.op.to_le());
+        buf.put_u64(self.len.to_le());
+    }
+}
+
+impl Decode for ReqHeader {
+    fn decode(buf: &[u8]) -> Result<Self, RpcError> {
+        if buf.len() < u64_to_usize(REQ_HEADER_SIZE) {
+            return Err(RpcError::InvalidRequest(
+                "Invalid request header".to_owned(),
+            ));
+        }
+
+        let seq = get_u64_from_buf(buf, 0)?;
+        let op = get_u8_from_buf(buf, 8)?;
+        let len = get_u64_from_buf(buf, 9)?;
+
+        Ok(ReqHeader { seq, op, len })
+    }
+}
+
+/// The message module contains the data structures shared between the client and server.
+/// Assume the cluster only contains one version server, so we won't consider the compatibility
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct RespHeader {
+    /// The sequence number of the response.
+    pub seq: u64,
+    /// The operation type of the response.
+    /// 0: keepalive
+    /// other is defined by the user
+    pub op: u8,
+    /// The length of the response.
+    pub len: u64,
+}
+
+impl Encode for RespHeader {
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.seq.to_le());
+        buf.put_u8(self.op);
+        buf.put_u64(self.len.to_le());
+    }
+}
+
+impl Decode for RespHeader {
+    fn decode(buf: &[u8]) -> Result<Self, RpcError> {
+        if buf.len() < u64_to_usize(RESP_HEADER_SIZE) {
+            return Err(RpcError::InvalidResponse(
+                "Invalid response header".to_owned(),
+            ));
+        }
+
+        let seq = get_u64_from_buf(buf, 0)?;
+        let op = get_u8_from_buf(buf, 8)?;
+        let len = get_u64_from_buf(buf, 9)?;
+
+        Ok(RespHeader { seq, op, len })
+    }
+}
+
+/// Define the Packet trait, for once send or receive packets
+///
+/// Client will create a packet and serialize it to a byte array,
+/// send it to the server. And create a temp response packet in client.
+///
+/// Server will receive the packet, deserialize it to a packet struct,
+/// and process the request, then create a response packet and serialize.
+///
+/// Client will receive the response packet and deserialize it to a packet struct.
+/// and check the status of the packet and the response.
+#[async_trait]
+pub trait Packet: Sync + Send + Clone + Debug + Encode {
+    /// Get the packet seq number
+    fn seq(&self) -> u64;
+    /// Set the packet seq number
+    fn set_seq(&mut self, seq: u64);
+
+    /// Get packet type
+    fn op(&self) -> u8;
+    /// Set packet type
+    fn set_op(&mut self, op: u8);
+
+    /// Set timestamp
+    fn set_timestamp(&mut self, timestamp: u64);
+    /// Get timestamp
+    fn get_timestamp(&self) -> u64;
+
+    /// Get request buf length
+    /// This function is used to get the length of the request body size.
+    fn get_req_len(&self) -> u64;
+
+    /// Serialize response data to bytes
+    /// We will get the serialized response data by accessing the property of the Packet
+    fn set_resp_data(&mut self, data: &[u8]) -> Result<(), RpcError>;
+
+    /// Set the packet result, and we will send the response buffer to caller, caller and directly decode this buffer
+    /// The buffer is different in req and resp, so we can not hold one buffer in packet
+    async fn set_result(self, status: Result<(), RpcError>);
+}
+/// The `PacketsInner` struct is used to store the current tasks.
+#[derive(Debug)]
+struct PacketsInner<P>
+where
+    P: Packet + Send + Sync,
+{
+    /// current tasks, marked by the seq number
+    packets: HashMap<u64, P>,
+}
+
+impl<P: Packet + Send + Sync> PacketsInner<P> {
+    /// Create a new `PacketsInner`
+    #[must_use]
+    pub fn new() -> Self {
+        PacketsInner {
+            packets: HashMap::new(),
+        }
+    }
+
+    /// Add a task to the packets
+    pub fn add_task(&mut self, seq: u64, packet: P) {
+        self.packets.insert(seq, packet);
+    }
+
+    /// Get a task from the packets and remove it
+    pub fn remove_task(&mut self, seq: u64) -> Option<P> {
+        // remove packet and return it
+        self.packets.remove(&seq)
+    }
+
+    /// Clean pending tasks as timeout
+    /// In first step, we will try to mark the task as timeout if it is pending and timeout
+    /// In 10 * timeout time, we will force to remove the task if the task is not consumed
+    pub async fn clean_timeout_tasks(&mut self, current_timestamp: u64, timeout: u64) {
+        let mut last_timeout_packets = Vec::new();
+        for (seq, packet) in &mut self.packets {
+            // Check if the task is timeout
+            let timestamp = packet.get_timestamp();
+            if current_timestamp - timestamp > timeout {
+                // Set the task as timeout
+                last_timeout_packets.push(*seq);
+            }
+        }
+
+        // clean the timeout packets
+        for seq in last_timeout_packets {
+            if let Some(packet) = self.packets.remove(&seq) {
+                debug!("Task {} is timeout", seq);
+                packet
+                    .set_result(Err(RpcError::Timeout(format!("Task {seq} is timeout"))))
+                    .await;
+            } else {
+                debug!("Task {} is timeout, but not found in the packets", seq);
+                continue;
+            }
+        }
+    }
+
+    /// Purge the outdated tasks when connection is timeout
+    pub async fn purge_outdated_tasks(&mut self) {
+        // Take ownership and pass it to the caller
+        for (seq, packet) in self.packets.drain() {
+            packet
+                .set_result(Err(RpcError::Timeout(format!("Task {seq} is timeout"))))
+                .await;
+        }
+
+        self.packets.clear();
+    }
+}
+
+/// The `PacketsKeeper` struct is used to store the current and previous tasks.
+/// It will be modified by single task, so we don't need to share it.
+#[derive(Debug)]
+pub struct PacketsKeeper<P>
+where
+    P: Packet + Send + Sync,
+{
+    /// current tasks, marked by the seq number
+    inner: Arc<Mutex<PacketsInner<P>>>,
+    /// buffer sender
+    buffer_packets_sender: flume::Sender<P>,
+    /// buffer receiver
+    buffer_packets_receiver: flume::Receiver<P>,
+    /// The maximum number of tasks that can be stored in the previous_tasks
+    /// We will mark the task as timeout if it is in the previous_tasks and the previous_tasks is full
+    timeout: u64,
+    /// current timestamp
+    current_time: Instant,
+}
+
+impl<P: Packet + Send + Sync> PacketsKeeper<P> {
+    /// Create a new `PacketsKeeper`
+    #[must_use]
+    pub fn new(timeout: u64) -> Self {
+        let (buffer_packets_sender, buffer_packets_receiver) = flume::bounded::<P>(1000);
+        let packets_inner = Arc::new(Mutex::new(PacketsInner::new()));
+        let current_time = tokio::time::Instant::now();
+
+        PacketsKeeper {
+            inner: packets_inner,
+            buffer_packets_sender,
+            buffer_packets_receiver,
+            timeout,
+            current_time,
+        }
+    }
+
+    /// Add a task to the packets
+    pub fn add_task(&self, packet: &mut P) -> Result<(), RpcError> {
+        // TODO: use a global atomic ticker(updated by check_loop) or read current time?
+        let timestamp = self.current_time.elapsed().as_secs();
+        packet.set_timestamp(timestamp);
+        self.buffer_packets_sender
+            .send(packet.to_owned())
+            .map_err(|e| {
+                RpcError::InternalError(format!("Failed to send packet to buffer: {e:?}"))
+            })?;
+
+        Ok(())
+    }
+
+    /// Clean pending tasks as timeout
+    pub async fn clean_timeout_tasks(&self) {
+        {
+            let mut packets_inner = self.inner.lock().await;
+            while let Ok(packet) = self.buffer_packets_receiver.try_recv() {
+                let seq = packet.seq();
+                packets_inner.add_task(seq, packet);
+            }
+
+            let current_timestamp = self.current_time.elapsed().as_secs();
+            packets_inner
+                .clean_timeout_tasks(current_timestamp, self.timeout)
+                .await;
+        }
+    }
+
+    /// Purge the outdated tasks when connection is timeout
+    pub async fn purge_outdated_tasks(&self) {
+        let mut packets_inner = self.inner.lock().await;
+        while let Ok(packet) = self.buffer_packets_receiver.try_recv() {
+            let seq = packet.seq();
+            packets_inner.add_task(seq, packet);
+        }
+
+        packets_inner.purge_outdated_tasks().await;
+    }
+
+    /// Get a task from the packets, and update data in the task
+    pub async fn take_task(&self, seq: u64, resp_buffer: &mut BytesMut) -> Result<(), RpcError> {
+        // Try to sync from buffer
+        {
+            let mut packets_inner = self.inner.lock().await;
+            while let Ok(packet) = self.buffer_packets_receiver.try_recv() {
+                let seq = packet.seq();
+                packets_inner.add_task(seq, packet);
+            }
+
+            if let Some(mut packet) = packets_inner.remove_task(seq) {
+                let seq = packet.seq();
+                // Update status data
+                // Try to set result code in `set_resp_data`
+                let set_result = packet.set_resp_data(resp_buffer);
+                match set_result {
+                    Ok(()) => {
+                        debug!("{:?} Success to set response data, seq: {:?}", self, seq);
+                        packet.set_result(Ok(())).await;
+                    }
+                    Err(err) => {
+                        debug!(
+                            "{:?} Failed to set response data: {:?} with error {:?}",
+                            self, seq, err
+                        );
+                        packet
+                            .set_result(Err(RpcError::InternalError(format!(
+                                "Failed to set response data: {seq:?} with error {err:?}"
+                            ))))
+                            .await;
+                    }
+                }
+                packets_inner.remove_task(seq);
+
+                return Ok(());
+            }
+        }
+
+        Err(RpcError::InvalidRequest(format!("can not find seq: {seq}")))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(dead_code)]
+mod tests {
+    use std::{mem, thread::sleep, time};
+
+    use crate::async_fuse::util::usize_to_u64;
+
+    use super::*;
+
+    #[derive(Debug, Clone)]
+    struct TestRequest {
+        pub mock: u64,
+    }
+
+    impl Encode for TestRequest {
+        fn encode(&self, _buf: &mut BytesMut) {}
+    }
+
+    #[derive(Debug, Clone)]
+    struct TestPacket {
+        pub seq: u64,
+        pub op: u8,
+        pub timestamp: u64,
+        pub request: TestRequest,
+        pub buf: BytesMut,
+        pub sender: flume::Sender<Result<(), RpcError>>,
+    }
+
+    impl Encode for TestPacket {
+        fn encode(&self, buf: &mut BytesMut) {
+            self.request.encode(buf);
+        }
+    }
+
+    #[async_trait]
+    impl Packet for TestPacket {
+        fn seq(&self) -> u64 {
+            self.seq
+        }
+
+        fn set_seq(&mut self, seq: u64) {
+            self.seq = seq;
+        }
+
+        fn op(&self) -> u8 {
+            self.op
+        }
+
+        fn set_op(&mut self, op: u8) {
+            self.op = op;
+        }
+
+        fn set_timestamp(&mut self, timestamp: u64) {
+            self.timestamp = timestamp;
+        }
+
+        fn get_timestamp(&self) -> u64 {
+            self.timestamp
+        }
+
+        fn get_req_len(&self) -> u64 {
+            usize_to_u64(mem::size_of_val(&self.request))
+        }
+
+        fn set_resp_data(&mut self, _data: &[u8]) -> Result<(), RpcError> {
+            Ok(())
+        }
+
+        async fn set_result(self, status: Result<(), RpcError>) {
+            self.sender.send(status).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_req_header_encode_and_decode() {
+        let header = ReqHeader {
+            seq: 1,
+            op: 2,
+            len: 3,
+        };
+        let mut buf = BytesMut::new();
+        header.encode(&mut buf);
+        assert_eq!(buf.len(), u64_to_usize(REQ_HEADER_SIZE));
+
+        let header_decoded = ReqHeader::decode(&buf).unwrap();
+        assert_eq!(header_decoded.seq, 1);
+        assert_eq!(header_decoded.op, 2);
+        assert_eq!(header_decoded.len, 3);
+    }
+
+    #[test]
+    fn test_resp_header_encode_and_decode() {
+        let header = RespHeader {
+            seq: 1,
+            op: 2,
+            len: 3,
+        };
+        let mut buf = BytesMut::new();
+        header.encode(&mut buf);
+        assert_eq!(buf.len(), u64_to_usize(RESP_HEADER_SIZE));
+
+        let header_decoded = RespHeader::decode(&buf).unwrap();
+        assert_eq!(header_decoded.seq, 1);
+        assert_eq!(header_decoded.op, 2);
+        assert_eq!(header_decoded.len, 3);
+    }
+
+    #[tokio::test]
+    async fn test_packets_keeper() {
+        let packets_keeper = PacketsKeeper::<TestPacket>::new(1);
+
+        // You can control what is need to be send.
+        let (tx, rx) = flume::unbounded::<Result<(), RpcError>>();
+
+        // Success
+        let mut packet = TestPacket {
+            seq: 1,
+            op: 2,
+            timestamp: 0,
+            buf: BytesMut::new(),
+            sender: tx.clone(),
+            request: TestRequest { mock: 0 },
+        };
+        packets_keeper.add_task(&mut packet).unwrap();
+        packets_keeper
+            .take_task(packet.seq(), &mut BytesMut::new())
+            .await
+            .unwrap();
+        match rx.recv() {
+            Ok(Ok(())) => {
+                debug!("Success to get response");
+            }
+            _ => panic!("Failed to get response"),
+        }
+
+        // Mark timeout
+        let mut packet_2 = TestPacket {
+            seq: 2,
+            op: 2,
+            timestamp: 0,
+            buf: BytesMut::new(),
+            sender: tx.clone(),
+            request: TestRequest { mock: 0 },
+        };
+        packets_keeper.add_task(&mut packet_2).unwrap();
+        sleep(time::Duration::from_secs(2));
+        packets_keeper.clean_timeout_tasks().await;
+        match rx.recv() {
+            Ok(res) => {
+                debug!("Task is timeout {:?}", res);
+                assert!(res.is_err());
+            }
+            _ => panic!("Failed to get response"),
+        }
+
+        // Purge the timeout task
+        let mut packet_3 = TestPacket {
+            seq: 3,
+            op: 2,
+            timestamp: 0,
+            buf: BytesMut::new(),
+            sender: tx.clone(),
+            request: TestRequest { mock: 0 },
+        };
+        packets_keeper.add_task(&mut packet_3).unwrap();
+        packets_keeper.purge_outdated_tasks().await;
+        match rx.recv() {
+            Ok(res) => {
+                debug!("Task is timeout {:?}", res);
+                assert!(res.is_err());
+            }
+            _ => panic!("Failed to get response"),
+        }
+    }
+}

--- a/src/storage/cache/rpc/server.rs
+++ b/src/storage/cache/rpc/server.rs
@@ -1,0 +1,493 @@
+use std::{
+    cell::UnsafeCell,
+    fmt::{self, Debug},
+    sync::Arc,
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use bytes::BytesMut;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net,
+    sync::mpsc,
+    task,
+};
+
+use crate::{read_exact_timeout, write_all_timeout};
+
+use super::{
+    common::{self, ServerTimeoutOptions},
+    error::RpcError,
+    message::{ReqType, RespType},
+    packet::{Decode, Encode, ReqHeader, RespHeader, REQ_HEADER_SIZE},
+    utils::u64_to_usize,
+    workerpool::WorkerPool,
+};
+
+use tracing::{debug, error, info};
+
+/// Define trait for implementing the RPC server connection handler.
+#[async_trait]
+pub trait RpcServerConnectionHandler {
+    /// Dispatch the handler for the connection.
+    async fn dispatch(
+        &self,
+        req_header: ReqHeader,
+        req_buffer: &[u8],
+        done_tx: mpsc::UnboundedSender<Vec<u8>>,
+    );
+}
+
+/// The connection for the RPC server.
+#[derive(Clone, Debug)]
+pub struct RpcServerConnection<T>
+where
+    T: RpcServerConnectionHandler + Send + Sync + 'static,
+{
+    /// The inner connection for the RPC server.
+    inner: Arc<RpcServerConnectionInner<T>>,
+}
+
+///
+#[derive(Debug)]
+pub struct RpcServerConnectionInner<T>
+where
+    T: RpcServerConnectionHandler + Send + Sync + 'static,
+{
+    /// The TCP stream for the connection.
+    stream: UnsafeCell<net::TcpStream>,
+    /// The worker pool for the connection.
+    /// TODO:
+    #[allow(dead_code)]
+    worker_pool: Arc<WorkerPool>,
+    /// Options for the timeout of the connection
+    timeout_options: ServerTimeoutOptions,
+    /// The handler for the connection
+    dispatch_handler: T,
+    /// Response buffer, try to reuse same buffer to reduce memory allocation
+    /// In case of the response is too large, we need to consider the buffer size
+    /// Init size is 4MB
+    /// Besides, we want to reduce memory copy, and read/write the response to the same data buffer
+    req_buf: UnsafeCell<BytesMut>,
+}
+
+/// Current implementation is safe because the stream is only accessed by one thread
+unsafe impl<T> Send for RpcServerConnectionInner<T> where
+    T: RpcServerConnectionHandler + Send + Sync + 'static
+{
+}
+
+/// Current implementation is safe because the stream is only accessed by one thread
+unsafe impl<T> Sync for RpcServerConnectionInner<T> where
+    T: RpcServerConnectionHandler + Send + Sync + 'static
+{
+}
+
+impl<T> RpcServerConnectionInner<T>
+where
+    T: RpcServerConnectionHandler + Send + Sync + 'static,
+{
+    /// Create a new RPC server connection.
+    pub fn new(
+        stream: net::TcpStream,
+        worker_pool: Arc<WorkerPool>,
+        timeout_options: ServerTimeoutOptions,
+        dispatch_handler: T,
+    ) -> Self {
+        Self {
+            stream: UnsafeCell::new(stream),
+            worker_pool,
+            timeout_options,
+            dispatch_handler,
+            req_buf: UnsafeCell::new(BytesMut::with_capacity(
+                common::DEFAULT_TCP_REQUEST_BUFFER_SIZE,
+            )),
+        }
+    }
+
+    /// Recv request header from the stream
+    pub async fn recv_header(&self) -> Result<ReqHeader, RpcError> {
+        // Try to read to buffer
+        match self
+            .recv_len(REQ_HEADER_SIZE, self.timeout_options.idle_timeout)
+            .await
+        {
+            Ok(()) => {}
+            Err(err) => {
+                debug!("Failed to receive request header: {:?}", err);
+                return Err(err);
+            }
+        }
+
+        let buffer: &mut BytesMut = unsafe { &mut *self.req_buf.get() };
+        let req_header = ReqHeader::decode(buffer)?;
+        debug!("Received request header: {:?}", req_header);
+
+        Ok(req_header)
+    }
+
+    /// Recv request body from the stream
+    pub async fn recv_len(&self, len: u64, recv_timeout: Duration) -> Result<(), RpcError> {
+        let mut req_buffer: &mut BytesMut = unsafe { &mut *self.req_buf.get() };
+        req_buffer.resize(u64_to_usize(len), 0);
+        let reader = self.get_stream_mut();
+        match read_exact_timeout!(reader, &mut req_buffer, recv_timeout).await {
+            Ok(size) => {
+                debug!("Received request body: {:?}", size);
+                Ok(())
+            }
+            Err(err) => {
+                debug!("Failed to receive request: {:?}", err);
+                Err(RpcError::InternalError(err.to_string()))
+            }
+        }
+    }
+
+    /// Send response to the stream
+    /// The response is a byte array, contains the response header and body.
+    pub async fn send_response(&self, resp: &[u8]) -> Result<(), RpcError> {
+        let writer = self.get_stream_mut();
+        match write_all_timeout!(writer, resp, self.timeout_options.write_timeout).await {
+            Ok(()) => {
+                debug!("Sent response successfully: {:?}", resp.len());
+                Ok(())
+            }
+            Err(err) => {
+                debug!("Failed to send response: {:?}", err);
+                Err(RpcError::InternalError(err.to_string()))
+            }
+        }
+    }
+
+    /// Get stream with mutable reference
+    #[allow(clippy::mut_from_ref)]
+    fn get_stream_mut(&self) -> &mut net::TcpStream {
+        // Current implementation is safe because the stream is only accessed by one thread
+        unsafe { &mut *self.stream.get() }
+    }
+}
+
+impl<T> RpcServerConnection<T>
+where
+    T: RpcServerConnectionHandler + Send + Sync + 'static,
+{
+    /// Create a new RPC server connection.
+    pub fn new(
+        stream: net::TcpStream,
+        worker_pool: Arc<WorkerPool>,
+        timeout_options: ServerTimeoutOptions,
+        dispatch_handler: T,
+    ) -> Self {
+        let inner = Arc::new(RpcServerConnectionInner::new(
+            stream,
+            worker_pool,
+            timeout_options,
+            dispatch_handler,
+        ));
+        Self { inner }
+    }
+
+    /// Dispatch the handler for the connection.
+    async fn dispatch(&self, req_header: ReqHeader, done_tx: mpsc::UnboundedSender<Vec<u8>>) {
+        // Dispatch the handler for the connection
+        let seq = req_header.seq;
+        let body_len = req_header.len;
+        if let Ok(req_type) = ReqType::try_from(req_header.op) {
+            debug!(
+                "Dispatch request with header type: {:?}, seq: {:?}, body_len: {:?}",
+                req_type, seq, body_len
+            );
+            if let ReqType::KeepAliveRequest = req_type {
+                // Keep-alive request
+                // Directly send keepalive response to client, do not need to submit to worker pool.
+                // In current implementation, we just send keepalive header to the client stream
+                let resp_header = RespHeader {
+                    seq,
+                    op: RespType::KeepAliveResponse.into(),
+                    len: 0,
+                };
+                // Only one process will access this buffer, so we can use this buffer directly.
+                let resp_buffer: &mut BytesMut = unsafe { &mut *self.inner.req_buf.get() };
+                RespHeader::encode(&resp_header, resp_buffer);
+                if let Ok(res) = self.inner.send_response(resp_buffer).await {
+                    debug!("Sent keepalive response: {:?}", res);
+                } else {
+                    error!("Failed to send keepalive response");
+                }
+            } else {
+                // Try to read the request body
+                match self
+                    .inner
+                    .recv_len(body_len, self.inner.timeout_options.read_timeout)
+                    .await
+                {
+                    Ok(()) => {}
+                    Err(err) => {
+                        error!("Failed to receive request body: {:?}", err);
+                        return;
+                    }
+                };
+                debug!(
+                    "Dispatched handler for the connection, seq: {:?}",
+                    req_header.seq
+                );
+                let req_buffer: &mut BytesMut = unsafe { &mut *self.inner.req_buf.get() };
+                self.inner
+                    .dispatch_handler
+                    .dispatch(req_header, req_buffer, done_tx)
+                    .await;
+            }
+        } else {
+            debug!("Inner request type is not matched: {:?}", req_header.op);
+        }
+    }
+
+    /// Keep the connection and get the handler for the connection.
+    pub async fn run(&self) {
+        // Dispatch the handler for the connection
+        debug!("RpcServerConnection::Received a new TcpStream.");
+
+        // TODO: copy done_tx to the worker pool
+        let (done_tx, mut done_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+
+        // Send response to the stream from the worker pool
+        // Worker pool will handle the response sending
+        let inner_conn = Arc::clone(&self.inner);
+        tokio::spawn(async move {
+            debug!("Start to send response to the stream from client");
+            loop {
+                if let Some(resp_buffer) = done_rx.recv().await {
+                    debug!("Recv buffer from done_tx channel, try to send response to the stream");
+                    // Send response to the stream
+                    if let Ok(res) = inner_conn.send_response(&resp_buffer).await {
+                        debug!("Sent file block response successfully: {:?}", res);
+                    } else {
+                        error!("Failed to send file block response");
+                    }
+                } else {
+                    info!("done_rx channel is closed, stop sending response to the stream");
+                    break;
+                }
+            }
+        });
+
+        let start_time = std::time::Instant::now();
+        loop {
+            // Receive the request header
+            let req_header = match self.inner.recv_header().await {
+                Ok(header) => {
+                    debug!("Received request header: {:?}", header);
+                    header
+                }
+                Err(err) => {
+                    debug!("Failed to receive request header: {:?}", err);
+                    return;
+                }
+            };
+
+            if req_header.seq == 1000 {
+                let end_time = std::time::Instant::now();
+                info!("Total time: {:?}", end_time - start_time);
+            }
+            // Dispatch the handler for the connection
+            self.dispatch(req_header, done_tx.clone()).await;
+        }
+    }
+}
+
+/// The worker factory for the RPC connection.
+#[derive(Clone, Debug)]
+pub struct RpcConnWorkerFactory<T>
+where
+    T: RpcServerConnectionHandler + Send + Sync + 'static,
+{
+    /// Global worker pool for the RPC connection, shared by all connections.
+    worker_pool: Arc<WorkerPool>,
+    /// The handler for the connection
+    dispatch_handler: T,
+}
+
+impl<T> RpcConnWorkerFactory<T>
+where
+    T: RpcServerConnectionHandler + Send + Sync + Debug + Clone + 'static,
+{
+    /// Create a new worker factory for the RPC connection.
+    pub fn new(max_workers: usize, max_jobs: usize, dispatch_handler: T) -> Self {
+        Self {
+            worker_pool: Arc::new(WorkerPool::new(max_workers, max_jobs)),
+            dispatch_handler,
+        }
+    }
+
+    /// Get dispatch handler for the connection.
+    pub fn get_dispatch_handler(&self) -> T {
+        self.dispatch_handler.clone()
+    }
+
+    /// Serve the connection.
+    pub fn serve(&self, conn: RpcServerConnection<T>) {
+        // Run the connection
+        tokio::spawn(async move {
+            conn.run().await;
+        });
+    }
+}
+
+/// The RPC server definition.
+pub struct RpcServer<T>
+where
+    T: RpcServerConnectionHandler + Send + Sync + Debug + Clone + 'static,
+{
+    /// Options for the timeout of the server connection
+    timeout_options: ServerTimeoutOptions,
+    /// Main worker for the server
+    main_worker: Option<task::JoinHandle<()>>,
+    /// The worker factory for the RPC connection
+    rpc_conn_worker_factory: RpcConnWorkerFactory<T>,
+}
+
+impl<T> Debug for RpcServer<T>
+where
+    T: RpcServerConnectionHandler + Send + Sync + Debug + Clone + 'static,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RpcServer")
+            .field("timeout_options", &self.timeout_options)
+            .field("main_worker", &self.main_worker)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> RpcServer<T>
+where
+    T: RpcServerConnectionHandler + Send + Sync + Debug + Clone + 'static,
+{
+    /// Create a new RPC server.
+    pub fn new(
+        timeout_options: &ServerTimeoutOptions,
+        max_workers: usize,
+        max_jobs: usize,
+        dispatch_handler: T,
+    ) -> Self {
+        Self {
+            timeout_options: timeout_options.clone(),
+            main_worker: None,
+            rpc_conn_worker_factory: RpcConnWorkerFactory::<T>::new(
+                max_workers,
+                max_jobs,
+                dispatch_handler,
+            ),
+        }
+    }
+
+    /// Start the RPC server.
+    pub async fn listen(&mut self, addr: &str) -> Result<(), RpcError> {
+        // Start the server
+        let listener = tokio::net::TcpListener::bind(addr)
+            .await
+            .map_err(|err| RpcError::InternalError(err.to_string()))?;
+        info!("listening on {:?}", addr.to_owned());
+
+        // Accept incoming connections
+        let timeout_options = self.timeout_options.clone();
+        let factory = self.rpc_conn_worker_factory.clone();
+        let handle = tokio::task::spawn(async move {
+            loop {
+                let conn_timeout_options = timeout_options.clone();
+                match listener.accept().await {
+                    Ok((stream, _)) => {
+                        match stream.peer_addr() {
+                            Ok(addr) => {
+                                debug!("Accepted connection from {:?}", addr);
+                            }
+                            Err(err) => {
+                                debug!("Failed to get peer address: {:?}", err);
+                                break;
+                            }
+                        }
+                        factory.serve(RpcServerConnection::<T>::new(
+                            stream,
+                            Arc::clone(&factory.worker_pool),
+                            conn_timeout_options,
+                            factory.get_dispatch_handler(),
+                        ));
+                    }
+                    Err(err) => {
+                        debug!("Failed to accept connection: {:?}", err);
+                        continue;
+                    }
+                }
+            }
+        });
+
+        self.main_worker = Some(handle);
+        Ok(())
+    }
+
+    /// Stop the RPC server.
+    pub fn stop(&mut self) {
+        // TODO: Gracefully stop the server?
+        if let Some(handle) = self.main_worker.take() {
+            handle.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use tokio::time;
+
+    use super::*;
+    use std::time::Duration;
+
+    /// Check if the port is in use
+    async fn is_port_in_use(addr: &str) -> bool {
+        if let Ok(stream) = tokio::net::TcpStream::connect(addr).await {
+            // Port is in use
+            drop(stream);
+            true
+        } else {
+            // Port is not in use
+            false
+        }
+    }
+
+    /// Test handler for the RPC server connection.
+    #[derive(Clone, Debug)]
+    struct TestHandler;
+
+    impl TestHandler {
+        /// Create a new test handler.
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+
+    #[async_trait]
+    impl RpcServerConnectionHandler for TestHandler {
+        async fn dispatch(
+            &self,
+            _req_header: ReqHeader,
+            _req_buffer: &[u8],
+            _done_tx: mpsc::UnboundedSender<Vec<u8>>,
+        ) {
+            // Dispatch the handler for the connection
+            debug!("Dispatched handler for the connection");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rpc_server() {
+        let addr = "127.0.0.1:2888";
+        let handler = TestHandler::new();
+        let mut server = RpcServer::new(&ServerTimeoutOptions::default(), 4, 100, handler);
+        server.listen(addr).await.unwrap();
+        time::sleep(Duration::from_secs(1)).await;
+        assert!(is_port_in_use(addr).await);
+        server.stop();
+        time::sleep(Duration::from_secs(1)).await;
+        assert!(!is_port_in_use(addr).await);
+    }
+}

--- a/src/storage/cache/rpc/utils.rs
+++ b/src/storage/cache/rpc/utils.rs
@@ -1,0 +1,84 @@
+use bytes::Buf;
+
+use super::error::RpcError;
+
+/// Read with timeout options from the environment variables
+#[macro_export]
+macro_rules! read_exact_timeout {
+    ($self:expr, $dst:expr, $read_timeout:expr) => {
+        async move {
+            use tokio::time::timeout;
+
+            match timeout($read_timeout, $self.read_exact($dst)).await {
+                Ok(res) => match res {
+                    Ok(size) => Ok(size),
+                    Err(read_err) => Err(read_err),
+                },
+                Err(timeout_err) => Err(timeout_err.into()),
+            }
+        }
+    };
+}
+
+/// Write with timeout options from the environment variables
+#[macro_export]
+macro_rules! write_all_timeout {
+    ($self:expr, $src:expr, $write_timeout:expr) => {
+        async move {
+            use tokio::time::timeout;
+
+            match timeout($write_timeout, $self.write_all($src)).await {
+                Ok(res) => match res {
+                    Ok(size) => Ok(size),
+                    Err(write_err) => Err(write_err),
+                },
+                Err(timeout_err) => Err(timeout_err.into()),
+            }
+        }
+    };
+}
+
+/// Connect a stream with timeout options from the environment variables
+#[macro_export]
+macro_rules! connect_timeout {
+    ($addr:expr, $connect_timeout:expr) => {
+        async move {
+            use tokio::net::TcpStream;
+            use tokio::time::timeout;
+
+            match timeout($connect_timeout, TcpStream::connect($addr)).await {
+                Ok(res) => match res {
+                    Ok(stream) => Ok(stream),
+                    Err(connect_err) => Err(connect_err),
+                },
+                Err(timeout_err) => Err(timeout_err.into()),
+            }
+        }
+    };
+}
+
+/// Try to get u64 data from buffer with range
+pub fn get_u64_from_buf(buf: &[u8], start: usize) -> Result<u64, RpcError> {
+    buf.get(start..start + 8)
+        .ok_or_else(|| RpcError::InternalError("Invalid range data".to_owned()))
+        .map(|mut slice| u64::from_le(slice.get_u64()))
+}
+
+/// Try to get u8 data from buffer with range
+pub fn get_u8_from_buf(buf: &[u8], start: usize) -> Result<u8, RpcError> {
+    buf.get(start)
+        .ok_or_else(|| RpcError::InternalError("In valid range data".to_owned()))
+        .map(|&byte| u8::from_le(byte))
+}
+
+/// Converts [`u64`] to [`usize`], and panic when the conversion fails.
+#[inline]
+#[must_use]
+pub const fn u64_to_usize(x: u64) -> usize {
+    #[allow(clippy::as_conversions)]
+    #[allow(clippy::cast_possible_truncation)]
+    #[cfg(not(target_pointer_width = "16"))]
+    {
+        x as usize
+    }
+}

--- a/src/storage/cache/rpc/workerpool.rs
+++ b/src/storage/cache/rpc/workerpool.rs
@@ -1,0 +1,223 @@
+use std::{
+    fmt::{self, Debug},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use tracing::debug;
+
+use super::error::RpcError;
+
+/// A job that can be executed by a worker.
+type JobImpl = Box<dyn Job + Send + Sync + 'static>;
+
+/// A worker that can execute async jobs.
+#[derive(Clone)]
+pub struct WorkerPool {
+    /// The number of workers in the worker pool.
+    /// Current implementation is that the worker pool with a fixed number of workers.
+    /// TODO: Test if we need a dynamic worker pool.
+    max_workers: usize,
+    /// The maximum number of jobs that can be waiting in the job queue.
+    max_waiting_jobs: usize,
+    /// The job queue for the worker pool, with a maximum buffer capacity of `max_waiting_jobs`.
+    /// 1. When the job queue is full, the worker pool will block to receive new jobs.
+    /// 2. When sender is dropped, the receiver will return `None` and the worker pool will shutdown.
+    /// 3. Check the receiver reference count to determine if the worker pool is still alive.
+    job_sender: Arc<flume::Sender<JobImpl>>,
+    /// The workers in the worker pool.
+    worker_queue: Vec<Worker>,
+}
+
+impl Debug for WorkerPool {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WorkerPool")
+            .field("max_workers", &self.max_workers)
+            .field("max_waiting_jobs", &self.max_waiting_jobs)
+            .field("worker_queue_len", &self.worker_queue.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl WorkerPool {
+    /// Create a new worker pool, which contains a number of max workers and max waiting jobs.
+    #[must_use]
+    pub fn new(max_workers: usize, max_waiting_jobs: usize) -> Self {
+        let (job_sender, job_receiver) = flume::bounded::<JobImpl>(max_waiting_jobs);
+        let mut worker_queue = Vec::new();
+
+        // In current implementation, we create a fixed number of workers.
+        let receiver = Arc::new(job_receiver);
+        for _ in 0..max_workers {
+            let worker = Worker::new(Arc::clone(&receiver));
+            worker.start();
+            worker_queue.push(worker);
+        }
+
+        Self {
+            max_workers,
+            max_waiting_jobs,
+            job_sender: Arc::new(job_sender),
+            worker_queue,
+        }
+    }
+
+    /// Submit a job to the worker pool synchronously, and block until the job is completed.
+    /// Other process will be blocked until the job is completed.
+    /// If all job try to submit the job, the process will be blocked.
+    pub fn submit_job(&self, job: JobImpl) -> Result<(), RpcError> {
+        // Submit the job to the job queue.
+        self.job_sender
+            .send(job)
+            .map_err(|_foo| RpcError::InternalError("Failed to submit job".to_owned()))?;
+
+        Ok(())
+    }
+
+    /// Shutdown
+    ///
+    /// Drop the worker, and the worker will exit.
+    pub fn shutdown(&self) {
+        for worker in &self.worker_queue {
+            worker.exit();
+        }
+    }
+}
+
+/// A worker that can execute async jobs.
+#[allow(dead_code)]
+#[derive(Clone)]
+struct Worker {
+    /// Job recv channel
+    job_rx: Arc<flume::Receiver<JobImpl>>,
+    /// Shutdown recv channel
+    shutdown_rx: flume::Receiver<()>,
+    /// Shutdown send channel
+    shutdown_tx: flume::Sender<()>,
+}
+
+impl Worker {
+    /// Create a new worker.
+    fn new(receiver: Arc<flume::Receiver<JobImpl>>) -> Self {
+        debug!("Create a new worker...");
+        let (shutdown_tx, shutdown_rx) = flume::bounded::<()>(1);
+        Self {
+            job_rx: receiver,
+            shutdown_rx,
+            shutdown_tx,
+        }
+    }
+
+    /// Start the worker.
+    fn start(&self) {
+        let shutdown_rx = self.shutdown_rx.clone();
+        let receiver = Arc::clone(&self.job_rx);
+        tokio::task::spawn(async move {
+            // Core worker loop
+            loop {
+                debug!("Worker is waiting for a job...");
+                tokio::select! {
+                    // Recv shutdown signal
+                    _ = shutdown_rx.recv_async() => {
+                        debug!("Worker received a shutdown signal...");
+                        break;
+                    }
+                    // Receive a job from the job queue.
+                    job = receiver.recv_async() => {
+                        if let Ok(job) = job {
+                            debug!("Worker received a job...");
+                            // 2. Run the job asynchronously.
+                            job.run().await;
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    /// Exit the worker.
+    fn exit(&self) {
+        match self.shutdown_tx.send(()) {
+            Ok(()) => debug!("Worker is exiting..."),
+            Err(e) => debug!("Failed to send shutdown signal: {:?}", e),
+        }
+    }
+}
+
+impl Drop for Worker {
+    fn drop(&mut self) {
+        self.exit();
+    }
+}
+
+/// A trait that represents a job that can be executed by a worker.
+#[async_trait]
+pub trait Job {
+    /// Run the job.
+    async fn run(&self);
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+
+    use core::time;
+
+    use tokio::{task, time::Instant};
+    use tracing::info;
+
+    use super::*;
+
+    struct TestJob;
+
+    #[async_trait]
+    impl Job for TestJob {
+        async fn run(&self) {
+            debug!("TestJob::run");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_worker_pool() {
+        // setup();
+        let worker_pool = WorkerPool::new(4, 4);
+        for _ in 0_i32..4_i32 {
+            worker_pool.submit_job(Box::new(TestJob)).unwrap();
+        }
+
+        // If submit over 4 jobs, it will be blocked here, because the job queue is full.
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
+        let res = worker_pool.submit_job(Box::new(TestJob));
+        res.unwrap();
+
+        drop(worker_pool);
+    }
+
+    #[tokio::test]
+    async fn benchmark_worker_pool() {
+        // setup();
+
+        // Test to use 4 workers to submit 1000 jobs, and calculate the time cost.
+        let worker_pool = Arc::new(WorkerPool::new(10, 1000));
+        let start = Instant::now();
+        for _ in 0_i32..1_000_i32 {
+            let worker_pool = Arc::clone(&worker_pool);
+            worker_pool.submit_job(Box::new(TestJob)).unwrap();
+        }
+        let end = start.elapsed();
+        info!("Workerpool time cost: {:?}", end);
+
+        // Test direct spawn 1000 tasks, and calculate the time cost.
+        let start = Instant::now();
+        let mut tasks: Vec<task::JoinHandle<()>> = Vec::new();
+        for _ in 0_i32..1_000_i32 {
+            let task = task::spawn(TestJob.run());
+            tasks.push(task);
+        }
+        for task in tasks {
+            task.await.unwrap();
+        }
+        let end = start.elapsed();
+        info!("Direct spawn time cost: {:?}", end);
+    }
+}

--- a/src/storage/cache/tests/mod.rs
+++ b/src/storage/cache/tests/mod.rs
@@ -1,0 +1,2 @@
+/// Unit tests for cache module
+pub mod rpc;

--- a/src/storage/cache/tests/rpc.rs
+++ b/src/storage/cache/tests/rpc.rs
@@ -1,0 +1,339 @@
+use std::sync::Once;
+
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::{
+    filter, fmt::layer, layer::SubscriberExt, util::SubscriberInitExt, Layer,
+};
+
+/// Use for unit test to setup tracing
+#[allow(dead_code)]
+static INIT: Once = Once::new();
+
+/// Set up once for tracing
+#[allow(dead_code)]
+fn setup() {
+    // init tracing once
+    INIT.call_once(|| {
+        // Set the tracing log level to debug
+        let filter =
+            filter::Targets::new().with_target("datenlord::storage::cache", LevelFilter::DEBUG);
+        tracing_subscriber::registry()
+            .with(layer().with_filter(filter))
+            .init();
+    });
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use crate::connect_timeout;
+    use crate::storage::cache::rpc::client::RpcClient;
+    use crate::storage::cache::rpc::common::{ClientTimeoutOptions, ServerTimeoutOptions};
+    use crate::storage::cache::rpc::message::{
+        FileBlockPacket, FileBlockRequest, FileBlockResponse, ReqType, RespType, StatusCode,
+    };
+    use crate::storage::cache::rpc::packet::{Decode, Encode, ReqHeader, RespHeader};
+    use crate::storage::cache::rpc::server::{RpcServer, RpcServerConnectionHandler};
+    use crate::storage::cache::rpc::utils::u64_to_usize;
+    use crate::storage::cache::rpc::workerpool::{Job, WorkerPool};
+    use async_trait::async_trait;
+    use bytes::BytesMut;
+    use tokio::sync::mpsc;
+    use tokio::time;
+    use tracing::{debug, error};
+
+    use crate::async_fuse::util::usize_to_u64;
+
+    /// The handler for the RPC file block request.
+    #[derive(Debug)]
+    pub struct FileBlockHandler {
+        /// The request header.
+        header: ReqHeader,
+        /// The file block request.
+        request: FileBlockRequest,
+        /// The channel for sending the response.
+        done_tx: mpsc::UnboundedSender<Vec<u8>>,
+    }
+
+    impl FileBlockHandler {
+        /// Create a new file block handler.
+        #[must_use]
+        pub fn new(
+            header: ReqHeader,
+            request: FileBlockRequest,
+            done_tx: mpsc::UnboundedSender<Vec<u8>>,
+        ) -> Self {
+            Self {
+                header,
+                request,
+                done_tx,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Job for FileBlockHandler {
+        async fn run(&self) {
+            // Mock: serve block request and send response
+            let size = self.request.block_size;
+
+            // Prepare response body
+            // Mock: response body is all zeros
+            let file_block_resp = FileBlockResponse {
+                file_id: self.request.file_id,
+                block_id: self.request.block_id,
+                block_size: size,
+                block_version: self.request.block_version,
+                hash_ring_version: self.request.hash_ring_version,
+                status: StatusCode::Success,
+                data: vec![0_u8; u64_to_usize(size)],
+            };
+            let mut resp_body_buffer = BytesMut::new();
+            file_block_resp.encode(&mut resp_body_buffer);
+            // Prepare response header
+            let resp_header = RespHeader {
+                seq: self.header.seq,
+                op: RespType::FileBlockResponse.into(),
+                len: usize_to_u64(resp_body_buffer.len()),
+            };
+            let mut resp_header_buffer = BytesMut::new();
+            resp_header.encode(&mut resp_header_buffer);
+            // Combine response header and body
+            resp_header_buffer.extend_from_slice(&resp_body_buffer);
+
+            // Send response to the done channel
+            match self.done_tx.send(resp_header_buffer.to_vec()) {
+                Ok(()) => {
+                    debug!("Sent response to done channel");
+                }
+                Err(err) => {
+                    error!("Failed to send response to done channel: {:?}", err);
+                }
+            }
+        }
+    }
+
+    /// The file block handler for the RPC server.
+    #[derive(Clone, Debug)]
+    pub struct FileBlockRpcServerHandler {
+        /// The worker pool for the RPC server.
+        worker_pool: Arc<WorkerPool>,
+    }
+
+    impl FileBlockRpcServerHandler {
+        /// Create a new file block RPC server handler.
+        #[must_use]
+        pub fn new(worker_pool: Arc<WorkerPool>) -> Self {
+            Self { worker_pool }
+        }
+    }
+
+    #[async_trait]
+    impl RpcServerConnectionHandler for FileBlockRpcServerHandler {
+        async fn dispatch(
+            &self,
+            req_header: ReqHeader,
+            req_buffer: &[u8],
+            done_tx: mpsc::UnboundedSender<Vec<u8>>,
+        ) {
+            // Dispatch the handler for the connection
+            if let Ok(req_type) = ReqType::try_from(req_header.op) {
+                if let ReqType::FileBlockRequest = req_type {
+                    // Try to read the request body
+                    // Decode the request body
+                    let req_body = match FileBlockRequest::decode(req_buffer) {
+                        Ok(req) => req,
+                        Err(err) => {
+                            debug!("Failed to decode file block request: {:?}", err);
+                            return;
+                        }
+                    };
+
+                    debug!(
+                        "FileBlockRpcServerHandler: Received file block request: {:?}",
+                        req_body
+                    );
+
+                    // File block request
+                    // Submit the handler to the worker pool
+                    // When the handler is done, send the response to the done channel
+                    // Response need to contain the response header and body
+                    let handler = FileBlockHandler::new(req_header, req_body, done_tx.clone());
+                    if let Ok(()) = self
+                        .worker_pool
+                        .submit_job(Box::new(handler))
+                        .map_err(|err| {
+                            debug!("Failed to submit job: {:?}", err);
+                        })
+                    {
+                        debug!("Submitted job to worker pool");
+                    }
+                } else {
+                    debug!(
+                        "FileBlockRpcServerHandler: Inner request type is not matched: {:?}",
+                        req_header.op
+                    );
+                }
+            }
+        }
+    }
+
+    /// Check if the port is in use
+    async fn is_port_in_use(addr: &str) -> bool {
+        if let Ok(stream) = tokio::net::TcpStream::connect(addr).await {
+            // Port is in use
+            drop(stream);
+            true
+        } else {
+            // Port is not in use
+            false
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_and_recv_packet() {
+        // setup();
+        // Setup server
+        let addr = "127.0.0.1:2788";
+        let pool = Arc::new(WorkerPool::new(4, 100));
+        let handler = FileBlockRpcServerHandler::new(Arc::clone(&pool));
+        let mut server = RpcServer::new(&ServerTimeoutOptions::default(), 4, 100, handler);
+        server.listen(addr).await.unwrap();
+        time::sleep(Duration::from_secs(1)).await;
+        assert!(is_port_in_use(addr).await);
+        time::sleep(Duration::from_secs(1)).await;
+
+        // Create a client
+        let timeout_options = ClientTimeoutOptions {
+            read_timeout: Duration::from_secs(100),
+            write_timeout: Duration::from_secs(100),
+            task_timeout: Duration::from_secs(100),
+            keep_alive_timeout: Duration::from_secs(20),
+        };
+        let connect_stream = connect_timeout!(addr, timeout_options.read_timeout)
+            .await
+            .unwrap();
+
+        let rpc_client = RpcClient::<FileBlockPacket>::new(connect_stream, timeout_options);
+        rpc_client.start_recv();
+
+        time::sleep(Duration::from_secs(1)).await;
+
+        // Send ping
+        rpc_client.ping().await.unwrap();
+
+        let (tx, rx) = flume::unbounded::<Result<FileBlockResponse, FileBlockRequest>>();
+        // Send file block request
+        let block_request = FileBlockRequest {
+            block_id: 0,
+            block_size: 4096,
+            file_id: 0,
+            block_version: 0,
+            hash_ring_version: 1,
+        };
+        let packet = FileBlockPacket::new(block_request, tx.clone());
+        rpc_client.send_request(packet).await.unwrap();
+
+        loop {
+            match rx.recv_async().await {
+                Ok(resp) => {
+                    let resp = resp.unwrap();
+                    debug!("Received response ok with len: {:?}", resp.data.len());
+
+                    assert_eq!(resp.file_id, 0);
+                    assert_eq!(resp.block_id, 0);
+                    assert_eq!(resp.block_size, 4096);
+                    assert_eq!(resp.status, StatusCode::Success);
+                    assert_eq!(resp.data.len(), 4096);
+                    debug!("Received response ok with len: {:?}", resp.data.len());
+                    break;
+                }
+                Err(err) => {
+                    error!("Failed to receive response: {:?}", err);
+                    time::sleep(Duration::from_secs(1)).await;
+                }
+            }
+        }
+
+        server.stop();
+    }
+
+    #[tokio::test]
+    async fn test_request_timeout() {
+        // setup();
+        // Setup server
+        let addr = "127.0.0.1:2791";
+        let pool = Arc::new(WorkerPool::new(4, 100));
+        let handler = FileBlockRpcServerHandler::new(Arc::clone(&pool));
+        let mut server = RpcServer::new(&ServerTimeoutOptions::default(), 4, 100, handler);
+        server.listen(addr).await.unwrap();
+        time::sleep(Duration::from_secs(1)).await;
+        assert!(is_port_in_use(addr).await);
+        time::sleep(Duration::from_secs(1)).await;
+
+        // Create a client with short timeout
+        let timeout_options = ClientTimeoutOptions {
+            read_timeout: Duration::from_secs(1),
+            write_timeout: Duration::from_secs(1),
+            task_timeout: Duration::from_secs(1),
+            keep_alive_timeout: Duration::from_secs(1),
+        };
+        let connect_stream = connect_timeout!(addr, timeout_options.read_timeout)
+            .await
+            .unwrap();
+
+        let rpc_client = RpcClient::<FileBlockPacket>::new(connect_stream, timeout_options);
+        rpc_client.start_recv();
+
+        time::sleep(Duration::from_secs(5)).await;
+
+        // Send ping, and current response is error
+        assert!(rpc_client.ping().await.is_err());
+
+        server.stop();
+    }
+
+    #[tokio::test]
+    async fn test_client_drop() {
+        // setup();
+        // Setup server
+        let addr = "127.0.0.1:2792";
+        let pool = Arc::new(WorkerPool::new(4, 100));
+        let handler = FileBlockRpcServerHandler::new(Arc::clone(&pool));
+        let mut server = RpcServer::new(&ServerTimeoutOptions::default(), 4, 100, handler);
+        server.listen(addr).await.unwrap();
+        time::sleep(Duration::from_secs(1)).await;
+        assert!(is_port_in_use(addr).await);
+        time::sleep(Duration::from_secs(1)).await;
+
+        // Create a client
+        let timeout_options = ClientTimeoutOptions {
+            read_timeout: Duration::from_secs(1),
+            write_timeout: Duration::from_secs(1),
+            task_timeout: Duration::from_secs(1),
+            keep_alive_timeout: Duration::from_secs(1),
+        };
+        let connect_stream = connect_timeout!(addr, timeout_options.read_timeout)
+            .await
+            .unwrap();
+
+        let rpc_client = RpcClient::<FileBlockPacket>::new(connect_stream, timeout_options);
+        rpc_client.start_recv();
+
+        // Drop client
+        drop(rpc_client);
+
+        // Wait some time to ensure the client has dropped, wait for tcp read timeout. default is 20 second
+        time::sleep(Duration::from_secs(20)).await;
+
+        // Check if the server has detected the dropped connection
+        // For example, check the connection count, logs, etc.
+        // done_rx channel is closed, stop sending response to the str
+
+        server.stop();
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -44,5 +44,5 @@ mod mock;
 #[cfg(test)]
 pub use mock::MemoryStorage;
 
-/// Cache module
-pub mod cache_proxy;
+/// The cache module for storage.
+pub mod cache;


### PR DESCRIPTION
# Background
In response to the need for efficient file transfers in distributed environments, this system aims to achieve fast transfer of file blocks and file ranges through asynchronous RPC (ARPC) methods. The system will focus on the transfer of file blocks (block) or file ranges (range) to optimize data flow processing and ensure data consistency and efficient transfer. It is mainly used for IO-intensive data streams and is particularly suitable for block and file storage IO operations. The design goal is to minimize CPU usage and maximize throughput.

# Problems
1. client connection is high, client will usually request to download bulk blocks from cache node, different blocks may be mapped to different cache node nodes, so a client may need to maintain many connections. 2. possible continuous block transfer, especially suitable for block storage and file storage IO operations.
2. possible continuous block transfer, in the current load balancing algorithm, the number of blocks and cache node number of different orders of magnitude, it is likely that there are more than one block, or even a continuous block mapped to the same cache node node, frequent creation of the same peer-to-peer connection may be unnecessary overhead.
3. The server side may need to handle many client requests at the same time, and each request is mainly an io task, supplemented by protocol parsing (simple check). Therefore, we need to simplify the server-side implementation, and at the same time, we need to manage these io tasks well.

# Design
In server side, we need to implement `handler` for server conn, and put a server job to workerpool(control the limitation).

In client side, we use `packets keeper` to keep packets and manager connection is timeout for current request. Also, we use `seq` to mark each request in one stream.

> Ref: https://datenlord.feishu.cn/docx/G7LTdqL3koUo8wxJ1aucHeELnNd