### PR TITLE
fix: new storage cache manager will cause unexcepted cache clean.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,9 @@ bytes = "1.6.0"
 hashbrown = "0.14.3"
 rand_distr = "0.4.3"
 serfig = "0.1.0"
+flume = "0.11.0"
+arc-swap = "1.7.1"
+serfig = "0.1.0"
 
 [build-dependencies]
 protoc-grpcio = "3.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,6 @@ rand_distr = "0.4.3"
 serfig = "0.1.0"
 flume = "0.11.0"
 arc-swap = "1.7.1"
-serfig = "0.1.0"
 
 [build-dependencies]
 protoc-grpcio = "3.0.0"

--- a/src/async_fuse/memfs/fs_util.rs
+++ b/src/async_fuse/memfs/fs_util.rs
@@ -41,6 +41,8 @@ pub struct FileAttr {
     pub gid: u32,
     /// Rdev
     pub rdev: u32,
+    /// Version
+    pub version: u64,
 }
 
 /// Whether to check permission.
@@ -66,6 +68,7 @@ impl FileAttr {
             uid: 0,
             gid: 0,
             rdev: 0,
+            version: 0,
         }
     }
 
@@ -269,6 +272,7 @@ impl Default for FileAttr {
             uid: 0,
             gid: 0,
             rdev: 0,
+            version: 0,
         }
     }
 }
@@ -371,6 +375,7 @@ mod tests {
             uid: 1000,
             gid: 1000,
             rdev: 0,
+            version: 0,
         };
 
         // Owner permission checks

--- a/src/async_fuse/memfs/metadata.rs
+++ b/src/async_fuse/memfs/metadata.rs
@@ -73,13 +73,14 @@ pub trait MetaData {
         ino: u64,
         new_mtime: SystemTime,
         new_size: u64,
+        new_version: u64,
     ) -> DatenLordResult<()>;
 
-    /// Helper function to get a open file's size and mtime
+    /// Helper function to get a open file's size, mtime and version
     /// # Return
-    /// Return a tuple of (file_size, modified_time)
+    /// Return a tuple of (file_size, modified_time, version)
     /// It will not change the file's atime
-    fn mtime_and_size(&self, ino: u64) -> (u64, SystemTime);
+    fn size_and_version(&self, ino: u64) -> (u64, SystemTime, u64);
 
     /// Set fuse fd into `MetaData`
     async fn set_fuse_fd(&self, fuse_fd: RawFd);
