### PR TITLE
feat(cache node): support cluster manager.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ opendal = {version = "0.43.0", features = ["layers-prometheus"]}
 signal-hook = { version = "0.3.17", features = ["iterator"]}
 signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 tokio-util = "0.7.10"
+arc-swap = "1.7.1"
 
 [build-dependencies]
 protoc-grpcio = "3.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ signal-hook = { version = "0.3.17", features = ["iterator"]}
 signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 tokio-util = "0.7.10"
 arc-swap = "1.7.1"
+flume = "0.11.0"
 
 [build-dependencies]
 protoc-grpcio = "3.0.0"

--- a/src/async_fuse/memfs/kv_engine/etcd_impl.rs
+++ b/src/async_fuse/memfs/kv_engine/etcd_impl.rs
@@ -118,6 +118,11 @@ impl Session {
 impl Drop for Session {
     fn drop(&mut self) {
         // Set the close flag
+        info!(
+            "drop the keep alive session, lease_id={lease_id}, ttl={ttl}",
+            lease_id = self.lease_id(),
+            ttl = self.ttl()
+        );
         self.close();
     }
 }
@@ -1001,6 +1006,9 @@ mod test {
 
     #[tokio::test]
     async fn test_watch() {
+        tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .init();
         let client = EtcdKVEngine::new_for_local_test(vec![ETCD_ADDRESS.to_owned()])
             .await
             .unwrap();

--- a/src/async_fuse/memfs/kv_engine/key_type.rs
+++ b/src/async_fuse/memfs/kv_engine/key_type.rs
@@ -28,6 +28,14 @@ pub enum KeyType {
     /// Just a string key for testing the KVEngine.
     #[cfg(test)]
     String(String),
+    /// Distributed cache node key
+    CacheNode(String),
+    /// Distributed hash ring key
+    CacheRing,
+    /// Distributed cache node master key
+    CacheNodeMaster,
+    /// Distribute cache cluster config
+    CacheClusterConfig,
 }
 
 // ::<KeyType>::get() -> ValueType
@@ -41,6 +49,8 @@ pub enum LockKeyType {
     VolumeInfoLock,
     /// ETCD file node list lock
     FileNodeListLock(INum),
+    /// Distributed cache node master key
+    CacheNodeMaster,
 }
 
 impl Display for KeyType {
@@ -56,6 +66,10 @@ impl Display for KeyType {
             KeyType::FileNodeList(ref inum) => write!(f, "FileNodeList({inum})"),
             #[cfg(test)]
             KeyType::String(ref s) => write!(f, "String({s})"),
+            KeyType::CacheNode(ref s) => write!(f, "CacheNode({s})"),
+            KeyType::CacheRing => write!(f, "CacheRing/"), // CacheRing
+            KeyType::CacheNodeMaster => write!(f, "CacheNodeMaster"), // CacheNodeMaster
+            KeyType::CacheClusterConfig => write!(f, "CacheClusterConfig/"), // CacheClusterConfig
         }
     }
 }
@@ -71,6 +85,9 @@ impl Display for LockKeyType {
             }
             LockKeyType::FileNodeListLock(ref inum) => {
                 write!(f, "FileNodeListLock({inum:?})")
+            }
+            LockKeyType::CacheNodeMaster => {
+                write!(f, "CacheNodeMaster")
             }
         }
     }
@@ -100,6 +117,10 @@ impl KeyType {
             KeyType::NodeIpPort(_) => "NodeIpPort",
             KeyType::VolumeInfo(_) => "VolumeInfo",
             KeyType::FileNodeList(_) => "FileNodeList",
+            KeyType::CacheNode(_) => "CacheNode",
+            KeyType::CacheRing => "CacheRing",
+            KeyType::CacheNodeMaster => "CacheNodeMaster",
+            KeyType::CacheClusterConfig => "CacheClusterConfig",
         }
     }
 
@@ -128,6 +149,18 @@ impl KeyType {
             KeyType::FileNodeList(ref inum) => {
                 write!(f, "{inum}").unwrap();
             }
+            KeyType::CacheNode(ref s) => {
+                write!(f, "{s}").unwrap();
+            }
+            KeyType::CacheRing => {
+                write!(f, "").unwrap();
+            }
+            KeyType::CacheNodeMaster => {
+                write!(f, "").unwrap();
+            }
+            KeyType::CacheClusterConfig => {
+                write!(f, "").unwrap();
+            }
         }
     }
 }
@@ -151,6 +184,7 @@ impl LockKeyType {
             LockKeyType::IdAllocatorLock(_) => "IdAllocLock",
             LockKeyType::VolumeInfoLock => "VolumeInfoLock",
             LockKeyType::FileNodeListLock(_) => "FileNodeListLock",
+            LockKeyType::CacheNodeMaster => "CacheNodeMaster",
         }
     }
 
@@ -165,6 +199,9 @@ impl LockKeyType {
             }
             LockKeyType::FileNodeListLock(ref inum) => {
                 write!(f, "{inum}").unwrap();
+            }
+            LockKeyType::CacheNodeMaster => {
+                write!(f, "").unwrap();
             }
         }
     }

--- a/src/async_fuse/memfs/kv_engine/key_type.rs
+++ b/src/async_fuse/memfs/kv_engine/key_type.rs
@@ -33,7 +33,7 @@ pub enum KeyType {
     /// Distributed hash ring key
     CacheRing,
     /// Distributed cache node master key
-    CacheNodeMaster,
+    CacheMasterNode,
     /// Distribute cache cluster config
     CacheClusterConfig,
 }
@@ -50,7 +50,7 @@ pub enum LockKeyType {
     /// ETCD file node list lock
     FileNodeListLock(INum),
     /// Distributed cache node master key
-    CacheNodeMaster,
+    CacheMasterNode,
 }
 
 impl Display for KeyType {
@@ -68,7 +68,7 @@ impl Display for KeyType {
             KeyType::String(ref s) => write!(f, "String({s})"),
             KeyType::CacheNode(ref s) => write!(f, "CacheNode({s})"),
             KeyType::CacheRing => write!(f, "CacheRing/"), // CacheRing
-            KeyType::CacheNodeMaster => write!(f, "CacheNodeMaster"), // CacheNodeMaster
+            KeyType::CacheMasterNode => write!(f, "CacheMasterNode"), // CacheMasterNode
             KeyType::CacheClusterConfig => write!(f, "CacheClusterConfig/"), // CacheClusterConfig
         }
     }
@@ -86,8 +86,8 @@ impl Display for LockKeyType {
             LockKeyType::FileNodeListLock(ref inum) => {
                 write!(f, "FileNodeListLock({inum:?})")
             }
-            LockKeyType::CacheNodeMaster => {
-                write!(f, "CacheNodeMaster")
+            LockKeyType::CacheMasterNode => {
+                write!(f, "CacheMasterNode")
             }
         }
     }
@@ -119,7 +119,7 @@ impl KeyType {
             KeyType::FileNodeList(_) => "FileNodeList",
             KeyType::CacheNode(_) => "CacheNode",
             KeyType::CacheRing => "CacheRing",
-            KeyType::CacheNodeMaster => "CacheNodeMaster",
+            KeyType::CacheMasterNode => "CacheMasterNode",
             KeyType::CacheClusterConfig => "CacheClusterConfig",
         }
     }
