### PR TITLE
feat(cache node): support cluster manager.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,9 +68,10 @@ opendal = {version = "0.43.0", features = ["layers-prometheus"]}
 signal-hook = { version = "0.3.17", features = ["iterator"]}
 signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 tokio-util = "0.7.10"
+arc-swap = "1.7.1"
+flume = "0.11.0"
 serfig = "0.1.0"
 bytes = "1.1"
-flume = "0.11.0"
 num_enum = "0.7.3"
 
 [build-dependencies]

--- a/src/async_fuse/memfs/kv_engine/etcd_impl.rs
+++ b/src/async_fuse/memfs/kv_engine/etcd_impl.rs
@@ -118,6 +118,11 @@ impl Session {
 impl Drop for Session {
     fn drop(&mut self) {
         // Set the close flag
+        debug!(
+            "drop the keep alive session, lease_id={lease_id}, ttl={ttl}",
+            lease_id = self.lease_id(),
+            ttl = self.ttl()
+        );
         self.close();
     }
 }

--- a/src/async_fuse/memfs/kv_engine/key_type.rs
+++ b/src/async_fuse/memfs/kv_engine/key_type.rs
@@ -27,7 +27,7 @@ pub enum KeyType {
     /// Distributed hash ring key
     CacheRing,
     /// Distributed cache node master key
-    CacheNodeMaster,
+    CacheMasterNode,
     /// Distribute cache cluster config
     CacheClusterConfig,
 }
@@ -44,7 +44,7 @@ pub enum LockKeyType {
     /// ETCD file node list lock
     FileNodeListLock(INum),
     /// Distributed cache node master key
-    CacheNodeMaster,
+    CacheMasterNode,
 }
 
 impl Display for KeyType {
@@ -60,7 +60,7 @@ impl Display for KeyType {
             KeyType::String(ref s) => write!(f, "String({s})"),
             KeyType::CacheNode(ref s) => write!(f, "CacheNode({s})"),
             KeyType::CacheRing => write!(f, "CacheRing/"), // CacheRing
-            KeyType::CacheNodeMaster => write!(f, "CacheNodeMaster"), // CacheNodeMaster
+            KeyType::CacheMasterNode => write!(f, "CacheMasterNode"), // CacheMasterNode
             KeyType::CacheClusterConfig => write!(f, "CacheClusterConfig/"), // CacheClusterConfig
         }
     }
@@ -78,8 +78,8 @@ impl Display for LockKeyType {
             LockKeyType::FileNodeListLock(ref inum) => {
                 write!(f, "FileNodeListLock({inum:?})")
             }
-            LockKeyType::CacheNodeMaster => {
-                write!(f, "CacheNodeMaster")
+            LockKeyType::CacheMasterNode => {
+                write!(f, "CacheMasterNode")
             }
         }
     }
@@ -109,7 +109,7 @@ impl KeyType {
             KeyType::FileNodeList(_) => "FileNodeList",
             KeyType::CacheNode(_) => "CacheNode",
             KeyType::CacheRing => "CacheRing",
-            KeyType::CacheNodeMaster => "CacheNodeMaster",
+            KeyType::CacheMasterNode => "CacheMasterNode",
             KeyType::CacheClusterConfig => "CacheClusterConfig",
         }
     }