@@ -117,8 +118,8 @@ pub trait MetaData {
 
     /// Helper function to read data
     /// # Return
-    /// Return a tuple of (file_size, modified_time)
-    async fn read_helper(&self, ino: u64) -> DatenLordResult<(u64, SystemTime)>;
+    /// Return a tuple of (file_size, modified_time, version)
+    async fn read_helper(&self, ino: u64) -> DatenLordResult<(u64, SystemTime, u64)>;
 
     /// Helper function to release dir
     async fn releasedir(&self, ino: u64, fh: u64) -> DatenLordResult<()>;

--- a/src/async_fuse/memfs/mod.rs
+++ b/src/async_fuse/memfs/mod.rs
@@ -536,8 +536,8 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         let ino = req.nodeid();
         let offset: u64 = offset.cast();
 
-        let (file_size, _) = match self.metadata.read_helper(ino).await {
-            Ok((file_size, mtime)) => (file_size, mtime),
+        let (file_size, _, version) = match self.metadata.read_helper(ino).await {
+            Ok((file_size, mtime, version)) => (file_size, mtime, version),
             Err(e) => {
                 return reply.error(e).await;
             }
@@ -554,7 +554,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
             size.cast()
         };
 
-        let result = self.storage.read(ino, fh, offset, read_size.cast()).await;
+        let result = self.storage.read(ino, fh, offset, read_size.cast(), version).await;
         // Check the load result
         match result {
             Ok(content) => reply.data(content).await,
@@ -583,8 +583,9 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         let ino = req.nodeid();
         let data_len: u64 = data.len().cast();
 
-        let (old_size, _) = self.metadata.mtime_and_size(ino);
-        let result = self.storage.write(ino, fh, offset.cast(), &data).await;
+        let (old_size, _, version) = self.metadata.size_and_version(ino);
+        // TODO: Current write operation is not atomic and transactional, we need to add a transaction in the future
+        let result = self.storage.write(ino, fh, offset.cast(), &data, version).await;
 
         let new_mtime = match result {
             Ok(()) => SystemTime::now(),
@@ -594,8 +595,9 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         };
 
         let new_size = old_size.max(offset.cast::<u64>().overflow_add(data_len));
+        let new_version = version.max(version.overflow_add(1));
 
-        let write_result = self.metadata.write_helper(ino, new_mtime, new_size).await;
+        let write_result = self.metadata.write_helper(ino, new_mtime, new_size, new_version).await;
         match write_result {
             Ok(()) => reply.written(data_len.cast()).await,
             Err(e) => reply.error(e).await,

--- a/src/async_fuse/memfs/mod.rs
+++ b/src/async_fuse/memfs/mod.rs
@@ -554,7 +554,10 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
             size.cast()
         };
 
-        let result = self.storage.read(ino, fh, offset, read_size.cast(), version).await;
+        let result = self
+            .storage
+            .read(ino, fh, offset, read_size.cast(), version)
+            .await;
         // Check the load result
         match result {
             Ok(content) => reply.data(content).await,
@@ -585,7 +588,10 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
 
         let (old_size, _, version) = self.metadata.size_and_version(ino);
         // TODO: Current write operation is not atomic and transactional, we need to add a transaction in the future
-        let result = self.storage.write(ino, fh, offset.cast(), &data, version).await;
+        let result = self
+            .storage
+            .write(ino, fh, offset.cast(), &data, version)
+            .await;
 
         let new_mtime = match result {
             Ok(()) => SystemTime::now(),
@@ -597,7 +603,10 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         let new_size = old_size.max(offset.cast::<u64>().overflow_add(data_len));
         let new_version = version.max(version.overflow_add(1));
 
-        let write_result = self.metadata.write_helper(ino, new_mtime, new_size, new_version).await;
+        let write_result = self
+            .metadata
+            .write_helper(ino, new_mtime, new_size, new_version)
+            .await;
         match write_result {
             Ok(()) => reply.written(data_len.cast()).await,
             Err(e) => reply.error(e).await,

--- a/src/async_fuse/memfs/mod.rs
+++ b/src/async_fuse/memfs/mod.rs
@@ -275,7 +275,8 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
         match self.metadata.open(context, ino, flags).await {
             Ok(fd) => {
                 self.storage.open(ino, fd.cast(), flags.into());
-                reply.opened(fd, flags).await
+                reply.opened(fd.cast(), flags).await // TODO: Fix the type
+                                                     // of fd
             }
             Err(e) => {
                 debug!("open() failed, the error is: {:?}", e);
@@ -720,7 +721,7 @@ impl<M: MetaData + Send + Sync + 'static> FileSystem for MemFs<M> {
                         ino={}  with flags={:?}, the new fd={}",
                     ino, o_flags, new_fd,
                 );
-                reply.opened(new_fd, flags).await
+                reply.opened(new_fd.cast(), flags).await
             }
             Err(e) => {
                 debug!(

--- a/src/async_fuse/memfs/s3_metadata.rs
+++ b/src/async_fuse/memfs/s3_metadata.rs
@@ -327,7 +327,12 @@ impl MetaData for S3MetaData {
                         if remote_attr.size != dirty_attr.size {
                             inode.update_mtime_ctime_to_now();
                             storage
-                                .truncate(ino, remote_attr.size.cast(), dirty_attr.size.cast(), remote_attr.version)
+                                .truncate(
+                                    ino,
+                                    remote_attr.size.cast(),
+                                    dirty_attr.size.cast(),
+                                    remote_attr.version,
+                                )
                                 .await?;
                             if param.fh.is_some() {
                                 // The file is open, update the attr in `open_files`
@@ -336,7 +341,10 @@ impl MetaData for S3MetaData {
                                 open_file.attr.size = dirty_attr.size;
                                 open_file.attr.mtime = inode.get_attr().mtime;
                                 open_file.attr.ctime = inode.get_attr().ctime;
-                                open_file.attr.version = open_file.attr.version.max(open_file.attr.version.overflow_add(1));
+                                open_file.attr.version = open_file
+                                    .attr
+                                    .version
+                                    .max(open_file.attr.version.overflow_add(1));
                             }
                         }
                         inode.set_attr(dirty_attr);

--- a/src/async_fuse/memfs/serial.rs
+++ b/src/async_fuse/memfs/serial.rs
@@ -35,6 +35,9 @@ pub struct SerialFileAttr {
     gid: u32,
     /// Rdev
     rdev: u32,
+    /// Serial node version number, default is 0 for compatibility
+    #[serde(default)]
+    version: u64,
 }
 
 impl SerialFileAttr {
@@ -143,6 +146,7 @@ pub fn file_attr_to_serial(attr: &FileAttr) -> SerialFileAttr {
         uid: attr.uid,
         gid: attr.gid,
         rdev: attr.rdev,
+        version: attr.version,
     }
 }
 
@@ -168,6 +172,7 @@ pub const fn serial_to_file_attr(attr: &SerialFileAttr) -> FileAttr {
         uid: attr.uid,
         gid: attr.gid,
         rdev: attr.rdev,
+        version: attr.version,
     }
 }
 
@@ -216,6 +221,7 @@ mod test {
             uid: rng.gen(),
             gid: rng.gen(),
             rdev: rng.gen(),
+            version: rng.gen(),
         }
     }
 

--- a/src/async_fuse/test/integration_tests.rs
+++ b/src/async_fuse/test/integration_tests.rs
@@ -699,12 +699,12 @@ fn test_delete_file(mount_dir: &Path) -> anyhow::Result<()> {
 }
 
 #[cfg(test)]
-#[allow(dead_code)]
 fn test_open_file_permission(mount_dir: &Path) -> anyhow::Result<()> {
     info!("test open file permission");
     let file_path = Path::new(mount_dir).join("test_open_file_permission.txt");
 
     // Delete file if it exists
+    #[allow(clippy::restriction)]
     let _ = fs::remove_file(&file_path);
     // Make sure current data is flushed to backend with new version
     // Ref pr: https://github.com/datenlord/datenlord/pull/536

--- a/src/new_storage/backend/backend_impl.rs
+++ b/src/new_storage/backend/backend_impl.rs
@@ -112,7 +112,7 @@ impl BackendImpl {
 #[async_trait]
 impl Backend for BackendImpl {
     #[inline]
-    async fn read(&self, path: &str, buf: &mut [u8]) -> StorageResult<usize> {
+    async fn read(&self, path: &str, buf: &mut [u8], _version: u64) -> StorageResult<usize> {
         let len = buf.len();
         let mut reader = self.operator.reader(path).await?;
         let mut read_size = 0;
@@ -140,7 +140,7 @@ impl Backend for BackendImpl {
     }
 
     #[inline]
-    async fn write(&self, path: &str, buf: &[u8]) -> StorageResult<()> {
+    async fn write(&self, path: &str, buf: &[u8], _version: u64) -> StorageResult<()> {
         let mut writer = self.operator.writer(path).await?;
         writer.write_all(buf).await?;
         writer.close().await?;
@@ -199,14 +199,15 @@ mod tests {
     async fn test_remove_all() {
         let backend = tmp_fs_backend().unwrap();
         let mut buf = vec![0; 16];
-        backend.write("a/1", &buf).await.unwrap();
-        backend.write("a/2", &buf).await.unwrap();
+        let version = 0;
+        backend.write("a/1", &buf, version).await.unwrap();
+        backend.write("a/2", &buf, version).await.unwrap();
 
         backend.remove_all("a/").await.unwrap();
 
-        let size = backend.read("a/1", &mut buf).await.unwrap();
+        let size = backend.read("a/1", &mut buf, version).await.unwrap();
         assert_eq!(size, 0);
-        let size = backend.read("a/2", &mut buf).await.unwrap();
+        let size = backend.read("a/2", &mut buf, version).await.unwrap();
         assert_eq!(size, 0);
     }
 }

--- a/src/new_storage/backend/memory_backend.rs
+++ b/src/new_storage/backend/memory_backend.rs
@@ -31,7 +31,7 @@ impl Debug for MemoryBackend {
 #[async_trait]
 impl Backend for MemoryBackend {
     #[inline]
-    async fn read(&self, path: &str, buf: &mut [u8]) -> StorageResult<usize> {
+    async fn read(&self, path: &str, buf: &mut [u8], _version: u64) -> StorageResult<usize> {
         // mock latency
         tokio::time::sleep(self.latency).await;
 
@@ -50,7 +50,7 @@ impl Backend for MemoryBackend {
     }
 
     #[inline]
-    async fn write(&self, path: &str, buf: &[u8]) -> StorageResult<()> {
+    async fn write(&self, path: &str, buf: &[u8], _version: u64) -> StorageResult<()> {
         // mock latency
         tokio::time::sleep(self.latency).await;
         self.map.insert(path.to_owned(), buf.to_vec());
@@ -107,14 +107,15 @@ mod tests {
     async fn test_remove_all() {
         let backend = MemoryBackend::new(Duration::from_millis(0));
         let mut buf = vec![0; 16];
-        backend.write("a/1", &buf).await.unwrap();
-        backend.write("a/2", &buf).await.unwrap();
+        let version = 0;
+        backend.write("a/1", &buf, version).await.unwrap();
+        backend.write("a/2", &buf, version).await.unwrap();
 
         backend.remove_all("a/").await.unwrap();
 
-        let size = backend.read("a/1", &mut buf).await.unwrap();
+        let size = backend.read("a/1", &mut buf, version).await.unwrap();
         assert_eq!(size, 0);
-        let size = backend.read("a/2", &mut buf).await.unwrap();
+        let size = backend.read("a/2", &mut buf, version).await.unwrap();
         assert_eq!(size, 0);
     }
 }

--- a/src/new_storage/block.rs
+++ b/src/new_storage/block.rs
@@ -47,6 +47,12 @@ pub struct Block {
     version: usize,
 }
 
+impl AsRef<[u8]> for Block {
+    fn as_ref(&self) -> &[u8] {
+        &self.data
+    }
+}
+
 impl Debug for Block {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Block")

--- a/src/new_storage/block.rs
+++ b/src/new_storage/block.rs
@@ -44,7 +44,7 @@ pub struct Block {
     /// The dirty flag
     dirty: bool,
     /// The version of the block
-    version: usize,
+    version: u64,
 }
 
 impl AsRef<[u8]> for Block {
@@ -81,8 +81,13 @@ impl Block {
 
     /// Returns the current version of the block.
     #[must_use]
-    pub fn version(&self) -> usize {
+    pub fn version(&self) -> u64 {
         self.version
+    }
+
+    /// Set the version of the block.
+    pub fn set_version(&mut self, version: u64) {
+        self.version = version;
     }
 
     /// Increments the version of the block.

--- a/src/new_storage/error.rs
+++ b/src/new_storage/error.rs
@@ -29,10 +29,6 @@ pub enum StorageError {
 impl From<StorageError> for DatenLordError {
     fn from(value: StorageError) -> Self {
         match value {
-            StorageError::OutOfRange { maximum, found } => DatenLordError::InternalErr {
-                source: anyhow!("IO out of range: the maximum is {maximum}, but {found} found."),
-                context: vec![],
-            },
             StorageError::OutOfMemory => DatenLordError::InternalErr {
                 source: anyhow::Error::new(Errno::EIO),
                 context: vec!["Cache is out of memory.".to_owned()],

--- a/src/new_storage/error.rs
+++ b/src/new_storage/error.rs
@@ -29,6 +29,10 @@ pub enum StorageError {
 impl From<StorageError> for DatenLordError {
     fn from(value: StorageError) -> Self {
         match value {
+            StorageError::OutOfRange { maximum, found } => DatenLordError::InternalErr {
+                source: anyhow!("IO out of range: the maximum is {maximum}, but {found} found."),
+                context: vec![],
+            },
             StorageError::OutOfMemory => DatenLordError::InternalErr {
                 source: anyhow::Error::new(Errno::EIO),
                 context: vec!["Cache is out of memory.".to_owned()],

--- a/src/new_storage/handle/handle.rs
+++ b/src/new_storage/handle/handle.rs
@@ -302,7 +302,7 @@ mod tests {
         handles.add_handle(file_handle.clone());
         let buf = vec![b'1', b'2', b'3', b'4'];
         let version = 0;
-        file_handle.write(0, &buf ,version).await.unwrap();
+        file_handle.write(0, &buf, version).await.unwrap();
         let version = 0;
         let read_buf = file_handle.read(0, 4, version).await.unwrap();
         assert_eq!(read_buf, buf);

--- a/src/new_storage/handle/writer.rs
+++ b/src/new_storage/handle/writer.rs
@@ -107,7 +107,6 @@ async fn write_back_block(task: Arc<WriteTask>) -> StorageResult<()> {
             task.cache.lock().unpin(&CacheKey {
                 ino: task.ino,
                 block_id: task.block_id,
-                version: task.version,
             });
             break;
         }
@@ -220,12 +219,11 @@ impl Writer {
         let key = CacheKey {
             ino: self.ino,
             block_id,
-            version,
         };
 
         {
             let cache = self.cache.lock();
-            if let Some(block) = cache.fetch(&key) {
+            if let Some(block) = cache.fetch(&key, version) {
                 return Ok(block);
             }
         }
@@ -239,7 +237,7 @@ impl Writer {
         let block = {
             let mut cache = self.cache.lock();
             cache
-                .new_block(&key, &buf)
+                .new_block(&key, &buf, version)
                 .ok_or(StorageError::OutOfMemory)?
         };
 

--- a/src/new_storage/memory_cache.rs
+++ b/src/new_storage/memory_cache.rs
@@ -17,6 +17,8 @@ pub struct CacheKey {
     pub ino: u64,
     /// The block ID.
     pub block_id: u64,
+    /// The version of the block
+    pub version: u64,
 }
 
 /// The `MemoryCache` struct is used to manage cache of blocks with a

--- a/src/new_storage/memory_cache.rs
+++ b/src/new_storage/memory_cache.rs
@@ -17,8 +17,6 @@ pub struct CacheKey {
     pub ino: u64,
     /// The block ID.
     pub block_id: u64,
-    /// The version of the block
-    pub version: u64,
 }
 
 /// The `MemoryCache` struct is used to manage cache of blocks with a
@@ -95,12 +93,13 @@ where
     /// # Panic
     /// The method panics if `data` is longer than `BLOCK_SIZE`.
     #[inline]
-    pub fn new_block(&mut self, key: &K, data: &[u8]) -> Option<Arc<RwLock<Block>>> {
+    pub fn new_block(&mut self, key: &K, data: &[u8], version: u64) -> Option<Arc<RwLock<Block>>> {
         // Check if the key is already exist
         if let Some(block) = self.map.get(key) {
-            // access, then pin,return
+            // access, update version, then pin,return
             self.policy.access(key);
             let block = Arc::clone(block);
+            block.write().set_version(version);
             block.write().pin();
             return Some(block);
         }
@@ -134,6 +133,7 @@ where
                     panic!("Input data is longer than a block.");
                 })
                 .copy_from_slice(data);
+            block.set_version(version);
         }
         Some(new_block)
     }
@@ -156,8 +156,12 @@ where
 
     /// Fetches the block associated with the given key from the cache.
     #[inline]
-    pub fn fetch(&self, key: &K) -> Option<Arc<RwLock<Block>>> {
+    pub fn fetch(&self, key: &K, version: u64) -> Option<Arc<RwLock<Block>>> {
         let block = self.map.get(key).cloned()?;
+        if block.read().version() != version {
+            return None;
+        }
+
         self.policy.access(key);
         {
             let mut block = block.write();
@@ -240,7 +244,7 @@ mod tests {
         let cache_size = 10;
         let mut manager = prepare_cache(cache_size);
         {
-            let block_0 = manager.new_block(&0, &content).unwrap();
+            let block_0 = manager.new_block(&0, &content, 0).unwrap();
             let mut block_0 = block_0.write();
             block_0.copy_from_slice(&content);
             block_0.set_dirty(true);
@@ -248,7 +252,7 @@ mod tests {
 
         {
             // Check if block_0's content is correct.
-            let block_0 = manager.fetch(&0).unwrap();
+            let block_0 = manager.fetch(&0, 0).unwrap();
             {
                 let block_0 = block_0.read();
                 // TODO: fix storage error
@@ -261,7 +265,7 @@ mod tests {
 
         // Create blocks [1,2,3,4,5,6,7,8,9]
         for i in 1..cache_size {
-            let block = manager.new_block(&i, &content).unwrap();
+            let block = manager.new_block(&i, &content, 0).unwrap();
             let mut block = block.write();
             block.copy_from_slice(&content);
         }
@@ -269,7 +273,7 @@ mod tests {
         // Now the cache is full and all blocks are pinned.
         // We can't create a new block.
         {
-            assert!(manager.new_block(&cache_size, &content).is_none());
+            assert!(manager.new_block(&cache_size, &content, 0).is_none());
         }
 
         {
@@ -277,10 +281,10 @@ mod tests {
         }
 
         // This would evict block 1 and create a new block.
-        assert!(manager.new_block(&cache_size, &content).is_some());
+        assert!(manager.new_block(&cache_size, &content, 0).is_some());
         {
             // Try get block 1
-            assert!(manager.fetch(&1).is_none());
+            assert!(manager.fetch(&1, 0).is_none());
         }
     }
 
@@ -288,8 +292,8 @@ mod tests {
     fn test_new_same_block() {
         let content = vec![0_u8; BLOCK_SIZE];
         let mut manager = prepare_cache(10);
-        let block_1 = manager.new_block(&0, &content).unwrap();
-        let block_2 = manager.new_block(&0, &content).unwrap();
+        let block_1 = manager.new_block(&0, &content, 0).unwrap();
+        let block_2 = manager.new_block(&0, &content, 0).unwrap();
 
         assert!(Arc::ptr_eq(&block_1, &block_2));
     }
@@ -299,8 +303,8 @@ mod tests {
         let content = vec![0_u8; BLOCK_SIZE];
         let mut manager = prepare_cache(10);
 
-        let _block = manager.new_block(&1, &content).unwrap();
-        let _block = manager.new_block(&2, &content).unwrap();
+        let _block = manager.new_block(&1, &content, 0).unwrap();
+        let _block = manager.new_block(&2, &content, 0).unwrap();
 
         manager.unpin(&2);
 
@@ -314,16 +318,16 @@ mod tests {
         let content = vec![0_u8; BLOCK_SIZE];
         let mut manager = prepare_cache(10);
 
-        let block_1 = manager.new_block(&1, &content).unwrap();
+        let block_1 = manager.new_block(&1, &content, 0).unwrap();
         manager.remove(&1); // This will NOT remove the pinned block
-        let block_2 = manager.fetch(&1).unwrap();
+        let block_2 = manager.fetch(&1, 0).unwrap();
         assert!(Arc::ptr_eq(&block_1, &block_2));
 
         manager.unpin(&1);
         manager.unpin(&1);
         manager.remove(&1);
 
-        let block_3 = manager.fetch(&1);
+        let block_3 = manager.fetch(&1, 0);
         assert!(block_3.is_none());
     }
 }

--- a/src/new_storage/storage_manager/manager.rs
+++ b/src/new_storage/storage_manager/manager.rs
@@ -47,17 +47,17 @@ impl Storage for StorageManager {
     /// Reads data from a file specified by the file handle, starting at the
     /// given offset and reading up to `len` bytes.
     #[inline]
-    async fn read(&self, _ino: u64, fh: u64, offset: u64, len: usize) -> StorageResult<Vec<u8>> {
+    async fn read(&self, _ino: u64, fh: u64, offset: u64, len: usize, version: u64) -> StorageResult<Vec<u8>> {
         let handle = self.get_handle(fh);
-        handle.read(offset, len.cast()).await
+        handle.read(offset, len.cast(), version).await
     }
 
     /// Writes data to a file specified by the file handle, starting at the
     /// given offset.
     #[inline]
-    async fn write(&self, _ino: u64, fh: u64, offset: u64, buf: &[u8]) -> StorageResult<()> {
+    async fn write(&self, _ino: u64, fh: u64, offset: u64, buf: &[u8], version: u64) -> StorageResult<()> {
         let handle = self.get_handle(fh);
-        handle.write(offset, buf).await?;
+        handle.write(offset, buf, version).await?;
         Ok(())
     }
 
@@ -83,7 +83,7 @@ impl Storage for StorageManager {
     /// Truncates a file specified by the inode number to a new size, given the
     /// old size.
     #[inline]
-    async fn truncate(&self, ino: u64, old_size: u64, new_size: u64) -> StorageResult<()> {
+    async fn truncate(&self, ino: u64, old_size: u64, new_size: u64, version: u64) -> StorageResult<()> {
         // If new_size == old_size, do nothing
         if new_size >= old_size {
             return Ok(());
@@ -116,7 +116,7 @@ impl Storage for StorageManager {
                 OpenFlag::Write,
             );
             let fill_content = vec![0; fill_size];
-            handle.write(new_size, &fill_content).await?;
+            handle.write(new_size, &fill_content, version).await?;
             handle.close().await?;
         }
 

--- a/src/new_storage/storage_manager/manager.rs
+++ b/src/new_storage/storage_manager/manager.rs
@@ -47,7 +47,14 @@ impl Storage for StorageManager {
     /// Reads data from a file specified by the file handle, starting at the
     /// given offset and reading up to `len` bytes.
     #[inline]
-    async fn read(&self, _ino: u64, fh: u64, offset: u64, len: usize, version: u64) -> StorageResult<Vec<u8>> {
+    async fn read(
+        &self,
+        _ino: u64,
+        fh: u64,
+        offset: u64,
+        len: usize,
+        version: u64,
+    ) -> StorageResult<Vec<u8>> {
         let handle = self.get_handle(fh);
         handle.read(offset, len.cast(), version).await
     }
@@ -55,7 +62,14 @@ impl Storage for StorageManager {
     /// Writes data to a file specified by the file handle, starting at the
     /// given offset.
     #[inline]
-    async fn write(&self, _ino: u64, fh: u64, offset: u64, buf: &[u8], version: u64) -> StorageResult<()> {
+    async fn write(
+        &self,
+        _ino: u64,
+        fh: u64,
+        offset: u64,
+        buf: &[u8],
+        version: u64,
+    ) -> StorageResult<()> {
         let handle = self.get_handle(fh);
         handle.write(offset, buf, version).await?;
         Ok(())
@@ -83,7 +97,13 @@ impl Storage for StorageManager {
     /// Truncates a file specified by the inode number to a new size, given the
     /// old size.
     #[inline]
-    async fn truncate(&self, ino: u64, old_size: u64, new_size: u64, version: u64) -> StorageResult<()> {
+    async fn truncate(
+        &self,
+        ino: u64,
+        old_size: u64,
+        new_size: u64,
+        version: u64,
+    ) -> StorageResult<()> {
         // If new_size == old_size, do nothing
         if new_size >= old_size {
             return Ok(());

--- a/src/new_storage/storage_manager/tests.rs
+++ b/src/new_storage/storage_manager/tests.rs
@@ -395,7 +395,10 @@ async fn test_truncate() {
     truncated_content.resize(BLOCK_SIZE, 0);
     assert_eq!(truncated_content, buffer);
 
-    storage.truncate(ino, block_size / 2, 0, version).await.unwrap();
+    storage
+        .truncate(ino, block_size / 2, 0, version)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]

--- a/src/new_storage/storage_trait.rs
+++ b/src/new_storage/storage_trait.rs
@@ -14,21 +14,41 @@ pub trait Storage {
     /// Reads data from a file specified by the inode number and file handle,
     /// starting at the given offset and reading up to `len` bytes.
     /// version is used to check if the file has been modified since the last read.
-    async fn read(&self, ino: u64, fh: u64, offset: u64, len: usize, version: u64) -> StorageResult<Vec<u8>>;
+    async fn read(
+        &self,
+        ino: u64,
+        fh: u64,
+        offset: u64,
+        len: usize,
+        version: u64,
+    ) -> StorageResult<Vec<u8>>;
 
     /// Writes data to a file specified by the inode number and file handle,
     /// starting at the given offset.
     /// version is used to check if the file has been modified since the last write,
-    /// current write implementaion might need to read the file from storage first,
+    /// current write implementation might need to read the file from storage first,
     /// so this function need to sync with read function.
-    async fn write(&self, ino: u64, fh: u64, offset: u64, buf: &[u8], version: u64) -> StorageResult<()>;
+    async fn write(
+        &self,
+        ino: u64,
+        fh: u64,
+        offset: u64,
+        buf: &[u8],
+        version: u64,
+    ) -> StorageResult<()>;
 
     /// Truncates a file specified by the inode number to a new size,
     /// given the old size and the new size.
     /// version is used to check if the file has been modified since the last truncate.
-    /// current truncate implementaion might need to read the file from storage first,
+    /// current truncate implementation might need to read the file from storage first,
     /// so this function need to sync with read function.
-    async fn truncate(&self, ino: u64, old_size: u64, new_size: u64, version: u64) -> StorageResult<()>;
+    async fn truncate(
+        &self,
+        ino: u64,
+        old_size: u64,
+        new_size: u64,
+        version: u64,
+    ) -> StorageResult<()>;
 
     /// Flushes any pending writes to a file specified by the inode number and
     /// file handle.

--- a/src/new_storage/storage_trait.rs
+++ b/src/new_storage/storage_trait.rs
@@ -13,15 +13,22 @@ pub trait Storage {
 
     /// Reads data from a file specified by the inode number and file handle,
     /// starting at the given offset and reading up to `len` bytes.
-    async fn read(&self, ino: u64, fh: u64, offset: u64, len: usize) -> StorageResult<Vec<u8>>;
+    /// version is used to check if the file has been modified since the last read.
+    async fn read(&self, ino: u64, fh: u64, offset: u64, len: usize, version: u64) -> StorageResult<Vec<u8>>;
 
     /// Writes data to a file specified by the inode number and file handle,
     /// starting at the given offset.
-    async fn write(&self, ino: u64, fh: u64, offset: u64, buf: &[u8]) -> StorageResult<()>;
+    /// version is used to check if the file has been modified since the last write,
+    /// current write implementaion might need to read the file from storage first,
+    /// so this function need to sync with read function.
+    async fn write(&self, ino: u64, fh: u64, offset: u64, buf: &[u8], version: u64) -> StorageResult<()>;
 
     /// Truncates a file specified by the inode number to a new size,
     /// given the old size and the new size.
-    async fn truncate(&self, ino: u64, old_size: u64, new_size: u64) -> StorageResult<()>;
+    /// version is used to check if the file has been modified since the last truncate.
+    /// current truncate implementaion might need to read the file from storage first,
+    /// so this function need to sync with read function.
+    async fn truncate(&self, ino: u64, old_size: u64, new_size: u64, version: u64) -> StorageResult<()>;
 
     /// Flushes any pending writes to a file specified by the inode number and
     /// file handle.


### PR DESCRIPTION
# Bug

The current file handling mechanism aggressively removes cache, but we want to retain this cache when continuous read/write operations are occurring.

# Fix

Update the cache with a versioning system. The LRU (Least Recently Used) policy will automatically clean up outdated cache entries when memory is insufficient.

Additionally, we can add a `file_version` to each block to quickly identify and discard outdated blocks in access function. The current implementation does not utilize this approach.

## TODO

1. Set version to cache value, write task can access outdate block and write this cache.
2. write 256k & write 4k mechaism for block version and block cache.

benchmark:
1. old policy:
```bash
python3 test_reader.py -n 10
Average read time: 0.21317 s
Maximum read time: 0.24317 s
Minimum read time: 0.18317 s
Median read time: 0.22317 s
```
3. new policy with version:
```bash
python3 test_reader.py -n 10
Average read time: 0.04402 s
Maximum read time: 0.24390 s
Minimum read time: 0.01637 s
Median read time: 0.02104 s
```