### PR TITLE
feat: introduce version to storage and update cache behavior.

### DIFF
--- a/src/async_fuse/memfs/fs_util.rs
+++ b/src/async_fuse/memfs/fs_util.rs
@@ -41,6 +41,8 @@ pub struct FileAttr {
     pub gid: u32,
     /// Rdev
     pub rdev: u32,
+    /// Version
+    pub version: u64,
 }
 
 /// Whether to check permission.
@@ -66,6 +68,7 @@ impl FileAttr {
             uid: 0,
             gid: 0,
             rdev: 0,
+            version: 0,
         }
     }
 
@@ -269,6 +272,7 @@ impl Default for FileAttr {
             uid: 0,
             gid: 0,
             rdev: 0,
+            version: 0,
         }
     }
 }
@@ -372,6 +376,7 @@ mod tests {
             uid: 1000,
             gid: 1000,
             rdev: 0,
+            version: 0,
         };
 
         // Owner permission checks

--- a/src/async_fuse/memfs/metadata.rs
+++ b/src/async_fuse/memfs/metadata.rs
@@ -68,7 +68,12 @@ pub trait MetaData {
     async fn rename(&self, context: ReqContext, param: RenameParam) -> DatenLordResult<()>;
 
     /// Helper function to write remote data
-    async fn write_remote_size_helper(&self, ino: u64, size: u64) -> DatenLordResult<FileAttr>;
+    async fn write_remote_size_and_version_helper(
+        &self,
+        ino: u64,
+        size: u64,
+        version: u64,
+    ) -> DatenLordResult<FileAttr>;
 
     /// Set fuse fd into `MetaData`
     async fn set_fuse_fd(&self, fuse_fd: RawFd);

--- a/src/async_fuse/memfs/serial.rs
+++ b/src/async_fuse/memfs/serial.rs
@@ -35,6 +35,9 @@ pub struct SerialFileAttr {
     gid: u32,
     /// Rdev
     rdev: u32,
+    /// Serial node version number, default is 0 for compatibility
+    #[serde(default)]
+    version: u64,
 }
 
 impl SerialFileAttr {
@@ -143,6 +146,7 @@ pub fn file_attr_to_serial(attr: &FileAttr) -> SerialFileAttr {
         uid: attr.uid,
         gid: attr.gid,
         rdev: attr.rdev,
+        version: attr.version,
     }
 }
 
@@ -168,6 +172,7 @@ pub const fn serial_to_file_attr(attr: &SerialFileAttr) -> FileAttr {
         uid: attr.uid,
         gid: attr.gid,
         rdev: attr.rdev,
+        version: attr.version,
     }
 }
 
@@ -216,6 +221,7 @@ mod test {
             uid: rng.gen(),
             gid: rng.gen(),
             rdev: rng.gen(),
+            version: rng.gen(),
         }
     }
 