@@ -139,7 +139,7 @@ impl KeyType {
             KeyType::CacheRing => {
                 write!(f, "").unwrap();
             }
-            KeyType::CacheNodeMaster => {
+            KeyType::CacheMasterNode => {
                 write!(f, "").unwrap();
             }
             KeyType::CacheClusterConfig => {
@@ -168,7 +168,7 @@ impl LockKeyType {
             LockKeyType::IdAllocatorLock(_) => "IdAllocLock",
             LockKeyType::VolumeInfoLock => "VolumeInfoLock",
             LockKeyType::FileNodeListLock(_) => "FileNodeListLock",
-            LockKeyType::CacheNodeMaster => "CacheNodeMaster",
+            LockKeyType::CacheMasterNode => "CacheMasterNode",
         }
     }
 
@@ -184,7 +184,7 @@ impl LockKeyType {
             LockKeyType::FileNodeListLock(ref inum) => {
                 write!(f, "{inum}").unwrap();
             }
-            LockKeyType::CacheNodeMaster => {
+            LockKeyType::CacheMasterNode => {
                 write!(f, "").unwrap();
             }
         }

--- a/src/storage/cache_proxy/cluster_manager.rs
+++ b/src/storage/cache_proxy/cluster_manager.rs
@@ -1,0 +1,1067 @@
+//! The utilities of distribute cache cluster management
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use arc_swap::{ArcSwap, ArcSwapOption};
+use futures::StreamExt;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use crate::async_fuse::memfs::kv_engine::etcd_impl::Session;
+use crate::async_fuse::memfs::kv_engine::{KVEngine, SetOption};
+use crate::async_fuse::memfs::kv_engine::{KVEngineType, KeyType, ValueType};
+use crate::common::error::{DatenLordError, DatenLordResult};
+
+use super::node::{MasterNodeInfo, Node, NodeStatus};
+use super::ring::Ring;
+
+/// The timeout for current node's session
+const SESSION_TIMEOUT_SEC: u64 = 10;
+
+/// This struct is used to interact with etcd server and manager the cluster.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct ClusterManager {
+    /// Inner struct
+    inner: Arc<ClusterManagerInner>,
+}
+
+#[allow(dead_code)]
+impl ClusterManager {
+    /// Create new cluster manager
+    pub fn new(kv_engine: Arc<KVEngineType>, node: Node) -> Self {
+        let inner = Arc::new(ClusterManagerInner::new(kv_engine, node));
+        Self { inner }
+    }
+
+    /// Get current node
+    #[must_use]
+    pub fn get_node(&self) -> Node {
+        self.inner.get_node()
+    }
+
+    /// Get current hashring
+    pub async fn get_ring(&self) -> DatenLordResult<Ring<Node>> {
+        self.inner.get_ring(false).await
+    }
+
+    /// Get all nodes
+    pub async fn get_nodes(&self) -> DatenLordResult<Vec<Node>> {
+        self.inner.get_nodes(false).await
+    }
+
+    /// Run the cluster manager as state machine
+    ///
+    /// We need to perpare current node info, current node list and generate hash ring info
+    pub async fn run(&self, token: CancellationToken) -> DatenLordResult<()> {
+        loop {
+            // Check the shutdown flag, if current flag is set, we need return to the caller
+            if self.inner.shutdown_flag.load(Ordering::Acquire) {
+                return Ok(());
+            }
+
+            // 0. Prepare for the session
+            self.inner.prepare().await?;
+
+            // 1. Init cluster manager and register to etcd
+            let mut current_node_info = self.inner.get_node();
+            debug!(
+                "Cluster manager start to run in node: {:?} status: {:?}",
+                current_node_info.ip(),
+                current_node_info.status()
+            );
+            while self.inner.register().await.is_err() {
+                warn!("Failed to register node, retry in 5s");
+                // Try to register node to etcd
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+
+            // 2. Do campaign
+            let (campaign_status, campaign_val) = self.inner.do_campaign().await?;
+            debug!(
+                "Node: {:?} Campaign status: {:?} val: {:?}",
+                current_node_info.ip(),
+                campaign_status,
+                campaign_val
+            );
+            if campaign_status {
+                // Update node status to Master
+                current_node_info.set_status(NodeStatus::Master);
+                self.inner.update_node(current_node_info);
+            }
+
+            // 3. Serve as normal status
+            let current_node_info = self.inner.get_node();
+            match current_node_info.status() {
+                // Serve as slave node
+                NodeStatus::Slave => match self.do_slave_tasks(token.clone()).await {
+                    Ok(()) => {
+                        debug!(
+                            "Current node {:?} status: {:?} will change to campaign",
+                            current_node_info.ip(),
+                            current_node_info.status()
+                        );
+                    }
+                    Err(e) => {
+                        warn!("Failed to do slave tasks: {:?}", e);
+                    }
+                },
+                // Serve as master node
+                NodeStatus::Master => match self.do_master_tasks(token.clone()).await {
+                    Ok(()) => {
+                        debug!(
+                            "Current node {:?} status: {:?} will change to campaign",
+                            current_node_info.ip(),
+                            current_node_info.status()
+                        );
+                    }
+                    Err(e) => {
+                        warn!("Failed to do master tasks: {:?}", e);
+                    }
+                },
+            }
+        }
+    }
+
+    /// Do master tasks
+    ///
+    /// 1. Master node will watch the node list update, and update the ring
+    /// 2. Master will check self
+    async fn do_master_tasks(&self, token: CancellationToken) -> DatenLordResult<()> {
+        let current_node_info = self.inner.get_node();
+        debug!(
+            "do_master_tasks: {:?} will watch the node list update, and update the ring",
+            current_node_info.ip()
+        );
+
+        // Keep alive master key
+        // Check current status
+        if current_node_info.status() != NodeStatus::Master {
+            // If the node status is not master, clean up master tasks and return
+            warn!(
+                "Current node {:?} status is not master, return to endpoint",
+                current_node_info.ip()
+            );
+
+            return Ok(());
+        }
+
+        // Do watch node list update task
+        // This task will block until the master status changed
+        self.inner.watch_nodes(token).await.with_context(|| {
+            format!(
+                "Current node {:?} Failed to watch the node list update, and update the ring",
+                current_node_info.ip()
+            )
+        })?;
+
+        Ok(())
+    }
+
+    /// Do slave tasks
+    ///
+    /// Slave node will watch the ring update and campaign master
+    #[allow(clippy::arithmetic_side_effects, clippy::pattern_type_mismatch)] // The `select!` macro will generate code that goes against these rules.
+    async fn do_slave_tasks(&self, token: CancellationToken) -> DatenLordResult<()> {
+        // Try to watch master and hashring
+        // Wait for status update
+        let current_node_info = self.inner.get_node();
+        debug!(
+            "do_slave_tasks: Node {:?} will watch the ring update and campaign master",
+            current_node_info.ip()
+        );
+        // Check the node status
+        if current_node_info.status() != NodeStatus::Slave {
+            return Ok(());
+        }
+
+        // Block here, try to watch master
+        // If the master is down and return ok, the slave node will try to get the master lock
+        // If watch_master failed, we will retry to watch master
+        self.inner.watch_master(token).await?;
+
+        Ok(())
+    }
+}
+
+/// Inner struct of cluster manager
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct ClusterManagerInner {
+    /// Etcd client
+    kv_engine: Arc<KVEngineType>,
+    /// Node session, try to keep the session alive, we will set the session in run method
+    node_session: ArcSwapOption<Session>,
+    /// current node info
+    node: ArcSwap<Node>,
+    /// current node list, we will set the session in run method
+    node_list: ArcSwap<Vec<Node>>,
+    /// current hash ring, we will set the session in run method
+    hash_ring: ArcSwap<Ring<Node>>,
+    // TODO: Support distribute cluster config here
+    /// Shutdown flag
+    shutdown_flag: AtomicBool,
+}
+
+#[allow(dead_code)]
+impl ClusterManagerInner {
+    /// Create a new cluster manager
+    pub fn new(kv_engine: Arc<KVEngineType>, node: Node) -> Self {
+        let node_session = ArcSwapOption::empty();
+        let node = ArcSwap::<Node>::new(Arc::new(node));
+        let node_list = ArcSwap::<Vec<Node>>::new(Arc::new(Vec::new()));
+        let hash_ring = ArcSwap::<Ring<Node>>::new(Arc::new(Ring::default()));
+        let shutdown_flag = AtomicBool::new(false);
+
+        Self {
+            kv_engine,
+            node_session,
+            node,
+            node_list,
+            hash_ring,
+            shutdown_flag,
+        }
+    }
+
+    /// Get valid session
+    pub fn get_valid_session(&self) -> DatenLordResult<Arc<Session>> {
+        let node_session = self.node_session.load();
+        if let Some(session) = node_session.as_ref().cloned() {
+            if session.is_closed() {
+                let current_node = self.node.load();
+                warn!(
+                    "Current {} session is invalid, return to endpoint",
+                    current_node.ip()
+                );
+                return Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Current {} session is invalid", current_node.ip())],
+                });
+            }
+            Ok(session)
+        } else {
+            let current_node = self.node.load();
+            warn!(
+                "Current {} session is not existed, return to endpoint",
+                current_node.ip()
+            );
+            Err(DatenLordError::CacheClusterErr {
+                context: vec![format!(
+                    "Current {} session is not existed",
+                    current_node.ip()
+                )],
+            })
+        }
+    }
+
+    /// Prepare for the session and other data
+    pub async fn prepare(&self) -> DatenLordResult<()> {
+        // Prepare session
+        let session = self
+            .kv_engine
+            .create_session(SESSION_TIMEOUT_SEC)
+            .await
+            .with_context(|| format!("{} failed to create session", self.node.load().ip()))?;
+        self.node_session.store(Some(session));
+        Ok(())
+    }
+
+    /// Register current node to etcd and keep alive
+    pub async fn register(&self) -> DatenLordResult<()> {
+        // Get current node info
+        let current_node_info = self.node.load();
+        debug!("register: {} to etcd", current_node_info.ip());
+        // Check session
+        let current_session = self.get_valid_session()?;
+
+        // Try to register current node to etcd
+        self.kv_engine
+            .set(
+                &KeyType::CacheNode(current_node_info.ip().to_owned()),
+                &ValueType::Json(serde_json::to_value(current_node_info.as_ref().clone())?),
+                Some(SetOption {
+                    // Set lease
+                    session: Some(current_session),
+                    prev_kv: false,
+                }),
+            )
+            .await
+            .with_context(|| "Failed to register node to etcd".to_owned())?;
+
+        debug!("register: {} to etcd success", current_node_info.ip());
+
+        Ok(())
+    }
+
+    /// Do campaign
+    ///
+    /// Try to campaign master, will return status and master value
+    pub async fn do_campaign(&self) -> DatenLordResult<(bool, String)> {
+        let node = self.get_node();
+        let hash_ring = self.get_ring(false).await?;
+        let session = self.get_valid_session()?;
+
+        // Master key info
+        let master_key = &KeyType::CacheMasterNode;
+        // Create master instance
+        let master_node_info =
+            MasterNodeInfo::new(node.ip().to_owned(), node.port(), hash_ring.version());
+        let master_node_info_json = serde_json::to_value(master_node_info)?;
+        let master_value = &ValueType::Json(master_node_info_json);
+        let master_serial_value = serde_json::to_string(master_value)
+            .with_context(|| format!("failed to serialize value={master_value:?} to string"))?;
+
+        // Try to set campaign
+        let txn = self.kv_engine.new_meta_txn().await;
+        let (campaign_status, campaign_val) = txn
+            .campaign(master_key, master_serial_value, session)
+            .await?;
+
+        Ok((campaign_status, campaign_val))
+    }
+
+    /// Clean up the tasks
+    pub fn clean_sessions(&self) {
+        // Clean up register tasks
+        self.node_session.store(None);
+    }
+
+    /// Try to check current session is valid
+    pub fn check_session_valid(&self) -> bool {
+        let session = self.node_session.load_full();
+        if let Some(session) = session.as_ref() {
+            if session.is_closed() {
+                return false;
+            }
+            return true;
+        }
+
+        false
+    }
+
+    /// Master node will watch the node list update, and update the ring
+    pub async fn watch_nodes(&self, token: CancellationToken) -> DatenLordResult<()> {
+        debug!(
+            "Node: {:?} watch_nodes: will watch the node list update",
+            self.get_node().ip()
+        );
+        // Write ticker task
+        let mut interval = tokio::time::interval(Duration::from_secs(SESSION_TIMEOUT_SEC));
+        let mut watch_event = false;
+
+        // Get all nodes with prefix and init hash ring list
+        // TODO: Block cluster and do not add any new node when watch_nodes is synced.
+
+        // Get all nodes with prefix
+        let key = &KeyType::CacheNode(String::new());
+        let mut nodes_watch_stream = self.kv_engine.watch(key).await?;
+
+        // Wait for node list update
+        loop {
+            if !self.check_session_valid() {
+                let current_node = self.node.load();
+                warn!(
+                    "Current {} session is invalid, return to endpoint",
+                    current_node.ip()
+                );
+                return Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Current {} session is invalid", current_node.ip())],
+                });
+            };
+
+            // Check event
+            tokio::select! {
+                // Shutdown event
+                _ = token.cancelled() => {
+                    debug!("Receive shutdown event, return to endpoint");
+                    self.clean_sessions();
+                    self.shutdown_flag.store(true, Ordering::Release);
+                    return Ok(());
+                }
+                // Write event
+                // This future will write all changed events in one task
+                _ = interval.tick() => {
+                    if watch_event {
+                        // Update cluster topo task
+                        match self.update_cluster_topo().await {
+                            Ok(()) => {
+                                debug!("Update cluster topo success");
+                            }
+                            Err(e) => {
+                                warn!("Failed to update cluster topo: {:?}", e);
+                                return Err(DatenLordError::CacheClusterErr {
+                                    context: vec![format!("Failed to update cluster topo: {:?}", e)],
+                                });
+                            }
+                        }
+                        watch_event = false;
+                    }
+                }
+                // Read event
+                stream_event = nodes_watch_stream.next() => {
+                    match stream_event {
+                        Some(Ok(event)) => {
+                            let key = event.0;
+                            let value = event.1;
+
+                            // TODO: We want a meticulous update, we can send the event change to a channel
+                            // Receive event, try to update cluster topo
+                            watch_event = true;
+
+                            if value.is_some() {
+                                // Update event
+                                debug!("Update node list event with key: {:?}", key);
+                            } else {
+                                // Delete event
+                                debug!("Delete node list event with key: {:?}", key);
+                            }
+                        }
+                        None => {
+                            warn!("Failed to get event from watch stream, because of stream channel is closed");
+                            return Err(DatenLordError::CacheClusterErr {
+                                context: vec![format!("Failed to get event from watch stream, because of stream channel is closed")],
+                            });
+                        }
+                        Some(Err(e)) => {
+                            // Raise error and return to upper level, try to rewatch master again
+                            warn!("Failed to watch node list key: {:?}", e);
+                            return Err(DatenLordError::CacheClusterErr {
+                                context: vec![format!("Failed to watch node list key")],
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Update cluster topo
+    ///
+    /// Try to fetch latest nodes and hashring, and update cluster by current master node
+    async fn update_cluster_topo(&self) -> DatenLordResult<()> {
+        // Check session
+        self.get_valid_session()?;
+
+        // 1. Update node list
+        let node_list = self.get_nodes(true).await?;
+        // We want to update the hashring base on etcd hashring value and version
+        let mut hash_ring = self.get_ring(true).await?;
+        // Try to replace current hashring with new node list
+        // TODO: It will cause a lot of copy, we need to update it in next PR.
+        let ring_res = hash_ring.batch_replace(node_list.clone(), true);
+        if ring_res.is_none() {
+            warn!("Failed to update hash ring");
+            return Err(DatenLordError::CacheClusterErr {
+                context: vec![format!("Failed to update hash ring")],
+            });
+        }
+        self.hash_ring.store(Arc::new(hash_ring));
+
+        // 2. Update hashring data and current master version to etcd with txn
+        self.save_ring().await?;
+
+        Ok(())
+    }
+
+    /// Try to watch the master node
+    /// If the master node is down, the slave node will try to get the master lock
+    /// Then current node will become the master node if operation is successful
+    pub async fn watch_master(&self, token: CancellationToken) -> DatenLordResult<()> {
+        debug!(
+            "Node: {:?} watch_master: will watch the master node and try to update master hashring",
+            self.get_node().ip()
+        );
+
+        // Watch with prefix
+        let master_key = &KeyType::CacheMasterNode;
+        let mut master_watch_stream = self.kv_engine.watch(master_key).await?;
+
+        // Check the master key is exist
+        // If the master key is not exist, the slave node will be blocked in watch stream and do nothing here
+        // We need to quickly return to the main loop and try to campaign master
+        // 1. Fetch the master node info
+        if let Some(ValueType::Json(master_json)) = self.kv_engine.get(master_key).await? {
+            let master_node_info: MasterNodeInfo = serde_json::from_value(master_json)?;
+            debug!("master node info: {:?}", master_node_info);
+        } else {
+            debug!("Master is not existed, try to campaign master");
+            return Ok(());
+        }
+
+        // Watch master key events
+        // master key is keeped by lease, so the master node will be auto deleted
+        // If master has changed, try to update the value
+        // 1. If master ip changed, try to change the master node
+        // if master node is down.
+        // If the version is changed, try to update the ring
+        // In current case, we just need to detect master key change and update hashring.
+        // 2. If the master key is auto deleted, exit and change current status to slave.
+        loop {
+            if !self.check_session_valid() {
+                let current_node = self.node.load();
+                warn!(
+                    "Current {} session is invalid, return to endpoint",
+                    current_node.ip()
+                );
+                return Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Current {} session is invalid", current_node.ip())],
+                });
+            };
+
+            // Check event
+            debug!("111");
+            tokio::select! {
+                // Shutdown event
+                () = token.cancelled() => {
+                    debug!("Receive shutdown event, return to endpoint");
+                    self.clean_sessions();
+                    self.shutdown_flag.store(true, Ordering::Release);
+                    return Ok(());
+                }
+                e =  master_watch_stream.next() => {
+                    match e {
+                        Some(Ok(event)) => {
+                            let key = event.0;
+                            let value = event.1;
+                            if value.is_some() {
+                                // Update event
+                                debug!(
+                                    "Receive update ring event with key: {:?} value: {:?}",
+                                    key, value
+                                );
+
+                                // When master update the hashring, we will try to fetch latest ring from etcd
+                                // In this step, we just need to update the ring
+                                // Fetch the latest ring from etcd
+                                // We just ignore the update event in current step
+                            } else {
+                                // Delete event
+                                debug!("delete master event with key: {:?}", key);
+                                // Master has down, try to campaign master
+                                // Return to main loop
+                                return Ok(());
+                            }
+                        }
+                        None => {
+                            warn!("Failed to get event from watch stream, because of stream channel is closed");
+                            return Err(DatenLordError::CacheClusterErr {
+                                context: vec![format!("Failed to get event from watch stream, because of stream channel is closed")],
+                            });
+                        }
+                        Some(Err(e)) => {
+                            // Raise error and return to upper level, try to rewatch master again
+                            warn!("Failed to watch master key: {:?}", e);
+                            return Err(DatenLordError::CacheClusterErr {
+                                context: vec![format!("Failed to watch master key")],
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Save current master node info and hashring to etcd with one txn
+    async fn save_ring(&self) -> DatenLordResult<()> {
+        // Only master node can save ring to etcd
+        // We need to make sure current node is master and only one master can save ring to etcd
+        if self.node.load().status() != NodeStatus::Master {
+            warn!("Current node is not master, can not save ring to etcd");
+            return Err(DatenLordError::CacheClusterErr {
+                context: vec![format!(
+                    "Current node is not master, can not save ring to etcd"
+                )],
+            });
+        }
+
+        // Add a txn to update ring, update hashring is usually in low priority.
+        // Try to check the ring version and update the ring to etcd
+        // If failed, we need to return upper level and regenerate the hashring
+        let ring_key = &KeyType::CacheRing;
+        let mut txn = self.kv_engine.new_meta_txn().await;
+        let latest_hash_ring = match txn.get(ring_key).await {
+            Ok(Some(ValueType::Json(ring_json))) => {
+                // Get current ring from etcd
+                let ring: Ring<Node> = serde_json::from_value(ring_json)?;
+                ring
+            }
+            Ok(_) => {
+                // Current hashring is not valid or not existed
+                // Try to get current local hash ring as default hashring
+                self.hash_ring.load().as_ref().clone()
+            }
+            Err(e) => {
+                warn!("Failed to get ring from etcd: {:?}", e);
+                return Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Failed to get ring from etcd")],
+                });
+            }
+        };
+
+        // Check current node is the valid master node
+        let master_key = &KeyType::CacheMasterNode;
+        let latest_master_node = match txn.get(master_key).await {
+            Ok(Some(ValueType::Json(master_json))) => {
+                // Get current master node from etcd
+                let master_node: MasterNodeInfo = serde_json::from_value(master_json)?;
+                master_node
+            }
+            Ok(_) => {
+                warn!("Failed to get master node from etcd, because current master node is not existed.");
+                return Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Failed to get master node from etcd, because current master node is not existed.")],
+                });
+            }
+            Err(e) => {
+                warn!("Failed to get master node from etcd: {:?}", e);
+                return Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Failed to get master node from etcd")],
+                });
+            }
+        };
+        // Create master instance
+        let current_node_info = self.node.load();
+        if latest_master_node.ip() != current_node_info.ip()
+            || latest_master_node.port() != current_node_info.port()
+        {
+            warn!("Current node is not the master node, return to endpoint");
+            return Err(DatenLordError::CacheClusterErr {
+                context: vec![format!("Current node is not the master node")],
+            });
+        }
+
+        // Prepare master node info and hashring data
+        let current_hash_ring = self.hash_ring.load();
+        if latest_hash_ring.version() > current_hash_ring.version() {
+            // If the latest ring version is greater than current ring version, we need to return
+            // and regenerate the hashring
+            warn!("Current ring version is not the latest, return to endpoint");
+            return Err(DatenLordError::CacheClusterErr {
+                context: vec![format!("Current ring version is not the latest")],
+            });
+        }
+        let master_node_info = MasterNodeInfo::new(
+            current_node_info.ip().to_owned(),
+            current_node_info.port(),
+            current_hash_ring.version(),
+        );
+        let master_node_info_json = serde_json::to_value(master_node_info)?;
+        let master_value = &ValueType::Json(master_node_info_json);
+        let ring = current_hash_ring.as_ref();
+        let current_json_value = serde_json::to_value(ring.clone())?;
+        let ring_value = &ValueType::Json(current_json_value);
+
+        txn.set(master_key, master_value);
+        txn.set(ring_key, ring_value);
+        txn.commit().await?;
+
+        Ok(())
+    }
+
+    /// Load ring from etcd
+    async fn load_ring(&self) -> DatenLordResult<Ring<Node>> {
+        let key = &KeyType::CacheRing;
+        debug!("Try to load ring from etcd: {}", key);
+
+        // Get ring from etcd
+        match self.kv_engine.get(key).await? {
+            Some(ValueType::Json(ring_json)) => {
+                let new_ring: Ring<Node> = serde_json::from_value(ring_json)?;
+
+                debug!("Load ring from etcd success");
+                Ok(new_ring)
+            }
+            None => {
+                debug!("Ring is not existed, return default ring");
+                Ok(Ring::default())
+            }
+            _ => {
+                warn!("Failed to deserialize ring");
+                Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Failed to deserialize ring")],
+                })
+            }
+        }
+    }
+
+    /// Get node list from etcd
+    async fn load_nodes(&self) -> DatenLordResult<Vec<Node>> {
+        let key = &KeyType::CacheNode(String::new());
+        debug!("Get node list from etcd: {}", key);
+
+        // Get node list from etcd
+        let nodes = self.kv_engine.range(key).await?;
+        let mut node_list = Vec::new();
+        for node in nodes {
+            if let ValueType::Json(node_json) = node {
+                let node: Node = serde_json::from_value(node_json)?;
+                node_list.push(node);
+            } else {
+                warn!("Failed to deserialize node");
+                return Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Failed to deserialize node")],
+                });
+            }
+        }
+
+        Ok(node_list)
+    }
+
+    /// Get all nodes
+    ///
+    /// This function is used to get all nodes from etcd
+    /// If we set `must_fetch`, we will also update current node list
+    pub async fn get_nodes(&self, must_fetch: bool) -> DatenLordResult<Vec<Node>> {
+        // Get latest node list from etcd
+        if must_fetch {
+            let latest_nodes = self.load_nodes().await?;
+            self.node_list.store(Arc::new(latest_nodes.clone()));
+            return Ok(latest_nodes);
+        }
+
+        Ok(self.node_list.load().as_ref().clone())
+    }
+
+    /// Get current node
+    pub fn get_node(&self) -> Node {
+        self.node.load().as_ref().clone()
+    }
+
+    /// Update current node
+    pub fn update_node(&self, node: Node) {
+        self.node.store(Arc::new(node));
+    }
+
+    /// Get hashring
+    ///
+    /// This function is used to get current hashring and update current hashring
+    /// If we set `must_fetch`, we will also update current hashring
+    pub async fn get_ring(&self, must_fetch: bool) -> DatenLordResult<Ring<Node>> {
+        // Get latest hashring from etcd and update current hashring
+        if must_fetch {
+            let latest_hash_ring = self.load_ring().await?;
+            self.hash_ring.store(Arc::new(latest_hash_ring.clone()));
+            return Ok(latest_hash_ring);
+        }
+
+        Ok(self.hash_ring.load().as_ref().clone())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio_util::sync::CancellationToken;
+    use tracing::{debug, level_filters::LevelFilter};
+    use tracing_subscriber::{
+        self, filter, fmt::layer, layer::SubscriberExt, util::SubscriberInitExt, Layer,
+    };
+
+    use crate::{
+        async_fuse::memfs::kv_engine::{DeleteOption, KVEngine, KVEngineType, KeyType},
+        storage::cache_proxy::{
+            cluster_manager::{ClusterManager, ClusterManagerInner, SESSION_TIMEOUT_SEC},
+            node::{Node, NodeStatus},
+        },
+    };
+
+    const ETCD_ADDRESS: &str = "127.0.0.1:2379";
+
+    /// Helper function to create a new node with a given IP address
+    fn create_node(ip: &str) -> Node {
+        let mut node = Node::default();
+        node.set_ip(ip.to_owned());
+
+        node
+    }
+
+    async fn clean_up_etcd() {
+        // Clean up all `CacheNode` prefix keys in etcd
+        KVEngineType::new(vec![ETCD_ADDRESS.to_owned()])
+            .await
+            .unwrap()
+            .delete(
+                &KeyType::CacheNode(String::new()),
+                Some(DeleteOption {
+                    prev_kv: false,
+                    range_end: Some(vec![0xff]),
+                }),
+            )
+            .await
+            .unwrap();
+
+        // Clean up all `CacheMasterNode` keys in etcd
+        KVEngineType::new(vec![ETCD_ADDRESS.to_owned()])
+            .await
+            .unwrap()
+            .delete(
+                &KeyType::CacheMasterNode,
+                Some(DeleteOption {
+                    prev_kv: false,
+                    range_end: Some(vec![0xff]),
+                }),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_single_master_election() {
+        let filter = filter::Targets::new().with_target(
+            "datenlord::storage::cache_proxy::cluster_manager",
+            LevelFilter::DEBUG,
+        );
+        tracing_subscriber::registry()
+            .with(layer().with_filter(filter))
+            .init();
+        let client = Arc::new(
+            KVEngineType::new(vec![ETCD_ADDRESS.to_owned()])
+                .await
+                .unwrap(),
+        );
+
+        // Clean up etcd
+        clean_up_etcd().await;
+
+        let test_master_node = create_node("192.168.1.2");
+        let master_cluster_manager =
+            ClusterManagerInner::new(Arc::clone(&client), test_master_node.clone());
+        master_cluster_manager.prepare().await.unwrap();
+        let test_slave_node_1 = create_node("192.168.1.3");
+        let slave_1_cluster_manager =
+            ClusterManagerInner::new(Arc::clone(&client), test_slave_node_1.clone());
+        slave_1_cluster_manager.prepare().await.unwrap();
+        let test_slave_node_2 = create_node("192.168.1.4");
+        let slave_2_cluster_manager =
+            ClusterManagerInner::new(Arc::clone(&client), test_slave_node_2.clone());
+        slave_2_cluster_manager.prepare().await.unwrap();
+
+        debug!("test_single_master_election: start to test single master election");
+
+        let (master_res, slave_1_res, slave_2_res) = tokio::join!(
+            async {
+                // Register node
+                master_cluster_manager.register().await.unwrap();
+                // campaign
+                master_cluster_manager.do_campaign().await.unwrap()
+            },
+            async {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                slave_1_cluster_manager.register().await.unwrap();
+                // campaign
+                slave_1_cluster_manager.do_campaign().await.unwrap()
+            },
+            async {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                slave_2_cluster_manager.register().await.unwrap();
+                // campaign
+                slave_2_cluster_manager.do_campaign().await.unwrap()
+            }
+        );
+
+        // Check the result
+        assert!(master_res.0);
+        assert!(!slave_1_res.0);
+        assert!(!slave_2_res.0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_remove_slave_node() {
+        let filter = filter::Targets::new().with_target(
+            "datenlord::storage::cache_proxy::cluster_manager",
+            LevelFilter::DEBUG,
+        );
+        tracing_subscriber::registry()
+            .with(layer().with_filter(filter))
+            .init();
+        let client = Arc::new(
+            KVEngineType::new(vec![ETCD_ADDRESS.to_owned()])
+                .await
+                .unwrap(),
+        );
+
+        let master_cancel_token = CancellationToken::new();
+        let slave_cancel_token_1 = CancellationToken::new();
+        let slave_cancel_token_2 = CancellationToken::new();
+
+
+        // Clean up etcd
+        clean_up_etcd().await;
+
+        // Setup initial state with multiple nodes
+        let test_master_node = create_node("192.168.3.2");
+        let test_slave_node = create_node("192.168.3.3");
+        let test_slave_node_2 = create_node("192.168.3.4");
+
+        let master_client = Arc::clone(&client);
+        let test_master_node_clone = test_master_node.clone();
+        let master_cluster_manager = Arc::new(ClusterManager::new(
+            master_client,
+            test_master_node_clone.clone(),
+        ));
+        let master_cluster_manager_clone = Arc::clone(&master_cluster_manager);
+        let master_cancel_token_clone = master_cancel_token.clone();
+        let master_handle = tokio::task::spawn(async move {
+            let res = master_cluster_manager_clone.run(master_cancel_token_clone).await;
+            debug!("master_handle: {:?}", res);
+        });
+
+
+        // Wait for election
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+        let slave_client = Arc::clone(&client);
+        let test_slave_node_clone = test_slave_node.clone();
+        let slave_cluster_manager_1 = Arc::new(ClusterManager::new(
+            slave_client,
+            test_slave_node_clone.clone(),
+        ));
+        let slave_cluster_manager_1_clone = Arc::clone(&slave_cluster_manager_1);
+        let slave_cancel_token_1_clone = slave_cancel_token_1.clone();
+        let slave_handle_1 = tokio::task::spawn(async move {
+            let res = slave_cluster_manager_1_clone.run(slave_cancel_token_1_clone).await;
+            debug!("slave_handle_1: {:?}", res);
+        });
+
+        let slave_client = Arc::clone(&client);
+        let test_slave_node_clone = test_slave_node_2.clone();
+        let slave_cluster_manager_2 = Arc::new(ClusterManager::new(
+            slave_client,
+            test_slave_node_clone.clone(),
+        ));
+        let slave_cluster_manager_2_clone = Arc::clone(&slave_cluster_manager_2);
+        let slave_cancel_token_2_clone = slave_cancel_token_2.clone();
+        let slave_handle_2 = tokio::task::spawn(async move {
+            let res: Result<(), crate::common::error::DatenLordError> =
+                slave_cluster_manager_2_clone.run(slave_cancel_token_2_clone).await;
+            debug!("slave_handle_2: {:?}", res);
+        });
+
+        // Wait for node online
+        tokio::time::sleep(std::time::Duration::from_secs(SESSION_TIMEOUT_SEC+1)).await;
+        assert_eq!(
+            Arc::clone(&master_cluster_manager).get_node().status(),
+            NodeStatus::Master
+        );
+        assert_eq!(
+            Arc::clone(&slave_cluster_manager_1).get_node().status(),
+            NodeStatus::Slave
+        );
+        assert_eq!(
+            Arc::clone(&slave_cluster_manager_2).get_node().status(),
+            NodeStatus::Slave
+        );
+        assert_eq!(master_cluster_manager.get_nodes().await.unwrap().len(), 3);
+
+        debug!("test_remove_slave_node: update node list");
+        // Cancel the slave task
+        slave_cancel_token_1.cancel();
+        slave_handle_1.abort();
+        // Wait for slave key is deleted
+        tokio::time::sleep(std::time::Duration::from_secs(SESSION_TIMEOUT_SEC+1)).await;
+
+        debug!("test_remove_slave_node: start to test remove slave node");
+        debug!(
+            "Get all nodes: {:?}",
+            master_cluster_manager.get_nodes().await.unwrap()
+        );
+
+        assert_eq!(
+            master_cluster_manager.get_node().status(),
+            NodeStatus::Master
+        );
+        assert_eq!(master_cluster_manager.get_nodes().await.unwrap().len(), 2);
+
+        slave_cancel_token_2.cancel();
+        master_cancel_token.cancel();
+        slave_handle_2.abort();
+        master_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_remove_master_node() {
+        let filter = filter::Targets::new().with_target(
+            "datenlord::storage::cache_proxy::cluster_manager",
+            LevelFilter::DEBUG,
+        );
+        tracing_subscriber::registry()
+            .with(layer().with_filter(filter))
+            .init();
+        let client = Arc::new(
+            KVEngineType::new(vec![ETCD_ADDRESS.to_owned()])
+                .await
+                .unwrap(),
+        );
+
+        let master_cancel_token = CancellationToken::new();
+        let slave_cancel_token_1 = CancellationToken::new();
+
+        // Clean up etcd
+        clean_up_etcd().await;
+
+        // Setup initial state with multiple nodes
+        let test_master_node = create_node("192.168.3.2");
+        let test_slave_node = create_node("192.168.3.3");
+
+        // Run master
+        let master_client = Arc::clone(&client);
+        let test_master_node_clone = test_master_node.clone();
+        let master_cluster_manager = Arc::new(ClusterManager::new(
+            master_client,
+            test_master_node_clone.clone(),
+        ));
+        let master_cluster_manager_clone = Arc::clone(&master_cluster_manager);
+        let master_cancel_token_clone = master_cancel_token.clone();
+        let master_handle = tokio::task::spawn(async move {
+            let res = master_cluster_manager_clone.run(master_cancel_token_clone).await;
+            debug!("master_handle: {:?}", res);
+        });
+
+        // Wait for the election to finish
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+        let slave_client = Arc::clone(&client);
+        let test_slave_node_clone = test_slave_node.clone();
+        let slave_cluster_manager_1 = Arc::new(ClusterManager::new(
+            slave_client,
+            test_slave_node_clone.clone(),
+        ));
+        let slave_cluster_manager_1_clone = Arc::clone(&slave_cluster_manager_1);
+        let slave_cancel_token_1_clone = slave_cancel_token_1.clone();
+        let slave_handle_1 = tokio::task::spawn(async move {
+            let res = slave_cluster_manager_1_clone.run(slave_cancel_token_1_clone).await;
+            debug!("slave_handle_1: {:?}", res);
+        });
+
+        // Wait for node online
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+        assert_eq!(
+            Arc::clone(&master_cluster_manager).get_node().status(),
+            NodeStatus::Master
+        );
+        assert_eq!(
+            Arc::clone(&slave_cluster_manager_1).get_node().status(),
+            NodeStatus::Slave
+        );
+
+        // Simulate master node removal
+        debug!("Simulate master node removal");
+        master_cancel_token.cancel();
+        master_handle.abort();
+        // Wait for the system to detect the master node removal
+        tokio::time::sleep(std::time::Duration::from_secs(SESSION_TIMEOUT_SEC + 1)).await;
+
+        // Check if the slave node has become the new master
+        let new_master_status = slave_cluster_manager_1.get_node().status();
+        assert_eq!(new_master_status, NodeStatus::Master);
+
+        debug!("test_remove_master_node: slave node has taken over as master");
+        slave_cancel_token_1.cancel();
+        slave_handle_1.abort();
+    }
+}

--- a/src/storage/cache_proxy/mod.rs
+++ b/src/storage/cache_proxy/mod.rs
@@ -8,3 +8,6 @@ pub mod node;
 
 /// Config module, config the distribute cache
 pub mod config;
+
+/// Cluster informer module, use metadata to manage the nodes
+pub mod cluster_manager;

--- a/src/storage/cache_proxy/ring.rs
+++ b/src/storage/cache_proxy/ring.rs
@@ -2,9 +2,11 @@
 
 use core::fmt;
 use std::cmp;
+use std::collections::HashSet;
 use std::hash::BuildHasher;
 use std::hash::Hash;
 
+use clippy_utilities::OverflowArithmetic;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use tracing::warn;
@@ -134,7 +136,8 @@ where
     hash_builder: S,
     /// The slots
     slots: Vec<Slot<T>>,
-    /// T to slot id mapping, accelerate finding the slot
+    /// T to slot id mapping, accelerate finding the slot and filter the same node
+    node_set: HashSet<T>,
     /// The slot step of the ring
     capacity: u64,
     /// The version of the ring
@@ -149,6 +152,7 @@ where
         Ring {
             hash_builder: DefaultHashBuilder,
             slots: Vec::new(),
+            node_set: HashSet::new(),
             capacity: DEFAULT_SLOT_SIZE,
             version: 0,
         }
@@ -166,6 +170,7 @@ where
         Self {
             hash_builder,
             slots: Vec::new(),
+            node_set: HashSet::new(),
             capacity: DEFAULT_SLOT_SIZE,
             version: 0,
         }
@@ -175,6 +180,7 @@ where
     /// It will node update the hash builder
     pub fn update(&mut self, ring: &Ring<T, S>) {
         self.slots = ring.slots.clone();
+        self.node_set = ring.node_set.clone();
         self.capacity = ring.capacity;
         self.version = ring.version;
     }
@@ -195,6 +201,12 @@ where
     #[must_use]
     pub fn version(&self) -> u64 {
         self.version
+    }
+
+    /// Get nodes
+    #[must_use]
+    pub fn nodes(&self) -> Vec<T> {
+        self.slots.iter().map(|slot| slot.inner.clone()).collect()
     }
 
     /// Check if the ring is empty
@@ -218,6 +230,10 @@ where
     /// We will create a new slot and update slot mapping, then add to the ring
     /// If must is true, the ring need to be rebalanced or expanded
     pub fn add(&mut self, node: &T, must: bool) -> Option<T> {
+        if self.node_set.contains(node) {
+            return Some(node.clone());
+        }
+
         // If the ring is full, return None
         if usize_to_u64(self.slots.len()) >= self.capacity {
             return None;
@@ -253,9 +269,7 @@ where
 
         // Calculate the new ranges for the split
         let slot_to_split = self.slots.get_mut(index)?;
-        let mid_point = (slot_to_split.start + slot_to_split.end)
-            .overflowing_div(2)
-            .0;
+        let mid_point = Self::safe_midpoint(slot_to_split.start, slot_to_split.end);
 
         // Create new slot with the second half of the range
         let new_slot = Slot::new(mid_point + 1, slot_to_split.end, node.clone());
@@ -274,7 +288,54 @@ where
             return None;
         }
 
+        self.node_set.insert(node.clone());
+
         Some(node.clone())
+    }
+
+    /// Calculate the safe midpoint
+    fn safe_midpoint(a: u64, b: u64) -> u64 {
+        match a.cmp(&b) {
+            cmp::Ordering::Greater => {
+                // if a > b and both u64, a - b and a / b will not overflow
+                let a_sub_b = a.overflow_sub(b);
+                let a_div_b = a_sub_b.overflow_div(2);
+                b.overflow_add(a_div_b)
+            }
+            cmp::Ordering::Less => {
+                let b_sub_a = b.overflow_sub(a);
+                let b_div_a = b_sub_a.overflow_div(2);
+                a.overflow_add(b_div_a)
+            }
+            cmp::Ordering::Equal => a,
+        }
+    }
+
+    /// Batch replace
+    ///
+    /// Try to modify current ring and try the best to keep the old ring distribution
+    /// It will return removed nodes here
+    pub fn batch_replace(&mut self, nodes: Vec<T>, must: bool) -> Option<Vec<T>> {
+        let add_set: HashSet<T> = nodes.iter().cloned().collect();
+
+        // Iterate current node_set to find the nodes to remove
+        let remove_nodes: Vec<T> = self
+            .node_set
+            .iter()
+            .filter(|node| !add_set.contains(*node))
+            .cloned()
+            .collect();
+
+        // Add the new nodes
+        self.batch_add(nodes, must).as_ref()?;
+
+        // Remove the old nodes
+        self.batch_remove(&remove_nodes, must).as_ref()?;
+
+        // Update current node_set
+        self.node_set = add_set;
+
+        Some(remove_nodes)
     }
 
     /// Add a batch of slots
@@ -283,30 +344,23 @@ where
         // Store the success nodes
         let mut success_nodes = Vec::new();
 
-        // If must is true, we need to expand the ring
-        if must {
-            if !self.rebalance() {
-                warn!("Rebalance failed");
-
-                return None;
-            }
-        } else if usize_to_u64(self.slots.len() + nodes.len()) > self.capacity {
+        if usize_to_u64(self.slots.len() + nodes.len()) > self.capacity {
             // If not satisfy the expand condition but too many nodes, return None
             return None;
-        } else {
-            // Try to modify the ring, so we need to increase the version
-            // TODO1: if the version is too large, we need to reset it
-            // if th slot allocation failed, we need to keep the version
+        }
 
-            // Iterate the nodes to add
-            for node in nodes {
-                // Try to rebalance it later
-                if let Some(n) = self.add(&node.clone(), false) {
-                    success_nodes.push(n);
-                }
+        // Try to modify the ring, so we need to increase the version
+        // TODO1: if the version is too large, we need to reset it
+        // if th slot allocation failed, we need to keep the version
+        // Iterate the nodes to add
+        for node in nodes {
+            // Try to rebalance it later
+            if let Some(n) = self.add(&node.clone(), false) {
+                success_nodes.push(n);
             }
         }
 
+        // If must is true, we need to expand the ring
         // Try to rebalance the ring
         if must {
             self.rebalance();
@@ -318,6 +372,10 @@ where
     /// Remove a slot
     /// If must is true, the ring need to be rebalanced
     pub fn remove(&mut self, node: T, must: bool) -> Option<T> {
+        if !self.node_set.contains(&node) {
+            return Some(node);
+        }
+
         // Find the slot to remove
         // TODO: Find the slot with faster way?
         // If the slot is not found, return None
@@ -330,6 +388,8 @@ where
         if must {
             self.rebalance();
         }
+
+        self.node_set.remove(&node);
 
         Some(node)
     }
@@ -349,6 +409,7 @@ where
 
         // Remove the slot, shift the rest of the slots
         let removed_slot = self.slots.remove(index);
+        self.node_set.remove(&removed_slot.inner);
 
         if self.slots.is_empty() {
             return None;
@@ -451,16 +512,21 @@ where
 
         // calculate new slot size
         let total_range = self.capacity;
-        let new_slot_size = total_range
-            .overflowing_div(usize_to_u64(self.slots.len()))
-            .0;
+        let new_slot_size = total_range.overflow_div(usize_to_u64(self.slots.len()));
         let mut start = 1_u64;
 
         // update slot range
         for slot in &mut self.slots {
             slot.start = start;
-            start += new_slot_size;
-            slot.end = start - 1;
+            // prevent overflow
+            let (start_add, o) = start.overflowing_add(new_slot_size);
+            if o {
+                slot.end = self.capacity;
+                start = self.capacity;
+            } else {
+                slot.end = start_add.overflow_sub(1);
+                start = start_add;
+            }
         }
 
         // update the last slot
@@ -516,13 +582,13 @@ mod tests {
         ring.add(&node3.clone(), false);
 
         assert_eq!(ring.len_slots(), 3);
-        assert_eq!(ring.capacity(), 1024);
+        assert_eq!(ring.capacity(), DEFAULT_SLOT_SIZE);
         assert_eq!(ring.version(), 3);
 
         ring.remove(node2.clone(), false);
 
         assert_eq!(ring.len_slots(), 2);
-        assert_eq!(ring.capacity(), 1024);
+        assert_eq!(ring.capacity(), DEFAULT_SLOT_SIZE);
         assert_eq!(ring.version(), 4);
     }
 
@@ -534,40 +600,71 @@ mod tests {
 
         let mut ring = Ring::new(DefaultHashBuilder);
 
-        ring.batch_add(vec![node1.clone(), node2.clone(), node3.clone()], false);
+        let add_result = ring.batch_add(vec![node1.clone(), node2.clone(), node3.clone()], false);
+        assert!(add_result.is_some());
+        assert_eq!(add_result.unwrap().len(), 3);
 
         assert_eq!(ring.len_slots(), 3);
-        assert_eq!(ring.capacity(), 1024);
+        assert_eq!(ring.capacity(), DEFAULT_SLOT_SIZE);
         assert_eq!(ring.version(), 3);
 
         // node1
         assert_eq!(ring.get_slot(&1_i32).unwrap().start, 1);
-        assert_eq!(ring.get_slot(&1_i32).unwrap().end, 512);
+        assert_eq!(
+            ring.get_slot(&1_i32).unwrap().end,
+            DEFAULT_SLOT_SIZE.overflow_div(4).overflow_add(1)
+        );
         // node2
-        assert_eq!(ring.get_slot(&999_i32).unwrap().start, 769);
-        assert_eq!(ring.get_slot(&999_i32).unwrap().end, 1024);
+        assert_eq!(
+            ring.get_slot(&999_i32).unwrap().start,
+            DEFAULT_SLOT_SIZE.overflow_div(2).overflow_add(2)
+        );
+        assert_eq!(ring.get_slot(&999_i32).unwrap().end, DEFAULT_SLOT_SIZE);
         // node3
-        assert_eq!(ring.get_slot(&10_000_i32).unwrap().start, 513);
-        assert_eq!(ring.get_slot(&10_000_i32).unwrap().end, 768);
+        assert_eq!(
+            ring.get_slot(&90_002_i32).unwrap().start,
+            DEFAULT_SLOT_SIZE.overflow_div(4).overflow_add(2)
+        );
+        assert_eq!(
+            ring.get_slot(&90_002_i32).unwrap().end,
+            DEFAULT_SLOT_SIZE.overflow_div(2).overflow_add(1)
+        );
 
         ring.slots_clear();
         assert_eq!(ring.version(), 3);
 
-        ring.batch_add(vec![node1.clone(), node2.clone(), node3.clone()], true);
+        let add_result = ring.batch_add(vec![node1.clone(), node2.clone(), node3.clone()], true);
+        assert!(add_result.is_some());
+        assert_eq!(add_result.unwrap().len(), 3);
 
         assert_eq!(ring.len_slots(), 3);
-        assert_eq!(ring.capacity(), 1024);
+        assert_eq!(ring.capacity(), DEFAULT_SLOT_SIZE);
         assert_eq!(ring.version(), 7); // 3 + 3 + 1(rebalance)
 
         // node1
         assert_eq!(ring.get_slot(&1_i32).unwrap().start, 1);
-        assert_eq!(ring.get_slot(&1_i32).unwrap().end, 341);
+        assert_eq!(
+            ring.get_slot(&1_i32).unwrap().end,
+            DEFAULT_SLOT_SIZE.overflow_div(3)
+        );
         // node2
-        assert_eq!(ring.get_slot(&999_i32).unwrap().start, 683);
-        assert_eq!(ring.get_slot(&999_i32).unwrap().end, 1024);
+        assert_eq!(
+            ring.get_slot(&999_i32).unwrap().start,
+            DEFAULT_SLOT_SIZE.overflow_div(3).overflow_add(1)
+        );
+        assert_eq!(
+            ring.get_slot(&999_i32).unwrap().end,
+            DEFAULT_SLOT_SIZE.overflow_div(3).overflow_mul(2)
+        );
         // node3
-        assert_eq!(ring.get_slot(&10_000_i32).unwrap().start, 342);
-        assert_eq!(ring.get_slot(&10_000_i32).unwrap().end, 682);
+        assert_eq!(
+            ring.get_slot(&99_003_i32).unwrap().start,
+            DEFAULT_SLOT_SIZE
+                .overflow_div(3)
+                .overflow_mul(2)
+                .overflow_add(1)
+        );
+        assert_eq!(ring.get_slot(&99_003_i32).unwrap().end, DEFAULT_SLOT_SIZE);
     }
 
     #[test]
@@ -581,28 +678,34 @@ mod tests {
         ring.batch_add(vec![node1.clone(), node2.clone(), node3.clone()], true);
 
         assert_eq!(ring.len_slots(), 3);
-        assert_eq!(ring.capacity(), 1024);
+        assert_eq!(ring.capacity(), DEFAULT_SLOT_SIZE);
         assert_eq!(ring.version(), 4); // 3 + 1
 
         ring.batch_remove(&[node2.clone()], true);
 
         assert_eq!(ring.len_slots(), 2);
-        assert_eq!(ring.capacity(), 1024);
+        assert_eq!(ring.capacity(), DEFAULT_SLOT_SIZE);
         assert_eq!(ring.version(), 6); // 4 + 1 + 1(rebalance)
 
         assert_eq!(ring.get_slot(&1_i32).unwrap().start, 1);
-        assert_eq!(ring.get_slot(&1_i32).unwrap().end, 512);
-        assert_eq!(ring.get_slot(&10_000_i32).unwrap().start, 513);
-        assert_eq!(ring.get_slot(&10_000_i32).unwrap().end, 1024);
+        assert_eq!(
+            ring.get_slot(&1_i32).unwrap().end,
+            DEFAULT_SLOT_SIZE.overflow_div(2)
+        );
+        assert_eq!(
+            ring.get_slot(&90_000_i32).unwrap().start,
+            DEFAULT_SLOT_SIZE.overflow_div(2).overflow_add(1)
+        );
+        assert_eq!(ring.get_slot(&90_000_i32).unwrap().end, DEFAULT_SLOT_SIZE);
 
         ring.batch_remove(&[node3.clone()], true);
 
         assert_eq!(ring.len_slots(), 1);
-        assert_eq!(ring.capacity(), 1024);
+        assert_eq!(ring.capacity(), DEFAULT_SLOT_SIZE);
         assert_eq!(ring.version(), 8); // 6 + 1 + 1(rebalance)
 
         assert_eq!(ring.get_slot(&1_i32).unwrap().start, 1);
-        assert_eq!(ring.get_slot(&1_i32).unwrap().end, 1024);
+        assert_eq!(ring.get_slot(&1_i32).unwrap().end, DEFAULT_SLOT_SIZE);
     }
 
     /// Test the ring add and remove
@@ -633,9 +736,9 @@ mod tests {
         assert_eq!(slot.inner().id, 1);
 
         let slot = ring.get_slot(&999_i32).unwrap();
-        assert_eq!(slot.inner().id, 3);
-
-        let slot = ring.get_slot(&10_000_i32).unwrap();
         assert_eq!(slot.inner().id, 2);
+
+        let slot = ring.get_slot(&90_002_i32).unwrap();
+        assert_eq!(slot.inner().id, 3);
     }
 }


### PR DESCRIPTION
# Design 

In this PR, we have implemented the cluster manager for distribute cache nodes, typically for these cases:
- Election Testing: Ensure that exactly one node is elected as the control node.
- Node Addition Testing: The controller should detect new nodes and modify the hash ring accordingly.
- Offline Logic Testing: Implement testing for node disconnections, e.g., by aborting coroutines, allowing etcd to detect these changes.
- Detection and Synchronization: Other nodes should detect changes in the etcd's hash ring and synchronize their in-memory state accordingly.

The core struct is `ClusterManager` & `ClusterManagerInner`.

### ClusterManager

```rs
pub struct ClusterManager {
    /// inner struct
    inner: Arc<ClusterManagerInner>,
}

impl ClusterManager {
    /// Create new cluster manager
    pub fn new(kv_engine: Arc<KVEngineType>, node: Node) -> Self {}
    
    /// Get current node
    #[must_use]
    pub fn get_node(&self) -> Node {}

    /// Get current hashring
    pub async fn get_ring(&self) -> DatenLordResult<Ring<Node>> {}
    
    /// Get all nodes
    pub async fn get_nodes(&self) -> DatenLordResult<Vec<Node>> {}
    
    ///  Stop the cluster manager
    pub fn stop(&self) {}
    
    /// Run the cluster manager as state machine
    ///
    /// We need to perpare current node info, current node list and generate hash ring info
    pub async fn run(&self) -> DatenLordResult<()> {}
    
    /// Do master tasks
    ///
    /// 1. Master node will watch the node list update, and update the ring
    /// 2. Master will check self
    async fn do_master_tasks(&self) -> DatenLordResult<()> {}
    
    /// Do slave tasks
    ///
    /// Slave node will watch the ring update and campaign master
    #[allow(clippy::arithmetic_side_effects, clippy::pattern_type_mismatch)] // The `select!` macro will generate code that goes against these rules.
    async fn do_slave_tasks(&self) -> DatenLordResult<()> {}
}
```

- run() core cluster manager method, i.e. synchronise etcd information/cluster configuration management, corresponds to ClusterManager in module relationship.
- get_xxx() exposes to other modules that hold ClusterManager, which can get information such as hashring maintained by the current node, and is internally managed by ArcSwap, which will return a copy of the current version (there may be some copying, but for the case where the number of nodes is not so large and updates are not frequent, it is a way to simplify the implementation). implementation).
- do_xxx_tasks() was originally placed inside inner, but ownership issues can be difficult to deal with when opening multiple tasks, so it puts the task here in ClusterManager and splits the read/write task inside the task.

### ClusterManagerInner

```rs
pub struct ClusterManagerInner {
    /// Etcd client
    kv_engine: Arc<KVEngineType>,
    /// Node session, try to keep the session alive, we will set the session in run method
    node_session: ArcSwapOption<Session>,
    /// current node info
    node: ArcSwap<Node>,
    /// current node list, we will set the session in run method
    node_list: ArcSwap<Vec<Node>>,
    /// current hash ring, we will set the session in run method
    hash_ring: ArcSwap<Ring<Node>>,
    // TODO: Support distribute cluster config here
}

impl ClusterManagerInner {
    /// Create a new cluster manager
    pub fn new(kv_engine: Arc<KVEngineType>, node: Node) -> Self {}
    
    /// Prepare for the session and other data
    ///
    /// We need to perpare current node info, current node list and generate hash ring info
    pub async fn prepare(&self) -> DatenLordResult<()> {}
    
    /// Update node info
    pub async fn update_node_in_cluster(&self) -> DatenLordResult<()> {}
    
    /// Register current node to etcd and keep alive
    pub async fn register(&self) -> DatenLordResult<()> {}
    
    /// Do campaign
    ///
    /// Try to campaign master, will return status and master value
    pub async fn do_campaign(&self) -> DatenLordResult<(bool, String)> {}
    
    /// Write current cluster info to etcd
    #[allow(clippy::arithmetic_side_effects, clippy::pattern_type_mismatch)] // The `select!` macro will generate code that goes against these rules.
    async fn write_task(&self, rx: flume::Receiver<()>, token: CancellationToken) {}
    
    /// Clean up the tasks
    pub fn clean_sessions(&self) {}
    
    /// Clean up the tasks
    pub fn clean_sessions(&self) {}
    
    /// Master node will watch the node list update, and update the ring
    pub async fn watch_nodes(&self, tx: flume::Sender<()>) -> DatenLordResult<()> {}
    
    /// Update cluster topo
    ///
    /// Try to update cluster by current master node
    async fn update_cluster_topo(&self) -> DatenLordResult<()> {}

    /// Try to watch the master node
    /// If the master node is down, the slave node will try to get the master lock
    /// Then current node will become the master node if operation is successful
    pub async fn watch_master(&self) -> DatenLordResult<()> {}
    
    /// Save ring to etcd
    async fn save_ring(&self) -> DatenLordResult<()> {}
    
    /// Load ring from etcd
    async fn load_ring(&self) -> DatenLordResult<Ring<Node>> {}
    
    /// Get node list from etcd
    async fn load_nodes(&self) -> DatenLordResult<Vec<Node>> {}
    
    /// Get all nodes
    ///
    /// This function is used to get all nodes from etcd
    /// If we set `must_fetch`, we will also update current node list
    pub async fn get_nodes(&self, must_fetch: bool) -> DatenLordResult<Vec<Node>> {}
    
    /// Get current node
    pub fn get_node(&self) -> Node {}
    
    /// Update current node
    pub fn update_node(&self, node: Node) {}
    
    /// Get hashring
    ///
    /// This function is used to get current hashring and update current hashring
    /// If we set `must_fetch`, we will also update current hashring
    pub async fn get_ring(&self, must_fetch: bool) -> DatenLordResult<Ring<Node>> {}
}
```

The definition of Inner will be rather monolithic and the exposed methods are basically single tasks.
- load/save/get/update are exposed utility methods to manipulate etcd configuration/local configuration.
- watch_xxx() is a task to observe a key event.
- write_task() is a task for the master to periodically watch for events and write them to etcd.
- The remaining methods are encapsulated for ease of reuse.