### PR TITLE
fix: fix current deprecated kube_state_metrics docker image version.

### DIFF
--- a/scripts/ci/datenlord-monitor-test.sh
+++ b/scripts/ci/datenlord-monitor-test.sh
@@ -2,7 +2,12 @@
 
 . scripts/setup/config.sh
 
-KUBE_STATE_METRICS_VERSION=${KUBE_STATE_METRICS_VERSION:-"v1.8.0"}
+# Previous version is v1.8.0, but in docker ci environment, it will fail to pull the image
+# [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default
+# and will be removed in an upcoming release. Suggest the author of quay.io/coreos/kube-state-metrics:v1.8.0
+# to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2.
+# More information at https://docs.docker.com/go/deprecated-image-specs/
+KUBE_STATE_METRICS_VERSION=${KUBE_STATE_METRICS_VERSION:-"v1.9.8"}
 ALERTMANAGER_VERSION=${ALERTMANAGER_VERSION:-"v0.19.0"}
 PROMETHEUS_VERSION=${PROMETHEUS_VERSION:-"v2.30.3"}
 GRAFANA_VERSION=${GRAFANA_VERSION:-"8.2.0"}
@@ -48,7 +53,7 @@ do
     exit
   else
     echo "waiting 15s"
-    n=$((n+1)) 
+    n=$((n+1))
     sleep 15
   fi
 done


### PR DESCRIPTION
The current v1.8.0 image version caused the k8s-e2e-test CI to fail. In this PR, we aim to update the image version to resolve the issue and ensure the CI check passes.