--- a/src/new_storage/backend/backend_impl.rs
+++ b/src/new_storage/backend/backend_impl.rs
@@ -112,7 +112,7 @@ impl BackendImpl {
 #[async_trait]
 impl Backend for BackendImpl {
     #[inline]
-    async fn read(&self, path: &str, buf: &mut [u8]) -> StorageResult<usize> {
+    async fn read(&self, path: &str, buf: &mut [u8], _version: u64) -> StorageResult<usize> {
         let len = buf.len();
         let mut reader = self.operator.reader(path).await?;
         let mut read_size = 0;
@@ -140,7 +140,7 @@ impl Backend for BackendImpl {
     }
 
     #[inline]
-    async fn write(&self, path: &str, buf: &[u8]) -> StorageResult<()> {
+    async fn write(&self, path: &str, buf: &[u8], _version: u64) -> StorageResult<()> {
         let mut writer = self.operator.writer(path).await?;
         writer.write_all(buf).await?;
         writer.close().await?;
@@ -199,14 +199,15 @@ mod tests {
     async fn test_remove_all() {
         let backend = tmp_fs_backend().unwrap();
         let mut buf = vec![0; 16];
-        backend.write("a/1", &buf).await.unwrap();
-        backend.write("a/2", &buf).await.unwrap();
+        let version = 0;
+        backend.write("a/1", &buf, version).await.unwrap();
+        backend.write("a/2", &buf, version).await.unwrap();
 
         backend.remove_all("a/").await.unwrap();
 
-        let size = backend.read("a/1", &mut buf).await.unwrap();
+        let size = backend.read("a/1", &mut buf, version).await.unwrap();
         assert_eq!(size, 0);
-        let size = backend.read("a/2", &mut buf).await.unwrap();
+        let size = backend.read("a/2", &mut buf, version).await.unwrap();
         assert_eq!(size, 0);
     }
 }

--- a/src/new_storage/backend/memory_backend.rs
+++ b/src/new_storage/backend/memory_backend.rs
@@ -31,7 +31,7 @@ impl Debug for MemoryBackend {
 #[async_trait]
 impl Backend for MemoryBackend {
     #[inline]
-    async fn read(&self, path: &str, buf: &mut [u8]) -> StorageResult<usize> {
+    async fn read(&self, path: &str, buf: &mut [u8], _version: u64) -> StorageResult<usize> {
         // mock latency
         tokio::time::sleep(self.latency).await;
 
@@ -50,7 +50,7 @@ impl Backend for MemoryBackend {
     }
 
     #[inline]
-    async fn write(&self, path: &str, buf: &[u8]) -> StorageResult<()> {
+    async fn write(&self, path: &str, buf: &[u8], _version: u64) -> StorageResult<()> {
         // mock latency
         tokio::time::sleep(self.latency).await;
         self.map.insert(path.to_owned(), buf.to_vec());
@@ -107,14 +107,15 @@ mod tests {
     async fn test_remove_all() {
         let backend = MemoryBackend::new(Duration::from_millis(0));
         let mut buf = vec![0; 16];
-        backend.write("a/1", &buf).await.unwrap();
-        backend.write("a/2", &buf).await.unwrap();
+        let version = 0;
+        backend.write("a/1", &buf, version).await.unwrap();
+        backend.write("a/2", &buf, version).await.unwrap();
 
         backend.remove_all("a/").await.unwrap();
 
-        let size = backend.read("a/1", &mut buf).await.unwrap();
+        let size = backend.read("a/1", &mut buf, version).await.unwrap();
         assert_eq!(size, 0);
-        let size = backend.read("a/2", &mut buf).await.unwrap();
+        let size = backend.read("a/2", &mut buf, version).await.unwrap();
         assert_eq!(size, 0);
     }
 }

--- a/src/new_storage/block.rs
+++ b/src/new_storage/block.rs
@@ -44,7 +44,13 @@ pub struct Block {
     /// The dirty flag
     dirty: bool,
     /// The version of the block
-    version: usize,
+    version: u64,
+}
+
+impl AsRef<[u8]> for Block {
+    fn as_ref(&self) -> &[u8] {
+        &self.data
+    }
 }
 
 impl Debug for Block {
@@ -75,8 +81,13 @@ impl Block {
 
     /// Returns the current version of the block.
     #[must_use]
-    pub fn version(&self) -> usize {
+    pub fn version(&self) -> u64 {
         self.version
+    }
+
+    /// Set the version of the block.
+    pub fn set_version(&mut self, version: u64) {
+        self.version = version;
     }
 
     /// Increments the version of the block.

--- a/src/new_storage/storage_manager/manager.rs
+++ b/src/new_storage/storage_manager/manager.rs
@@ -82,9 +82,15 @@ impl<M: MetaData + Send + Sync + 'static> Storage for StorageManager<M> {
     /// Reads data from a file specified by the file handle, starting at the
     /// given offset and reading up to `len` bytes.
     #[inline]
-    async fn read(&self, ino: u64, offset: u64, len: usize) -> StorageResult<Vec<u8>> {
+    async fn read(
+        &self,
+        ino: u64,
+        offset: u64,
+        len: usize,
+        version: u64,
+    ) -> StorageResult<Vec<u8>> {
         match self.get_handle(ino).await {
-            Some(fh) => fh.read(offset, len.cast()).await,
+            Some(fh) => fh.read(offset, len.cast(), version).await,
             None => Err(StorageError::Internal(anyhow::anyhow!(
                 "This file handle is not exists."
             ))),
@@ -94,9 +100,16 @@ impl<M: MetaData + Send + Sync + 'static> Storage for StorageManager<M> {
     /// Writes data to a file specified by the file handle, starting at the
     /// given offset.
     #[inline]
-    async fn write(&self, ino: u64, offset: u64, buf: &[u8], size: u64) -> StorageResult<()> {
+    async fn write(
+        &self,
+        ino: u64,
+        offset: u64,
+        buf: &[u8],
+        size: u64,
+        version: u64,
+    ) -> StorageResult<()> {
         match self.get_handle(ino).await {
-            Some(fh) => fh.write(offset, buf, size).await,
+            Some(fh) => fh.write(offset, buf, size, version).await,
             None => {
                 panic!("Cannot write to a file that is not open.");
             }
@@ -130,10 +143,16 @@ impl<M: MetaData + Send + Sync + 'static> Storage for StorageManager<M> {
     /// Truncates a file specified by the inode number to a new size, given the
     /// old size.
     #[inline]
-    async fn truncate(&self, ino: u64, old_size: u64, new_size: u64) -> StorageResult<()> {
+    async fn truncate(
+        &self,
+        ino: u64,
+        old_size: u64,
+        new_size: u64,
+        version: u64,
+    ) -> StorageResult<()> {
         info!(
-            "truncate: ino: {} old_size: {} new_size: {}",
-            ino, old_size, new_size
+            "truncate: ino: {} old_size: {} new_size: {} version: {}",
+            ino, old_size, new_size, version
         );
         // If new_size == old_size, do nothing
         if new_size >= old_size {
@@ -162,7 +181,7 @@ impl<M: MetaData + Send + Sync + 'static> Storage for StorageManager<M> {
             let fill_content = vec![0; fill_size];
             match self.get_handle(ino).await {
                 Some(fh) => {
-                    fh.write(new_size, &fill_content, new_size).await?;
+                    fh.write(new_size, &fill_content, new_size, version).await?;
                 }
                 None => {
                     panic!("Cannot write to a file that is not open.");

--- a/src/new_storage/storage_manager/tests.rs
+++ b/src/new_storage/storage_manager/tests.rs
@@ -91,9 +91,10 @@ fn check_data(data: &[u8], user_index: u64) {
 async fn warm_up(storage: Arc<StorageManager<S3MetaData>>, ino: u64) {
     let _fh = CURRENT_FD.fetch_add(1, Ordering::SeqCst);
     storage.open(ino, FileAttr::default()).await;
+    let version = 0;
     for i in 0..TOTAL_TEST_BLOCKS {
         let buf = storage
-            .read(ino, (i * IO_SIZE) as u64, IO_SIZE)
+            .read(ino, (i * IO_SIZE) as u64, IO_SIZE, version)
             .await
             .unwrap();
         assert_eq!(buf.len(), IO_SIZE);
@@ -103,9 +104,10 @@ async fn warm_up(storage: Arc<StorageManager<S3MetaData>>, ino: u64) {
 async fn seq_read(storage: Arc<StorageManager<S3MetaData>>, ino: u64) {
     let _fh = CURRENT_FD.fetch_add(1, Ordering::SeqCst);
     storage.open(ino, FileAttr::default()).await;
+    let version = 0;
     for i in 0..TOTAL_TEST_BLOCKS {
         let buf = storage
-            .read(ino, (i * IO_SIZE) as u64, IO_SIZE)
+            .read(ino, (i * IO_SIZE) as u64, IO_SIZE, version)
             .await
             .unwrap();
         assert_eq!(buf.len(), IO_SIZE);
@@ -118,6 +120,7 @@ async fn create_a_file(storage: Arc<StorageManager<S3MetaData>>, ino: u64) {
     let _fh = CURRENT_FD.fetch_add(1, Ordering::SeqCst);
     storage.open(ino, FileAttr::default()).await;
     let start = std::time::Instant::now();
+    let version = 0;
     for i in 0..TOTAL_TEST_BLOCKS {
         let mut content = Vec::new();
         modify_data(&mut content, i as u64);
@@ -127,6 +130,7 @@ async fn create_a_file(storage: Arc<StorageManager<S3MetaData>>, ino: u64) {
                 (i * IO_SIZE) as u64,
                 &content,
                 ((i + 1) * IO_SIZE) as u64,
+                version,
             )
             .await
             .unwrap();
@@ -168,11 +172,8 @@ async fn concurrency_read() {
         BLOCK_SIZE,
         metadata_client,
     ));
-    println!("111");
     create_a_file(Arc::clone(&storage), 10).await;
-    println!("222");
     warm_up(Arc::clone(&storage), 10).await;
-    println!("333");
     // Concurrency read ,thread num : 1,2,4,8
     for i in 0..5 {
         let mut tasks = vec![];
@@ -264,9 +265,10 @@ async fn scan_worker(storage: Arc<StorageManager<S3MetaData>>, ino: u64, time: u
     let start = tokio::time::Instant::now();
     let mut i = 0;
     let mut scan_cnt = 0;
+    let version = 0;
     while tokio::time::Instant::now() - start < tokio::time::Duration::from_secs(time) {
         let buf = storage
-            .read(ino, (i * IO_SIZE) as u64, IO_SIZE)
+            .read(ino, (i * IO_SIZE) as u64, IO_SIZE, version)
             .await
             .unwrap();
         assert_eq!(buf.len(), IO_SIZE);
@@ -290,8 +292,9 @@ async fn get_worker(storage: Arc<StorageManager<S3MetaData>>, ino: u64, time: u6
         // 使用 Zipfian 分布来选择数据块 ID
         let i = zipf.sample(&mut thread_rng()) as usize % TOTAL_TEST_BLOCKS;
 
+        let version = 0;
         let buf = storage
-            .read(ino, (i * IO_SIZE) as u64, IO_SIZE)
+            .read(ino, (i * IO_SIZE) as u64, IO_SIZE, version)
             .await
             .unwrap();
         assert_eq!(buf.len(), IO_SIZE);
@@ -394,57 +397,63 @@ async fn test_truncate() {
     let block_size: u64 = BLOCK_SIZE.cast();
     let mut buffer = vec![0; BLOCK_SIZE];
 
+    let version = 0;
     let _fh = CURRENT_FD.fetch_add(1, Ordering::SeqCst);
     storage.open(ino, FileAttr::default()).await;
-    storage.write(ino, 0, &content, block_size).await.unwrap();
+    storage
+        .write(ino, 0, &content, block_size, version)
+        .await
+        .unwrap();
     storage.close(ino).await.unwrap();
+    let version = 0;
     let size = backend
-        .read(&format_path(ino, 1), &mut buffer)
+        .read(&format_path(ino, 1), &mut buffer, version)
         .await
         .unwrap();
     assert_eq!(size, BLOCK_SIZE);
     let size = backend
-        .read(&format_path(ino, 2), &mut buffer)
+        .read(&format_path(ino, 2), &mut buffer, version)
         .await
         .unwrap();
     assert_eq!(size, 0);
 
+    let version = 0;
     // Truncate to a greater size, noop
     storage.open(ino, FileAttr::default()).await;
     storage
-        .truncate(ino, block_size * 2, block_size * 3)
+        .truncate(ino, block_size * 2, block_size * 3, version)
         .await
         .unwrap();
     storage.close(ino).await.unwrap();
 
     let size = backend
-        .read(&format_path(ino, 2), &mut buffer)
+        .read(&format_path(ino, 2), &mut buffer, version)
         .await
         .unwrap();
     assert_eq!(size, 0);
 
     storage.open(ino, FileAttr::default()).await;
     storage
-        .truncate(ino, block_size * 2, block_size)
+        .truncate(ino, block_size * 2, block_size, version)
         .await
         .unwrap();
     storage.close(ino).await.unwrap();
 
     let size = backend
-        .read(&format_path(ino, 1), &mut buffer)
+        .read(&format_path(ino, 1), &mut buffer, version)
         .await
         .unwrap();
     assert_eq!(size, 0);
 
     storage.open(ino, FileAttr::default()).await;
     storage
-        .truncate(ino, block_size, block_size / 2)
+        .truncate(ino, block_size, block_size / 2, version)
         .await
         .unwrap();
     storage.close(ino).await.unwrap();
 
     let size = backend
-        .read(&format_path(ino, 0), &mut buffer)
+        .read(&format_path(ino, 0), &mut buffer, version)
         .await
         .unwrap();
     assert_eq!(size, BLOCK_SIZE);
@@ -453,7 +462,10 @@ async fn test_truncate() {
     assert_eq!(truncated_content, buffer);
 
     storage.open(ino, FileAttr::default()).await;
-    storage.truncate(ino, block_size / 2, 0).await.unwrap();
+    storage
+        .truncate(ino, block_size / 2, 0, version)
+        .await
+        .unwrap();
     storage.close(ino).await.unwrap();
 }
 
@@ -475,24 +487,27 @@ async fn test_remove() {
     let content = vec![6_u8; BLOCK_SIZE * 2];
     let ino = 0;
     let mut buffer = vec![0; BLOCK_SIZE];
+    let version = 0;
 
     let _fh = CURRENT_FD.fetch_add(1, Ordering::SeqCst);
     storage.open(ino, FileAttr::default()).await;
     storage
-        .write(ino, 0, &content, BLOCK_SIZE.cast())
+        .write(ino, 0, &content, BLOCK_SIZE.cast(), version)
         .await
         .unwrap();
     storage.close(ino).await.unwrap();
 
     storage.remove(ino).await.unwrap();
 
+    let version = 0;
+
     let size = backend
-        .read(&format_path(ino, 0), &mut buffer)
+        .read(&format_path(ino, 0), &mut buffer, version)
         .await
         .unwrap();
     assert_eq!(size, 0);
     let size = backend
-        .read(&format_path(ino, 1), &mut buffer)
+        .read(&format_path(ino, 1), &mut buffer, version)
         .await
         .unwrap();
     assert_eq!(size, 0);

--- a/src/new_storage/storage_trait.rs
+++ b/src/new_storage/storage_trait.rs
@@ -27,16 +27,37 @@ pub trait Storage {
 
     /// Reads data from a file specified by the inode number and file handle,
     /// starting at the given offset and reading up to `len` bytes.
-    async fn read(&self, ino: u64, offset: u64, len: usize) -> StorageResult<Vec<u8>>;
+    /// version is used to check if the file has been modified since the last read.
+    async fn read(&self, ino: u64, offset: u64, len: usize, version: u64)
+        -> StorageResult<Vec<u8>>;
 
     /// Writes data to a file specified by the inode number and file handle,
     /// starting at the given offset.
+    /// version is used to check if the file has been modified since the last write,
+    /// current write implementation might need to read the file from storage first,
+    /// so this function need to sync with read function.
     /// The `size` parameter is the size of hole file in this operation.
-    async fn write(&self, ino: u64, offset: u64, buf: &[u8], size: u64) -> StorageResult<()>;
+    async fn write(
+        &self,
+        ino: u64,
+        offset: u64,
+        buf: &[u8],
+        size: u64,
+        version: u64,
+    ) -> StorageResult<()>;
 
     /// Truncates a file specified by the inode number to a new size,
     /// given the old size and the new size.
-    async fn truncate(&self, ino: u64, old_size: u64, new_size: u64) -> StorageResult<()>;
+    /// version is used to check if the file has been modified since the last truncate.
+    /// current truncate implementation might need to read the file from storage first,
+    /// so this function need to sync with read function.
+    async fn truncate(
+        &self,
+        ino: u64,
+        old_size: u64,
+        new_size: u64,
+        version: u64,
+    ) -> StorageResult<()>;
 
     /// Flushes any pending writes to a file specified by the inode number and
     /// file handle.


### PR DESCRIPTION
# Bug

The current file handling mechanism aggressively removes cache, but we want to retain this cache when continuous read/write operations are occurring.

# Fix

Update the cache with a versioning system. The LRU (Least Recently Used) policy will automatically clean up outdated cache entries when memory is insufficient.

Additionally, we can add a `file_version` to each block to quickly identify and discard outdated blocks in access function. The current implementation does not utilize this approach.

## TODO

1. Set version to cache value, write task can access outdate block and write this cache.
2. write 256k & write 4k mechaism for block version and block cache.

benchmark:
1. old policy:
```bash
python3 test_reader.py -n 10
Average read time: 0.21317 s
Maximum read time: 0.24317 s
Minimum read time: 0.18317 s
Median read time: 0.22317 s
```
3. new policy with version:
```bash
python3 test_reader.py -n 10
Average read time: 0.04402 s
Maximum read time: 0.24390 s
Minimum read time: 0.01637 s
Median read time: 0.02104 s
```