@@ -155,7 +155,7 @@ impl KeyType {
             KeyType::CacheRing => {
                 write!(f, "").unwrap();
             }
-            KeyType::CacheNodeMaster => {
+            KeyType::CacheMasterNode => {
                 write!(f, "").unwrap();
             }
             KeyType::CacheClusterConfig => {
@@ -184,7 +184,7 @@ impl LockKeyType {
             LockKeyType::IdAllocatorLock(_) => "IdAllocLock",
             LockKeyType::VolumeInfoLock => "VolumeInfoLock",
             LockKeyType::FileNodeListLock(_) => "FileNodeListLock",
-            LockKeyType::CacheNodeMaster => "CacheNodeMaster",
+            LockKeyType::CacheMasterNode => "CacheMasterNode",
         }
     }
 
@@ -200,7 +200,7 @@ impl LockKeyType {
             LockKeyType::FileNodeListLock(ref inum) => {
                 write!(f, "{inum}").unwrap();
             }
-            LockKeyType::CacheNodeMaster => {
+            LockKeyType::CacheMasterNode => {
                 write!(f, "").unwrap();
             }
         }

--- a/src/async_fuse/memfs/kv_engine/mod.rs
+++ b/src/async_fuse/memfs/kv_engine/mod.rs
@@ -42,7 +42,7 @@ pub trait MetaTxn: Send {
         key: &KeyType,
         val: String,
         lease_id: i64,
-    ) -> DatenLordResult<(bool, Option<String>)>;
+    ) -> DatenLordResult<(bool, String)>;
     /// Commit the transaction.
     /// Only when commit is called, the write operations will be executed.
     /// If the commit is successful, return true, else return false.

--- a/src/async_fuse/memfs/kv_engine/mod.rs
+++ b/src/async_fuse/memfs/kv_engine/mod.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use tokio::sync::mpsc;
 
 use crate::common::async_fuse_error::KVEngineError;
 use crate::common::error::{DatenLordError, DatenLordResult};
@@ -210,6 +209,8 @@ impl KeyRange {
 pub trait KVEngine: Send + Sync + Debug + Sized {
     /// The session type for keep alive
     type Session: Send + Sync;
+    /// The watch stream type
+    type KVEngineWatchStream;
 
     /// create a new KVEngine.
     async fn new(end_points: Vec<String>) -> DatenLordResult<Self>;
@@ -228,6 +229,8 @@ pub trait KVEngine: Send + Sync + Debug + Sized {
         value: &ValueType,
         option: Option<SetOption>,
     ) -> DatenLordResult<Option<ValueType>>;
+    /// Create a lease
+    async fn create_lease(&self, ttl: i64) -> DatenLordResult<i64>;
     /// Delete the kv pair by the key.
     async fn delete(
         &self,
@@ -245,7 +248,7 @@ pub trait KVEngine: Send + Sync + Debug + Sized {
     async fn watch(
         &self,
         key: &KeyType,
-    ) -> DatenLordResult<mpsc::Receiver<(String, Option<ValueType>)>>;
+    ) -> DatenLordResult<Self::KVEngineWatchStream>;
 }
 
 /// The version of the key.

--- a/src/async_fuse/memfs/kv_engine/mod.rs
+++ b/src/async_fuse/memfs/kv_engine/mod.rs
@@ -245,10 +245,7 @@ pub trait KVEngine: Send + Sync + Debug + Sized {
     async fn range(&self, prefix: &KeyType) -> DatenLordResult<Vec<ValueType>>;
 
     /// Watch the key, return a receiver to receive the value
-    async fn watch(
-        &self,
-        key: &KeyType,
-    ) -> DatenLordResult<Self::KVEngineWatchStream>;
+    async fn watch(&self, key: &KeyType) -> DatenLordResult<Self::KVEngineWatchStream>;
 }
 
 /// The version of the key.

--- a/src/async_fuse/memfs/kv_engine/mod.rs
+++ b/src/async_fuse/memfs/kv_engine/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use etcd_impl::Session;
 
 use crate::common::async_fuse_error::KVEngineError;
 use crate::common::error::{DatenLordError, DatenLordResult};
@@ -27,6 +28,9 @@ pub use value_type::ValueType;
 /// The Txn is used to provide support for metadata.
 #[async_trait]
 pub trait MetaTxn: Send {
+    /// The session type for keep alive
+    type Session: Send + Sync;
+
     /// Get the value by the key.
     /// Notice : do not get the same key twice in one transaction.
     async fn get(&mut self, key: &KeyType) -> DatenLordResult<Option<ValueType>>;
@@ -40,7 +44,7 @@ pub trait MetaTxn: Send {
         &self,
         key: &KeyType,
         val: String,
-        lease_id: i64,
+        session: Arc<Self::Session>,
     ) -> DatenLordResult<(bool, String)>;
     /// Commit the transaction.
     /// Only when commit is called, the write operations will be executed.
@@ -53,10 +57,10 @@ pub trait MetaTxn: Send {
 /// `lease` is used to set the lease of the key
 /// `prev_kv` is used to return the previous key-value pair
 #[allow(dead_code)]
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
 pub struct SetOption {
     /// The lease of the key
-    pub(crate) lease: Option<i64>,
+    pub(crate) session: Option<Arc<Session>>,
     /// Whether to return the previous key-value pair
     pub(crate) prev_kv: bool,
 }
@@ -68,7 +72,7 @@ impl SetOption {
     /// Default lease is None, `prev_kv` is false
     fn new() -> Self {
         Self {
-            lease: None,
+            session: None,
             prev_kv: false,
         }
     }
@@ -76,8 +80,8 @@ impl SetOption {
     #[allow(dead_code)]
     #[must_use]
     /// Set the lease of the key
-    fn with_lease(mut self, lease: i64) -> Self {
-        self.lease = Some(lease);
+    fn with_session(mut self, session: Arc<Session>) -> Self {
+        self.session = Some(session);
         self
     }
 
@@ -95,7 +99,7 @@ impl SetOption {
 /// `prev_kv` is used to return the previous key-value pair
 /// `range_end` is used to delete all keys in the range [key, `range_end`)
 #[allow(dead_code)]
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
 pub struct DeleteOption {
     /// Whether to return the previous key-value pair
     pub(crate) prev_kv: bool,
@@ -215,7 +219,7 @@ pub trait KVEngine: Send + Sync + Debug + Sized {
     /// create a new KVEngine.
     async fn new(end_points: Vec<String>) -> DatenLordResult<Self>;
     /// Create a new transaction.
-    async fn new_meta_txn(&self) -> Box<dyn MetaTxn + Send>;
+    async fn new_meta_txn(&self) -> Box<dyn MetaTxn<Session = Self::Session> + Send>;
     /// Distribute lock - lock
     async fn lock(&self, key: &LockKeyType, timeout: Duration) -> DatenLordResult<Vec<u8>>;
     /// Distribute lock - unlock
@@ -229,8 +233,6 @@ pub trait KVEngine: Send + Sync + Debug + Sized {
         value: &ValueType,
         option: Option<SetOption>,
     ) -> DatenLordResult<Option<ValueType>>;
-    /// Create a lease
-    async fn create_lease(&self, ttl: i64) -> DatenLordResult<i64>;
     /// Delete the kv pair by the key.
     async fn delete(
         &self,
@@ -238,8 +240,8 @@ pub trait KVEngine: Send + Sync + Debug + Sized {
         option: Option<DeleteOption>,
     ) -> DatenLordResult<Option<ValueType>>;
 
-    /// Lease keep alive
-    async fn create_session(&self, lease_id: i64, ttl: u64) -> DatenLordResult<Arc<Self::Session>>;
+    /// Create a lease with keepalive
+    async fn create_session(&self, ttl: u64) -> DatenLordResult<Arc<Self::Session>>;
 
     /// Range get, return all key-value pairs start with prefix
     async fn range(&self, prefix: &KeyType) -> DatenLordResult<Vec<ValueType>>;

--- a/src/async_fuse/memfs/kv_engine/value_type.rs
+++ b/src/async_fuse/memfs/kv_engine/value_type.rs
@@ -21,6 +21,8 @@ pub enum ValueType {
     Raw(Vec<u8>),
     /// String value
     String(String),
+    /// Json value
+    Json(serde_json::Value),
 }
 
 impl ValueType {

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -249,6 +249,12 @@ pub enum DatenLordError {
         /// Context of the error
         context: Vec<String>,
     },
+    /// Cache cluster error
+    #[error("Cache cluster error, context is {:#?}.", .context)]
+    CacheClusterErr {
+        /// Context of the error
+        context: Vec<String>,
+    },
     // /// Error when doing s3 operation.
     // #[error("S3 error: {0}")]
     // S3Error(s3_wrapper::S3Error),
@@ -340,7 +346,8 @@ impl DatenLordError {
                 TransactionRetryLimitExceededErr,
                 InternalErr,
                 Unimplemented,
-                InconsistentFS
+                InconsistentFS,
+                CacheClusterErr
             ]
         );
         self
@@ -402,7 +409,8 @@ impl From<DatenLordError> for RpcStatusCode {
             | DatenLordError::InternalErr { .. }
             | DatenLordError::KVEngineErr { .. }
             | DatenLordError::JoinErr { .. }
-            | DatenLordError::InconsistentFS { .. } => Self::INTERNAL,
+            | DatenLordError::InconsistentFS { .. }
+            | DatenLordError::CacheClusterErr { .. } => Self::INTERNAL,
             DatenLordError::GrpcioErr { source, .. } => match source {
                 grpcio::Error::RpcFailure(ref status) => status.code(),
                 grpcio::Error::Codec(..)

--- a/src/common/task_manager/task.rs
+++ b/src/common/task_manager/task.rs
@@ -32,6 +32,8 @@ pub enum TaskName {
     WriteBack,
     /// The scheduler extender.
     SchedulerExtender,
+    /// The task for etcd keep alive
+    EtcdKeepAlive,
 }
 
 /// The task handle(s) of the current task node.
@@ -181,10 +183,11 @@ impl Task {
 }
 
 /// Edges of the dependency graph of the tasks.
-pub(super) const EDGES: [(TaskName, TaskName); 9] = [
+pub(super) const EDGES: [(TaskName, TaskName); 10] = [
     (TaskName::Root, TaskName::Metrics),
     (TaskName::Root, TaskName::BlockFlush),
     (TaskName::Root, TaskName::SchedulerExtender),
+    (TaskName::Root, TaskName::EtcdKeepAlive),
     (TaskName::BlockFlush, TaskName::AsyncFuse),
     (TaskName::BlockFlush, TaskName::FuseRequest),
     (TaskName::FuseRequest, TaskName::AsyncFuse),

--- a/src/storage/cache_proxy/cluster_manager.rs
+++ b/src/storage/cache_proxy/cluster_manager.rs
@@ -392,6 +392,15 @@ impl ClusterManagerInner {
         let mut interval = tokio::time::interval(Duration::from_secs(SESSION_TIMEOUT_SEC));
         let mut watch_event = false;
         loop {
+            if !self.check_session_valid() {
+                let current_node = self.node.load();
+                error!(
+                    "Current {} session is invalid, return to endpoint",
+                    current_node.ip()
+                );
+                return;
+            };
+
             tokio::select! {
                 _ = interval.tick() => {
                     // Update cluster topo
@@ -431,10 +440,8 @@ impl ClusterManagerInner {
         let session = self.node_session.load();
         if let Some(session) = session.as_ref() {
             if session.is_closed() {
-                info!("Current session is valid");
                 return false;
             }
-
             return true;
         }
 
@@ -954,7 +961,7 @@ mod tests {
         ));
         let slave_cluster_manager_2_clone = Arc::clone(&slave_cluster_manager_2);
         let slave_handle_2 = tokio::task::spawn(async move {
-            let res = slave_cluster_manager_2_clone.run().await;
+            let res: Result<(), crate::common::error::DatenLordError> = slave_cluster_manager_2_clone.run().await;
             info!("slave_handle_2: {:?}", res);
         });
 
@@ -1058,10 +1065,10 @@ mod tests {
 
         // Simulate master node removal
         info!("Simulate master node removal");
-        master_handle.abort();
         master_cluster_manager.stop();
+        master_handle.abort();
         // Wait for the system to detect the master node removal
-        tokio::time::sleep(std::time::Duration::from_secs(SESSION_TIMEOUT_SEC)).await;
+        tokio::time::sleep(std::time::Duration::from_secs(SESSION_TIMEOUT_SEC + 1)).await;
 
         // Check if the slave node has become the new master
         let new_master_status = slave_cluster_manager_1.get_node().status();

--- a/src/storage/cache_proxy/cluster_manager.rs
+++ b/src/storage/cache_proxy/cluster_manager.rs
@@ -1,0 +1,1035 @@
+//! The utilities of distribute cache cluster management
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+use parking_lot::RwLock;
+use tracing::{debug, error, info, warn};
+
+use crate::async_fuse::memfs::kv_engine::{etcd_impl, KVEngine, SetOption};
+use crate::async_fuse::memfs::kv_engine::{KVEngineType, KeyType, ValueType};
+use crate::common::error::{Context, DatenLordError, DatenLordResult};
+
+use super::node::{MasterNodeInfo, Node, NodeStatus};
+use super::ring::Ring;
+
+/// The timeout for the lock of updating the master node
+const MASTER_LOCK_TIMEOUT_SEC: i64 = 30;
+/// The timeout for the node register
+const NODE_REGISTER_TIMEOUT_SEC: i64 = 10;
+
+/// Node sessions
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct NodeSessions {
+    /// Register session
+    /// Used to store the register tasks,
+    /// so we can cancel the tasks when the node is down or role changed
+    register_session: Option<Arc<etcd_impl::Session>>,
+    /// Master session
+    /// Used to store the master tasks,
+    /// Ditto
+    master_session: Option<Arc<etcd_impl::Session>>,
+}
+
+impl NodeSessions {
+    /// Create a new node sessions
+    pub fn new() -> Self {
+        Self {
+            register_session: None,
+            master_session: None,
+        }
+    }
+
+    /// Get register session
+    pub fn register_session(&self) -> Option<Arc<etcd_impl::Session>> {
+        self.register_session.clone()
+    }
+
+    /// Get master session
+    pub fn master_session(&self) -> Option<Arc<etcd_impl::Session>> {
+        self.master_session.clone()
+    }
+
+    /// Update register session
+    pub fn update_register_session(&mut self, session: Option<Arc<etcd_impl::Session>>) {
+        self.register_session = session;
+    }
+
+    /// Update master session
+    pub fn update_master_session(&mut self, session: Option<Arc<etcd_impl::Session>>) {
+        self.master_session = session;
+    }
+
+    /// Delete register session
+    pub fn delete_register_session(&mut self) {
+        self.register_session = None;
+    }
+
+    /// Delete master session
+    pub fn delete_master_session(&mut self) {
+        self.master_session = None;
+    }
+}
+
+/// ClusterManager
+///
+/// This struct is used to interact with etcd server and manager the cluster.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct ClusterManager {
+    /// inner struct
+    inner: Arc<ClusterManagerInner>,
+}
+
+#[allow(dead_code)]
+impl ClusterManager {
+    /// Create new cluster manager
+    pub fn new(kv_engine: Arc<KVEngineType>) -> Self {
+        let inner = Arc::new(ClusterManagerInner::new(kv_engine));
+        Self { inner }
+    }
+
+    /// Run the cluster manager as state machine
+    ///
+    /// We need to perpare current node info, current node list and generate hash ring info
+    pub async fn run(
+        &self,
+        node: Arc<RwLock<Node>>,
+        nodes: Arc<RwLock<Vec<Node>>>,
+        ring: Arc<RwLock<Ring<Node>>>,
+    ) -> DatenLordResult<()> {
+        self.inner.run(node, nodes, ring).await
+    }
+
+    /// Register
+    ///
+    /// Register current node to etcd and keep alive
+    pub async fn register(&self, node: Arc<RwLock<Node>>) -> DatenLordResult<()> {
+        self.inner.register(node).await
+    }
+
+    /// Campaign
+    ///
+    /// Try to campaign master, will return status and master value
+    pub async fn do_campaign(
+        &self,
+        node: Arc<RwLock<Node>>,
+        ring_version: u64,
+    ) -> DatenLordResult<(bool, String)> {
+        self.inner.do_campaign(node, ring_version).await
+    }
+
+    /// Do slave tasks
+    ///
+    /// Slave node will watch the ring update and campaign master
+    pub async fn do_slave_tasks(
+        &self,
+        node: Arc<RwLock<Node>>,
+        ring: Arc<RwLock<Ring<Node>>>,
+    ) -> DatenLordResult<()> {
+        self.inner.do_slave_tasks(node, ring).await
+    }
+
+    /// Do master tasks
+    ///
+    /// Master node will watch the node list update, and update the ring
+    pub async fn do_master_tasks(
+        &self,
+        node: Arc<RwLock<Node>>,
+        nodes: Arc<RwLock<Vec<Node>>>,
+        ring: Arc<RwLock<Ring<Node>>>,
+    ) -> DatenLordResult<()> {
+        self.inner.do_master_tasks(node, nodes, ring).await
+    }
+}
+
+/// ClusterManagerInner
+///
+/// Inner struct of ClusterManager
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct ClusterManagerInner {
+    /// Etcd client
+    kv_engine: Arc<KVEngineType>,
+    /// Node sessions, try to keep the session alive
+    node_sessions: Arc<RwLock<NodeSessions>>,
+}
+
+#[allow(dead_code)]
+impl ClusterManagerInner {
+    /// Create a new cluster manager
+    pub fn new(kv_engine: Arc<KVEngineType>) -> Self {
+        let node_sessions = Arc::new(RwLock::new(NodeSessions::new()));
+        Self {
+            kv_engine,
+            node_sessions,
+        }
+    }
+
+    /// Run the cluster manager as state machine
+    ///
+    /// We need to perpare current node info, current node list and generate hash ring info
+    pub async fn run(
+        &self,
+        node: Arc<RwLock<Node>>,
+        nodes: Arc<RwLock<Vec<Node>>>,
+        ring: Arc<RwLock<Ring<Node>>>,
+    ) -> DatenLordResult<()> {
+        // 1. Init cluster manager
+        info!("Cluster manager start to run");
+        info!("Current node status: {:?}", node.clone().read().status());
+        // Next step is to register the node
+        node.write().set_status(NodeStatus::Registering);
+        self.update_node_info(node.clone()).await?;
+        loop {
+            // 2. Register node to etcd
+            info!("Current node status: {:?}", node.clone().read().status());
+            while self.register(node.clone()).await.is_err() {
+                error!("Failed to register node, retry in 5s");
+                // Try to register node to etcd
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+            // Update node status to Registering
+            node.write().set_status(NodeStatus::Slave);
+            self.update_node_info(node.clone()).await?;
+
+            loop {
+                // 3. Do campaign
+                let (campaign_status, campaign_val) = self
+                    .do_campaign(node.clone(), ring.read().version())
+                    .await?;
+                info!(
+                    "Campaign status: {:?} val: {:?}",
+                    campaign_status, campaign_val
+                );
+
+                // Check current hashring version and update local ring
+                let current_master_node_info =
+                    serde_json::from_str::<MasterNodeInfo>(&campaign_val)?;
+                if current_master_node_info.hash_ring_version != ring.read().version() {
+                    // Fetch the latest ring from etcd
+                    self.load_ring(ring.clone()).await?;
+                }
+
+                // 4. Serve as normal status
+                match node.clone().read().status() {
+                    // Serve as slave node
+                    NodeStatus::Slave => {
+                        self.do_slave_tasks(node.clone(), ring.clone()).await?;
+                    }
+                    // Serve as master node
+                    NodeStatus::Master => {
+                        self.do_master_tasks(node.clone(), nodes.clone(), ring.clone())
+                            .await?;
+                    }
+                    // Other parts can not
+                    _ => {
+                        // Clean up tasks
+                        self.clean_sessions().await;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Update node info
+    pub async fn update_node_info(&self, node: Arc<RwLock<Node>>) -> DatenLordResult<()> {
+        let node = node.read();
+        let key = &KeyType::CacheNode(node.ip().to_owned());
+        while self
+            .kv_engine
+            .set(
+                key,
+                &ValueType::Json(serde_json::to_value(node.clone())?),
+                None,
+            )
+            .await
+            .is_err()
+        {
+            error!("Failed to update node info, retry in 5s");
+            // Try to update node info
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+
+        Ok(())
+    }
+
+    /// Register current node to etcd and keep alive
+    pub async fn register(&self, node: Arc<RwLock<Node>>) -> DatenLordResult<()> {
+        // Get current node info
+        let node_dump = node.read().clone();
+        info!("register: {} to etcd", node_dump.ip());
+
+        // Try to get lease for current node
+        let lease = self
+            .kv_engine
+            .create_lease(NODE_REGISTER_TIMEOUT_SEC)
+            .await
+            .with_context(|| "Failed to get lease for current node")?;
+
+        // Try to register current node to etcd
+        self.kv_engine
+            .set(
+                &KeyType::CacheNode(node_dump.ip().to_owned()),
+                &ValueType::Json(serde_json::to_value(node_dump.clone())?),
+                Some(SetOption {
+                    // Set lease
+                    lease: Some(lease),
+                    prev_kv: false,
+                }),
+            )
+            .await
+            .with_context(|| format!("Failed to register node to etcd"))?;
+
+        info!("register: {} to etcd success", node_dump.ip());
+
+        // Set online status, default is slave
+        node.write().set_status(NodeStatus::Slave);
+
+        // Try keep alive current node to clsuter
+        let register_session = self
+            .kv_engine
+            .create_session(lease, NODE_REGISTER_TIMEOUT_SEC as u64)
+            .await?;
+        self.node_sessions
+            .write()
+            .update_register_session(Some(register_session.clone()));
+
+        Ok(())
+    }
+
+    /// Do campaign
+    ///
+    /// Try to campaign master, will return status and master value
+    pub async fn do_campaign(
+        &self,
+        node: Arc<RwLock<Node>>,
+        ring_version: u64,
+    ) -> DatenLordResult<(bool, String)> {
+        let client = self.kv_engine.clone();
+        let lease = self
+            .kv_engine
+            .create_lease(MASTER_LOCK_TIMEOUT_SEC)
+            .await
+            .with_context(|| "Failed to get lease for current node")?;
+
+        // Master key info
+        let master_key = &KeyType::CacheMasterNode;
+        // Create master instance
+        let master_node_info = MasterNodeInfo::new(
+            node.read().ip().to_owned(),
+            node.read().port(),
+            ring_version,
+        );
+        let master_node_info_json = serde_json::to_value(master_node_info)?.to_string();
+
+        // Try to set campaign
+        let txn = client.new_meta_txn().await;
+        let (campaign_status, campaign_val) = txn
+            .campaign(master_key, master_node_info_json, lease)
+            .await?;
+        // Check the leader key
+        if campaign_status {
+            // Serve as master node
+            node.write().set_status(NodeStatus::Master);
+
+            // Try keep alive current master to clsuter
+            let master_session = self
+                .kv_engine
+                .create_session(lease, NODE_REGISTER_TIMEOUT_SEC as u64)
+                .await?;
+            self.node_sessions
+                .write()
+                .update_master_session(Some(master_session.clone()));
+        } else {
+            // Serve as slave node
+            node.write().set_status(NodeStatus::Slave);
+        }
+
+        Ok((campaign_status, campaign_val))
+    }
+
+    /// Do slave tasks
+    ///
+    /// Slave node will watch the ring update and campaign master
+    pub async fn do_slave_tasks(
+        &self,
+        node: Arc<RwLock<Node>>,
+        ring: Arc<RwLock<Ring<Node>>>,
+    ) -> DatenLordResult<()> {
+        info!("do_slave_tasks: will watch the ring update and campaign master");
+
+        // 1. Try to watch master and hashring
+        // Wait for status update
+        loop {
+            // Check the node status
+            tokio::select! {
+                _ = tokio::time::sleep(Duration::from_secs(MASTER_LOCK_TIMEOUT_SEC as u64 / 3)) => {
+                    // Check the node status
+                    if node.read().status() != NodeStatus::Slave {
+                        // If the node status is not slave, clean up slave tasks and return
+                        // Clean up slave tasks
+                        self.clean_sessions().await;
+
+                        return Ok(());
+                    }
+
+                    // Block here, try to watch master
+                    self.watch_master(ring.clone()).await?;
+                }
+            }
+        }
+    }
+
+    /// Do master tasks
+    ///
+    /// 1. Master node will watch the node list update, and update the ring
+    /// 2. Master will check self
+    pub async fn do_master_tasks(
+        &self,
+        node: Arc<RwLock<Node>>,
+        nodes: Arc<RwLock<Vec<Node>>>,
+        ring: Arc<RwLock<Ring<Node>>>,
+    ) -> DatenLordResult<()> {
+        info!("do_master_tasks: will watch the node list update, and update the ring");
+
+        // loop for node list update
+        loop {
+            // Keep alive master key
+            // Check current status
+            if node.read().status() != NodeStatus::Master {
+                // If the node status is not master, clean up master tasks and return
+                error!("Current node status is not master, return to endpoint");
+
+                return Ok(());
+            }
+
+            // Do watch node list update task
+            // This task will block until the master status changed
+            self
+                .watch_nodes(node.clone(), nodes.clone(), ring.clone())
+                .await.with_context(|| "Failed to watch the node list update, and update the ring")?;
+        }
+    }
+
+    /// Clean up the tasks
+    pub async fn clean_sessions(&self) {
+        // Clean up register tasks
+        self.node_sessions.write().delete_register_session();
+
+        // Clean up master tasks
+        self.node_sessions.write().delete_master_session();
+    }
+
+    /// Try to check current session is valid
+    pub async fn check_session_valid(&self, node: Arc<RwLock<Node>>) -> bool {
+        // Check register session
+        if let Some(register_session) = self.node_sessions.read().register_session() {
+            if register_session.is_closed() {
+                info!("Current session is valid");
+                return false;
+            }
+        }
+
+        // Check master session
+        if node.read().status() == NodeStatus::Master {
+            if let Some(master_session) = self.node_sessions.read().master_session() {
+                if master_session.is_closed() {
+                    info!("Current session is valid");
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+
+    /// Master node will watch the node list update, and update the ring
+    pub async fn watch_nodes(
+        &self,
+        node: Arc<RwLock<Node>>,
+        nodes: Arc<RwLock<Vec<Node>>>,
+        ring: Arc<RwLock<Ring<Node>>>,
+    ) -> DatenLordResult<()> {
+        info!("watch_nodes: will watch the node list update");
+
+        // Get all nodes with prefix and init hash ring list
+        // TODO: Block cluster and do not add any new node when watch_nodes is synced.
+        let cluster_nodes = self.get_nodes().await?;
+        let mut node_write = nodes.write();
+        let mut ring_write = ring.write();
+        info!("watch_nodes: init node list");
+        for cluster_node in cluster_nodes {
+            ring_write.add(&cluster_node.clone(), true);
+            node_write.push(cluster_node.clone());
+        }
+        drop(node_write);
+        drop(ring_write);
+
+        info!("watch_nodes: init node list success");
+
+        self.update_cluster_topo(node.clone(), ring.clone()).await?;
+
+        // Get all nodes with prefix
+        let key = &KeyType::CacheNode("".to_string());
+        let mut nodes_watch_stream = self.kv_engine.watch(key).await.unwrap();
+
+        info!(
+            "watch_nodes: will watch the node list update with key: {:?}",
+            key
+        );
+
+        // Wait for node list update
+        loop {
+            match nodes_watch_stream.next().await {
+                Some(Ok(event)) => {
+                    let key = event.0;
+                    let value = event.1;
+                    match value {
+                        Some(item_value) => {
+                            // Update event
+                            info!("Receive update node list event with key: {:?}", key);
+
+                            // deserialize node list to Vec<Node>
+                            let updated_node = match item_value {
+                                ValueType::Json(nodes_json) => {
+                                    let updated_node: Node =
+                                        serde_json::from_value(nodes_json.to_owned()).unwrap();
+                                    Some(updated_node)
+                                }
+                                _ => None,
+                            };
+
+                            // Update current node list info
+                            if let Some(updated_node) = updated_node {
+                                // Append new node to the node list
+                                nodes.write().push(updated_node.clone());
+
+                                // Update ring
+                                ring.write().add(&updated_node, true);
+
+                                // Update cluster topo
+                                self.update_cluster_topo(node.clone(), ring.clone()).await?;
+                            } else {
+                                error!("Failed to deserialize node list");
+                            }
+                        }
+                        None => {
+                            // Delete event
+                            info!("delete node list event with key: {:?}", key);
+                            // Get ip from key
+                            let key = key.to_owned();
+                            let key = key.replace("CacheNode", "");
+                            info!("delete node list event with key: {:?}", key);
+
+                            // Try to remove the node from the node list and updated the ring
+                            if let Some(removed_node) =
+                                nodes.read().iter().find(|node| node.ip() == key)
+                            {
+                                // Try to remove the node from the node list and get the node info
+                                // And remove node from the node list
+                                let _ = nodes.write().retain(|n| n.ip() != removed_node.ip());
+
+                                info!("Remove node from node list: {:?}", removed_node);
+
+                                // Update ring
+                                let _ = ring.write().remove(removed_node.to_owned(), true);
+
+                                // Update cluster topo
+                                self.update_cluster_topo(node.clone(), ring.clone()).await?;
+                            }
+                        }
+                    }
+                }
+                None => {
+                    info!("111");
+                    // No event
+                    continue;
+                }
+                Some(Err(e)) => {
+                    // Raise error and return to upper level, try to rewatch master again
+                    error!("Failed to watch node list key: {:?}", e);
+                    return Err(DatenLordError::CacheClusterErr {
+                        context: vec![format!("Failed to watch node list key")],
+                    });
+                }
+            }
+        }
+    }
+
+    /// Update cluster topo
+    ///
+    /// Try to update cluster by current master node
+    async fn update_cluster_topo(
+        &self,
+        node: Arc<RwLock<Node>>,
+        ring: Arc<RwLock<Ring<Node>>>,
+    ) -> DatenLordResult<()> {
+        // Update to etcd
+        let master_key = &KeyType::CacheMasterNode;
+
+        // Create master instance
+        let master_node_info = MasterNodeInfo::new(
+            node.read().ip().to_owned(),
+            node.read().port(),
+            ring.read().version(),
+        );
+        let master_node_info_json = serde_json::to_value(master_node_info)?;
+        let master_value = &ValueType::Json(master_node_info_json);
+
+        // Check both session valid
+        if !self.check_session_valid(node.clone()).await {
+            error!("Current session is invalid, return to endpoint");
+            return Err(DatenLordError::CacheClusterErr {
+                context: vec![format!("Current session is invalid")],
+            });
+        }
+
+        let master_sessions = self.node_sessions.read().master_session();
+        match master_sessions {
+            Some(session) => {
+                // Update master data
+                // Try to update master hashring version
+                let lease = session.lease_id();
+                self.kv_engine
+                    .set(
+                        master_key,
+                        master_value,
+                        Some(SetOption {
+                            // Set lease
+                            lease: Some(lease),
+                            prev_kv: false,
+                        }),
+                    )
+                    .await?;
+
+                // Update hashring data
+                let _ = self.save_ring(ring.clone()).await?;
+            }
+            None => {
+                error!("Failed to renew lease for master node");
+                // Change to slave node
+                node.write().set_status(NodeStatus::Slave);
+                return Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Failed to renew lease for master node")],
+                });
+            }
+        };
+
+        Ok(())
+    }
+
+    /// Try to watch the master node
+    /// If the master node is down, the slave node will try to get the master lock
+    /// Then current node will become the master node
+    pub async fn watch_master(&self, ring: Arc<RwLock<Ring<Node>>>) -> DatenLordResult<()> {
+        info!("watch_master: will watch the master node and try to update master hashring");
+
+        // Watch with prefix
+        let master_key = &KeyType::CacheMasterNode;
+        let mut master_watch_stream = self.kv_engine.watch(master_key).await.unwrap();
+
+        // Watch master key events
+        // If master has changed, try to update the value
+        // 1. If master ip changed, try to change the master node
+        // TODO: master key is keeped by lease, so the master node will be auto deleted
+        // if master node is down.
+        // If the version is changed, try to update the ring
+        // In current case, we just need to detect master key change and update hashring.
+        // 2. If the master key is auto deleted, exit and change current status to slave.
+        loop {
+            match master_watch_stream.next().await {
+                Some(Ok(event)) => {
+                    let key = event.0;
+                    let value = event.1;
+                    match value {
+                        Some(_) => {
+                            // Update event
+                            debug!("Receive update ring event with key: {:?}", key);
+
+                            // In this step, we just need to update the ring
+                            self.load_ring(ring.clone()).await?;
+                        }
+                        None => {
+                            // Delete event
+                            info!("delete master event with key: {:?}", key);
+                            // Master has down, try to campaign master
+                            // Return to main loop
+                            return Ok(());
+                        }
+                    }
+                }
+                None => {
+                    // No event
+                    continue;
+                }
+                Some(Err(e)) => {
+                    // Raise error and return to upper level, try to rewatch master again
+                    error!("Failed to watch master key: {:?}", e);
+                    return Err(DatenLordError::CacheClusterErr {
+                        context: vec![format!("Failed to watch master key")],
+                    });
+                }
+            }
+        }
+    }
+
+    /// Save ring to etcd
+    pub async fn save_ring(&self, ring: Arc<RwLock<Ring<Node>>>) -> DatenLordResult<()> {
+        // Only master node can save ring to etcd
+        // So we do not need to lock the ring
+        let ring_key = &KeyType::CacheRing;
+        let current_json_value;
+        if let Ok(json_value) = serde_json::to_value(ring.read().clone()) {
+            current_json_value = json_value;
+        } else {
+            error!("Failed to serialize ring");
+            return Ok(());
+        }
+        let ring_value = &ValueType::Json(current_json_value);
+
+        let key = &KeyType::CacheRing;
+        debug!("Save ring to etcd: {}", key);
+        self.kv_engine.set(ring_key, ring_value, None).await?;
+
+        Ok(())
+    }
+
+    /// Load ring from etcd
+    pub async fn load_ring(&self, ring: Arc<RwLock<Ring<Node>>>) -> DatenLordResult<()> {
+        let key = &KeyType::CacheRing;
+        debug!("Try to load ring from etcd: {}", key);
+
+        // Get ring from etcd
+        match self.kv_engine.get(key).await? {
+            Some(ValueType::Json(ring_json)) => {
+                let new_ring: Ring<Node> = serde_json::from_value(ring_json)?;
+                ring.write().update(&new_ring);
+
+                info!("Load ring from etcd success");
+                Ok(())
+            }
+            _ => {
+                error!("Failed to deserialize ring");
+                Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Failed to deserialize ring")],
+                })
+            }
+        }
+    }
+
+    /// Get node lists
+    pub async fn get_nodes(&self) -> DatenLordResult<Vec<Node>> {
+        let key = &KeyType::CacheNode("".to_string());
+        debug!("Get node list from etcd: {}", key);
+
+        // Get node list from etcd
+        let nodes = self.kv_engine.range(key).await?;
+        let mut node_list = Vec::new();
+        for node in nodes {
+            match node {
+                ValueType::Json(node_json) => {
+                    let node: Node = serde_json::from_value(node_json)?;
+                    node_list.push(node);
+                }
+                _ => {
+                    warn!("Failed to deserialize node");
+                }
+            }
+        }
+
+        Ok(node_list)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::sync::Arc;
+
+    use parking_lot::RwLock;
+    use tracing::info;
+    use tracing_subscriber;
+
+    use crate::{
+        async_fuse::memfs::kv_engine::{DeleteOption, KVEngine, KVEngineType, KeyType},
+        storage::cache_proxy::{
+            cluster_manager::{ClusterManager, NODE_REGISTER_TIMEOUT_SEC},
+            node::{Node, NodeStatus},
+            ring::Ring,
+        },
+    };
+
+    const ETCD_ADDRESS: &str = "127.0.0.1:2379";
+
+    /// Helper function to create a new node with a given IP address
+    fn create_node(ip: &str) -> Arc<RwLock<Node>> {
+        let mut node = Node::default();
+        node.set_ip(ip.to_string());
+
+        let node = Arc::new(RwLock::new(node));
+        node
+    }
+
+    async fn clean_up_etcd() {
+        // Clean up all `CacheNode` prefix keys in etcd
+        let _ = KVEngineType::new(vec![ETCD_ADDRESS.to_string()])
+            .await
+            .unwrap()
+            .delete(
+                &KeyType::CacheNode("".to_string()),
+                Some(DeleteOption {
+                    prev_kv: false,
+                    range_end: Some(vec![0xff]),
+                }),
+            )
+            .await;
+
+        // Clean up all `CacheMasterNode` keys in etcd
+        let _ = KVEngineType::new(vec![ETCD_ADDRESS.to_string()])
+            .await
+            .unwrap()
+            .delete(
+                &KeyType::CacheMasterNode,
+                Some(DeleteOption {
+                    prev_kv: false,
+                    range_end: Some(vec![0xff]),
+                }),
+            )
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_single_master_election() {
+        tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .init();
+        let client = Arc::new(
+            KVEngineType::new(vec![ETCD_ADDRESS.to_string()])
+                .await
+                .unwrap(),
+        );
+
+        // Clean up etcd
+        clean_up_etcd().await;
+
+        let ring_version: u64 = 1;
+        let test_master_node = create_node("192.168.1.2");
+        let master_cluster_manager = ClusterManager::new(client.clone());
+        let test_slave_node_1 = create_node("192.168.1.3");
+        let slave_1_cluster_manager = ClusterManager::new(client.clone());
+        let test_slave_node_2 = create_node("192.168.1.4");
+        let slave_2_cluster_manager = ClusterManager::new(client.clone());
+
+        info!("test_single_master_election: start to test single master election");
+
+        let (master_res, slave_1_res, slave_2_res) = tokio::join!(
+            async {
+                // Register node
+                let _ = master_cluster_manager
+                    .register(test_master_node.clone())
+                    .await;
+                // campaign
+                master_cluster_manager
+                    .do_campaign(test_master_node.clone(), ring_version)
+                    .await
+            },
+            async {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                let _ = slave_1_cluster_manager
+                    .register(test_slave_node_1.clone())
+                    .await;
+                // campaign
+                slave_1_cluster_manager
+                    .do_campaign(test_slave_node_1.clone(), ring_version)
+                    .await
+            },
+            async {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                let _ = slave_2_cluster_manager
+                    .register(test_slave_node_2.clone())
+                    .await;
+                // campaign
+                slave_2_cluster_manager
+                    .do_campaign(test_slave_node_2.clone(), ring_version)
+                    .await
+            }
+        );
+
+        // Check the result
+        assert!(master_res.is_ok());
+        assert!(slave_1_res.is_ok());
+        assert!(slave_2_res.is_ok());
+
+        // Check node role
+        assert_eq!(test_master_node.read().status(), NodeStatus::Master);
+        assert_eq!(test_slave_node_1.read().status(), NodeStatus::Slave);
+        assert_eq!(test_slave_node_2.read().status(), NodeStatus::Slave);
+    }
+
+    #[tokio::test]
+    async fn test_add_new_node() {
+        tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .init();
+        let client = Arc::new(
+            KVEngineType::new(vec![ETCD_ADDRESS.to_string()])
+                .await
+                .unwrap(),
+        );
+
+        // Clean up etcd
+        clean_up_etcd().await;
+
+        let ring_version: u64 = 1;
+        let test_master_node = create_node("192.168.2.2");
+        let master_cluster_manager = ClusterManager::new(client.clone());
+        let test_slave_node_1 = create_node("192.168.2.3");
+        let slave_1_cluster_manager = ClusterManager::new(client.clone());
+        let test_slave_node_2 = create_node("192.168.2.4");
+        let slave_2_cluster_manager = ClusterManager::new(client.clone());
+
+        // Join master and slave1
+        let (master_res, slave_1_res) = tokio::join!(
+            async {
+                // Register node
+                let _ = master_cluster_manager
+                    .register(test_master_node.clone())
+                    .await;
+                // campaign
+                master_cluster_manager
+                    .do_campaign(test_master_node.clone(), ring_version)
+                    .await
+            },
+            async {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                let _ = slave_1_cluster_manager
+                    .register(test_slave_node_1.clone())
+                    .await;
+                // campaign
+                slave_1_cluster_manager
+                    .do_campaign(test_slave_node_1.clone(), ring_version)
+                    .await
+            }
+        );
+
+        // Wait for the election to finish
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+        // Check the result
+        assert!(master_res.is_ok());
+        assert!(slave_1_res.is_ok());
+
+        // Test add new node
+        let _ = slave_2_cluster_manager
+            .register(test_slave_node_2.clone())
+            .await
+            .unwrap();
+        // campaign
+        let _ = slave_2_cluster_manager
+            .do_campaign(test_slave_node_2.clone(), ring_version)
+            .await
+            .unwrap();
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+        // Check node role
+        assert_eq!(test_master_node.read().status(), NodeStatus::Master);
+        assert_eq!(test_slave_node_1.read().status(), NodeStatus::Slave);
+        assert_eq!(test_slave_node_2.read().status(), NodeStatus::Slave);
+    }
+
+    #[tokio::test]
+    async fn test_remove_slave_node() {
+        tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .init();
+        let client = Arc::new(
+            KVEngineType::new(vec![ETCD_ADDRESS.to_string()])
+                .await
+                .unwrap(),
+        );
+
+        // Clean up etcd
+        clean_up_etcd().await;
+
+        // Setup initial state with multiple nodes
+        let test_master_node: Arc<parking_lot::lock_api::RwLock<parking_lot::RawRwLock, Node>> = create_node("192.168.3.2");
+        let test_master_ring: Arc<RwLock<Ring<Node>>> = Arc::new(RwLock::new(Ring::default()));
+        let test_slave_node: Arc<parking_lot::lock_api::RwLock<parking_lot::RawRwLock, Node>> = create_node("192.168.3.3");
+        // let test_slave_nodes: Arc<RwLock<Vec<Node>>> = Arc::new(RwLock::new(vec![]));
+        // let test_slave_ring: Arc<RwLock<Ring<Node>>> = Arc::new(RwLock::new(Ring::default()));
+        // let test_master_nodes: Arc<RwLock<Vec<Node>>> = Arc::new(RwLock::new(vec![
+        //     test_master_node.read().clone(),
+        //     test_slave_node.read().clone(),
+        // ]));
+        let test_master_nodes: Arc<RwLock<Vec<Node>>> = Arc::new(RwLock::new(vec![]));
+
+        let master_client = client.clone();
+        let test_master_node_clone = test_master_node.clone();
+        let test_master_nodes_clone = test_master_nodes.clone();
+        let master_handle = tokio::task::spawn_blocking(move || {
+            tokio::runtime::Handle::current().block_on(async move {
+                let master_cluster_manager = Arc::new(ClusterManager::new(master_client));
+                // Register node
+                let _ = master_cluster_manager
+                .register(test_master_node_clone.clone())
+                .await;
+                // Campaign
+                let _ = master_cluster_manager
+                    .do_campaign(test_master_node_clone.clone(), 1)
+                    .await
+                    .unwrap();
+                // Run master
+                let res = master_cluster_manager.do_master_tasks(
+                    test_master_node_clone.clone(),
+                    test_master_nodes_clone.clone(),
+                    test_master_ring.clone(),
+                ).await;
+                info!("master_handle: {:?}", res);
+            });
+        });
+
+        // Slave online
+        let slave_client = client.clone();
+        let test_slave_node_clone = test_slave_node.clone();
+        let slave_cluster_manager = Arc::new(ClusterManager::new(slave_client));
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        // Register
+        let _ = slave_cluster_manager
+            .register(test_slave_node_clone.clone())
+            .await;
+        // Campaign
+        let _ = slave_cluster_manager
+            .do_campaign(test_slave_node_clone.clone(), 1)
+            .await
+            .unwrap();
+
+        // Wait for the election to finish
+        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        assert_eq!(test_master_node.read().status(), NodeStatus::Master);
+        assert_eq!(test_slave_node.read().status(), NodeStatus::Slave);
+
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        info!("test_remove_slave_node: update node list");
+        assert_eq!(test_master_node.read().status(), NodeStatus::Master);
+        assert_eq!(test_master_nodes.read().len(), 2);
+
+        // Cancel the slave task
+        drop(slave_cluster_manager);
+        // Wait for slave key is deleted
+        tokio::time::sleep(std::time::Duration::from_secs(2 * NODE_REGISTER_TIMEOUT_SEC as u64)).await;
+        info!("test_remove_slave_node: start to test remove slave node");
+        info!("Get all nodes: {:?}", test_master_nodes.read());
+
+        assert_eq!(test_master_node.read().status(), NodeStatus::Master);
+        assert_eq!(test_master_nodes.read().len(), 1);
+
+        master_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_remove_master_node() {}
+}

--- a/src/storage/cache_proxy/config.rs
+++ b/src/storage/cache_proxy/config.rs
@@ -1,0 +1,22 @@
+/// Config for the distribute cache
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Key-value store addresses
+    pub kv_addrs: Vec<String>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Config {
+    /// Create a new config
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            kv_addrs: Vec::new(),
+        }
+    }
+}

--- a/src/storage/cache_proxy/mod.rs
+++ b/src/storage/cache_proxy/mod.rs
@@ -8,3 +8,6 @@ pub mod node;
 
 /// Config module, config the distribute cache
 pub mod config;
+
+/// Cluster informer module, use metadata to manage the nodes
+pub mod cluster_manager;

--- a/src/storage/cache_proxy/mod.rs
+++ b/src/storage/cache_proxy/mod.rs
@@ -1,7 +1,10 @@
-/// This module contains the cache proxy implementation.
+/// This module contains the distribute cache implementation.
 
 /// Hash ring module
 pub mod ring;
 
 /// Node module
 pub mod node;
+
+/// Config module, config the distribute cache
+pub mod config;

--- a/src/storage/cache_proxy/node.rs
+++ b/src/storage/cache_proxy/node.rs
@@ -135,7 +135,7 @@ impl Node {
 }
 
 /// Node status
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Copy)]
 pub enum NodeStatus {
     /// The node is preparing
     Initializing,

--- a/src/storage/cache_proxy/ring.rs
+++ b/src/storage/cache_proxy/ring.rs
@@ -12,7 +12,7 @@ use tracing::warn;
 use crate::async_fuse::util::usize_to_u64;
 
 /// The default slot size
-/// We use u64::MAX as the default slot size
+/// We use `u64::MAX` as the default slot size
 /// And we do not need to worry about the overflow
 const DEFAULT_SLOT_SIZE: u64 = std::u64::MAX;
 
@@ -127,7 +127,7 @@ impl Default for DefaultHashBuilder {
 pub struct Ring<T, S = DefaultHashBuilder>
 where
     T: NodeType,
-    S: BuildHasher,
+    S: BuildHasher + Clone,
 {
     /// The hash builder
     #[serde(skip)]
@@ -158,9 +158,10 @@ where
 impl<T, S> Ring<T, S>
 where
     T: NodeType,
-    S: BuildHasher,
+    S: BuildHasher + Clone,
 {
     /// Create a new hash ring with a given hash builder and capacity
+    #[must_use]
     pub fn new(hash_builder: S) -> Self {
         Self {
             hash_builder,
@@ -170,22 +171,34 @@ where
         }
     }
 
+    /// Update the ring with a given ring
+    /// It will node update the hash builder
+    pub fn update(&mut self, ring: &Ring<T, S>) {
+        self.slots = ring.slots.clone();
+        self.capacity = ring.capacity;
+        self.version = ring.version;
+    }
+
     /// Get the slot length
+    #[must_use]
     pub fn len_slots(&self) -> usize {
         self.slots.len()
     }
 
     /// Get the slot at a given index
+    #[must_use]
     pub fn capacity(&self) -> u64 {
         self.capacity
     }
 
     /// Get version
+    #[must_use]
     pub fn version(&self) -> u64 {
         self.version
     }
 
     /// Check if the ring is empty
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.slots.is_empty()
     }
@@ -199,7 +212,7 @@ where
 impl<T, S: BuildHasher> Ring<T, S>
 where
     T: NodeType,
-    S: BuildHasher,
+    S: BuildHasher + Clone,
 {
     /// Add a node to a slot
     /// We will create a new slot and update slot mapping, then add to the ring

--- a/src/storage/cache_proxy/ring.rs
+++ b/src/storage/cache_proxy/ring.rs
@@ -253,9 +253,14 @@ where
 
         // Calculate the new ranges for the split
         let slot_to_split = self.slots.get_mut(index)?;
-        let mid_point = (slot_to_split.start + slot_to_split.end)
-            .overflowing_div(2)
-            .0;
+        let (mut sum, overflowed) = slot_to_split.start.overflowing_add(slot_to_split.end);
+        if overflowed {
+            sum = self.capacity;
+        }
+        let (mid_point, overflowed) = sum.overflowing_div(2);
+        if overflowed {
+            return None;
+        }
 
         // Create new slot with the second half of the range
         let new_slot = Slot::new(mid_point + 1, slot_to_split.end, node.clone());


### PR DESCRIPTION
Support distribute cache meta engine type: etcd.

1. Use kvengine as common client.
2. Support watch function(TODO)
3. Implement basic `MetaDataClient` trait.


# Design Document for Cluster Manager.

## Objectives
- **Election Testing**: Ensure that exactly one node is elected as the control node.
- **Node Addition Testing**: The controller should detect new nodes and modify the hash ring accordingly.
- **Offline Logic Testing**: Implement testing for node disconnections, e.g., by aborting coroutines, allowing etcd to detect these changes.
- **Detection and Synchronization**: Other nodes should detect changes in the etcd's hash ring and synchronize their in-memory state accordingly.

## Design Overview

### DistributedCacheCluster

The `DistributedCacheCluster` acts as the observational unit for the entire cluster, incorporating a consistent hashing ring, an online node list, and a cluster notifier.

```rust
/// DistributedCacheCluster
///
/// This struct is used to manage the inner topology cache.
pub struct DistributedCacheCluster {
    /// The cache proxy topology
    node: Arc<RwLock<Node>>,
    /// Proxy topology for hashring
    hashring: Arc<RwLock<Ring<Node>>>,
    /// Node list
    node_list: Arc<RwLock<Vec<Node>>>,
    /// Cluster informer
    cluster_informer: Arc<ClusterInformer>,
}

impl DistributedCacheCluster {
    /// Register to cluster
    pub async fn register(&self) -> DatenLordResult<()> {}
}
```

### Node

Represents the current node's role, status, and fundamental information. Nodes start in `Prepare` state and set as `slave`. There must be exactly one `master` in the cluster.

```rust
/// Physical node struct
///
/// physical node is the node in the slot mapping
#[derive(Debug, Clone, Serialize, Deserialize)]
pub struct Node {
    /// We assume that ip is unique in our system
    ip: String,
    /// The port of the node
    port: u16,
    /// The weight of the node
    weight: u32,
    /// The status of the node
    status: NodeStatus,
    /// The role of the node
    role: NodeRole,
}

/// Node status
#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
pub enum NodeStatus {
    /// The node is online
    Online,
    /// The node is offline
    Offline,
    /// The node is preparing
    Prepare,
}

/// Node role
#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
pub enum NodeRole {
    /// The node is master
    Master,
    /// The node is slave
    Slave,
}
```

### Cluster Informer

Acts as the central observation entry for cluster synchronization, mainly maintaining an etcd client and managing mutable node and hash ring information passed by `DistributedCacheCluster`.

```rust
/// ETCD client
///
/// This struct is used to interact with etcd server.
#[derive(Debug, Clone)]
#[allow(dead_code)]
pub struct ClusterInformer {
    /// Etcd client
    kv_engine: Arc<KVEngineType>,
    /// Retry times
    retry_times: Arc<AtomicUsize>,
}

impl ClusterInformer {
    /// Register current node to etcd and keep alive
    pub async fn register(&self, node: Arc<RwLock<Node>>) -> DatenLordResult<()> {}

    /// Register current node to master and keep alive
    pub async fn register_master(&self, node: Arc<RwLock<Node>>) -> DatenLordResult<()> {}

    /// Slave nodes will watch the ring update
    pub async fn watch_ring(&self, ring: Arc<RwLock<Ring<Node>>>) -> DatenLordResult<()> {}

    /// Master node will watch the node list update, and update the ring
    pub async fn watch_nodes(
        &self,
        nodes: Arc<RwLock<Vec<Node>>>,
        ring: Arc<RwLock<Ring<Node>>>,
    ) -> DatenLordResult<()> {}

    /// Try to watch the master node
    pub async fn watch_master(
        &self,
        node: Arc<RwLock<Node>>,
        nodes: Arc<RwLock<Vec<Node>>>,
        ring: Arc<RwLock<Ring<Node>>>,
    ) -> DatenLordResult<()> {}
}
```

## Implementation Details

### Consistency Hashing for Node Election
- When the master node fails, slave nodes will attempt to acquire the master lock. The successful node becomes the new master.

### Master Node Updates Hash Ring
- The master node is responsible for monitoring the node list updates and adjusting the hash ring accordingly to maintain load balancing.

### Node Online/Offline Events
- Nodes listen for specific key changes in etcd to monitor the master node status. If the master is detected as down, a slave will attempt to become the new master.

### Consistency Hash Ring Cluster Synchronization
- Each node monitors changes to the hash ring in etcd. When changes are detected, nodes update their local hash rings to remain in sync with the cluster state.

Design doc: https://datenlord.feishu.cn/docx/LoavdI51IopRuPx8Kyuc2DiRnr6