### PR TITLE
feat: introduce local cache for KVCache manager.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,6 +794,7 @@ dependencies = [
  "etcd-client",
  "event-listener 2.5.3",
  "flate2",
+ "flume",
  "futures",
  "grpcio",
  "hashbrown 0.14.5",
@@ -808,6 +809,7 @@ dependencies = [
  "mock-etcd",
  "mockall",
  "nix",
+ "num",
  "once_cell",
  "opendal",
  "parking_lot 0.12.2",
@@ -816,6 +818,7 @@ dependencies = [
  "prometheus",
  "protobuf",
  "protoc-grpcio",
+ "radix_trie",
  "rand",
  "rand_distr",
  "ring-io",
@@ -908,6 +911,12 @@ checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "env_logger"
@@ -1091,6 +1100,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1836,6 +1857,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,6 +1901,20 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -1892,6 +1945,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1913,6 +1975,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -2473,6 +2546,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "git+https://github.com/datenlord/radix_trie#68d7db82e240daf8ff41a5edabbf9eaf8187a945"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]
@@ -3175,6 +3257,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,9 @@ hashbrown = "0.14.3"
 rand_distr = "0.4.3"
 serfig = "0.1.0"
 arc-swap = "1.7.1"
+radix_trie = { git = "https://github.com/datenlord/radix_trie" }
+num = "0.4.3"
+flume = "0.11.0"
 
 [build-dependencies]
 protoc-grpcio = "3.0.0"

--- a/src/distribute_kv_cache/local_cache/backend.rs
+++ b/src/distribute_kv_cache/local_cache/backend.rs
@@ -1,0 +1,116 @@
+use async_trait::async_trait;
+use opendal::{raw::oio::ReadExt, services::Fs, ErrorKind, Operator};
+use tokio::io::AsyncWriteExt;
+
+use std::fmt::Debug;
+
+use super::StorageResult;
+
+/// The `Backend` trait represents a backend storage system.
+#[async_trait]
+pub trait Backend: Debug + Send + Sync {
+    /// Reads data from the storage system into the given buffer.
+    async fn read(&self, path: &str, buf: &mut [u8]) -> StorageResult<usize>;
+    /// Stores data from the given buffer into the storage system.
+    async fn store(&self, path: &str, buf: &[u8]) -> StorageResult<()>;
+    /// Removes the data from the storage system.
+    async fn remove(&self, path: &str) -> StorageResult<()>;
+}
+
+/// The `FSBackend` struct represents a backend storage system that uses the filesystem.
+#[derive(Debug)]
+pub struct FSBackend {
+    /// The `Operator` instance used for interacting with the storage system.
+    operator: Operator,
+}
+
+impl FSBackend {
+    /// Creates a new `FSBackend` instance with the given `Operator`.
+    #[must_use]
+    pub fn new(operator: Operator) -> Self {
+        Self { operator }
+    }
+}
+
+impl Default for FSBackend {
+    /// Create a tmp backend
+    #[allow(clippy::unwrap_used)]
+    fn default() -> Self {
+        let mut builder = Fs::default();
+        builder.root("/tmp/backend/");
+        let operator = Operator::new(builder).unwrap().finish();
+        Self { operator }
+    }
+}
+
+#[async_trait]
+impl Backend for FSBackend {
+    /// Reads data from the storage system into the given buffer.
+    #[inline]
+    async fn read(&self, path: &str, buf: &mut [u8]) -> StorageResult<usize> {
+        let mut reader = self.operator.reader(path).await?;
+        let mut read_size = 0;
+
+        loop {
+            // Read data and catch the size
+            let result = reader.read(buf).await;
+            match result {
+                Ok(size) => {
+                    if size == 0 {
+                        break;
+                    }
+                    read_size += size;
+                }
+                Err(e) => {
+                    // If not found just return 0.
+                    if e.kind() == ErrorKind::NotFound {
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(read_size)
+    }
+
+    /// Stores data from the given buffer into the storage system.
+    #[inline]
+    async fn store(&self, path: &str, buf: &[u8]) -> StorageResult<()> {
+        let mut writer = self.operator.writer(path).await?;
+        writer.write_all(buf).await?;
+        writer.close().await?;
+        Ok(())
+    }
+
+    /// Removes the data from the storage system.
+    #[inline]
+    async fn remove(&self, path: &str) -> StorageResult<()> {
+        self.operator.remove_all(path).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use opendal::services::Fs;
+
+    #[tokio::test]
+    async fn test_fs_backend() {
+        let mut builder = Fs::default();
+        builder.root("/tmp/backend/");
+        let operator = Operator::new(builder).unwrap().finish();
+        let backend = FSBackend::new(operator);
+
+        let path = "/tmp/backend/test.txt";
+        let data = b"Hello, world!";
+        backend.store(path, data).await.unwrap();
+
+        let mut buf = vec![0; data.len()];
+        backend.read(path, &mut buf).await.unwrap();
+        assert_eq!(buf, data);
+
+        backend.remove(path).await.unwrap();
+    }
+}

--- a/src/distribute_kv_cache/local_cache/block.rs
+++ b/src/distribute_kv_cache/local_cache/block.rs
@@ -1,0 +1,165 @@
+use std::hash::{Hash, Hasher};
+
+/// Use 512 KB block size
+pub const BLOCK_SIZE: usize = 512 * 1024;
+
+#[derive(Clone, Debug)]
+/// Provide current node meta infos
+pub struct MetaData {
+    /// File attr inum
+    inum: u64,
+    /// Block write time, generated with snowflake
+    version: u64,
+    /// Block offset in file
+    offset: u64,
+    /// Block size
+    size: u64,
+}
+
+impl Eq for MetaData {}
+
+impl PartialEq for MetaData {
+    fn eq(&self, other: &Self) -> bool {
+        self.inum == other.inum
+            && self.version == other.version
+            && self.offset == other.offset
+            && self.size == other.size
+    }
+}
+
+impl Hash for MetaData {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.inum.hash(state);
+        self.version.hash(state);
+        self.offset.hash(state);
+        self.size.hash(state);
+    }
+}
+
+impl MetaData {
+    /// Create a new `MetaData` instance
+    #[must_use]
+    pub fn new(inum: u64, version: u64, offset: u64, size: u64) -> Self {
+        MetaData {
+            inum,
+            version,
+            offset,
+            size,
+        }
+    }
+
+    /// Get the inum of the `MetaData`
+    #[must_use]
+    pub fn get_inum(&self) -> u64 {
+        self.inum
+    }
+
+    /// Get the version of the `MetaData`
+    #[must_use]
+    pub fn get_version(&self) -> u64 {
+        self.version
+    }
+
+    /// Get the offset of the `MetaData`
+    #[must_use]
+    pub fn get_offset(&self) -> u64 {
+        self.offset
+    }
+
+    /// Get the size of the `MetaData`
+    #[must_use]
+    pub fn get_size(&self) -> u64 {
+        self.size
+    }
+
+    /// Convert the `MetaData` to a string
+    #[must_use]
+    pub fn to_id(&self) -> String {
+        format!("{}/{}.block", self.inum, self.offset)
+    }
+
+    /// Create a `MetaData` from a string
+    #[must_use]
+    pub fn from_id(id: &str) -> Option<Self> {
+        let parts: Vec<&str> = id.split('_').collect();
+        if parts.len() != 4 {
+            return None;
+        }
+
+        let inum: u64 = parts.first()?.parse().ok()?;
+        let version: u64 = parts.get(1)?.parse().ok()?;
+        let offset: u64 = parts.get(2)?.parse().ok()?;
+        let size: u64 = parts.get(3)?.parse().ok()?;
+
+        Some(MetaData {
+            inum,
+            version,
+            offset,
+            size,
+        })
+    }
+}
+
+/// Block struct to hold block data and metadata
+#[derive(Clone, Debug)]
+pub struct Block {
+    ///  The metadata of the block
+    meta_data: MetaData,
+    /// The raw data of the block
+    data: bytes::Bytes,
+}
+
+impl Block {
+    /// Create a new Block instance
+    pub fn new(meta_data: MetaData, data: bytes::Bytes) -> Self {
+        // Make sure data length is BLOCK_SIZE
+        // debug_assert!(data.len() == BLOCK_SIZE);
+
+        Block { meta_data, data }
+    }
+
+    /// Get the block inner data of the Block
+    pub fn get_data(&self) -> bytes::Bytes {
+        self.data.clone()
+    }
+
+    /// Get the block meta data of the Block
+    pub fn get_meta_data(&self) -> MetaData {
+        self.meta_data.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_id() {
+        let meta_data = MetaData {
+            inum: 123,
+            version: 456,
+            offset: 789,
+            size: 10,
+        };
+        let expected_id = "123_456_789_10".to_owned();
+        assert_eq!(meta_data.to_id(), expected_id);
+    }
+
+    #[test]
+    fn test_from_id_valid() {
+        let id = "123_456_789_10";
+        let expected_meta_data = MetaData {
+            inum: 123,
+            version: 456,
+            offset: 789,
+            size: 10,
+        };
+        assert_eq!(MetaData::from_id(id), Some(expected_meta_data));
+    }
+
+    #[test]
+    fn test_from_id_invalid() {
+        let id = "123_456_789";
+        assert_eq!(MetaData::from_id(id), None);
+    }
+}

--- a/src/distribute_kv_cache/local_cache/manager.rs
+++ b/src/distribute_kv_cache/local_cache/manager.rs
@@ -1,0 +1,460 @@
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    sync::{atomic::AtomicU64, Arc, RwLock},
+};
+
+use radix_trie::Trie;
+use tracing::{debug, error};
+
+use crate::distribute_kv_cache::local_cache::block::BLOCK_SIZE;
+
+use super::{
+    backend::{Backend, FSBackend},
+    block::{Block, MetaData},
+    policy::{EvictPolicy, LRUPolicy},
+    StorageResult,
+};
+
+/// `CacheManager` struct to manage cache
+#[derive(Debug)]
+pub struct CacheManager<K, P>
+where
+    K: Eq + std::hash::Hash + Clone + Debug,
+    P: EvictPolicy<K>,
+{
+    /// The evict policy
+    policy: P,
+    /// The block cache
+    cache: HashMap<K, Arc<RwLock<Block>>>,
+}
+
+impl<K, P> CacheManager<K, P>
+where
+    K: Eq + std::hash::Hash + Clone + Debug,
+    P: EvictPolicy<K>,
+{
+    /// Create a new `CacheManager`
+    pub fn new(policy: P) -> Self {
+        CacheManager {
+            policy,
+            cache: HashMap::new(),
+        }
+    }
+
+    /// Insert a block into the cache
+    pub fn put(&mut self, key: &K, block: &Arc<RwLock<Block>>) {
+        // If the cache is full, evict the least recently used block
+        if self.cache.len() >= self.policy.capacity() {
+            println!(
+                "Cache {:?} is full policy is {:?}, evict the least recently used block",
+                self.cache.len(),
+                self.policy.size()
+            );
+            if let Some(evicted_block) = self.policy.evict() {
+                println!("Evict block: {evicted_block:?}");
+                // self.cache.remove(&evicted_block.clone());
+                // Safe drop
+                if self.cache.contains_key(&evicted_block) {
+                    println!("Evict block: {evicted_block:?}");
+                    self.cache.remove(&evicted_block);
+                } else {
+                    println!("Evicted block {evicted_block:?} not found in cache!");
+                }
+            }
+        }
+
+        // Insert the block into the cache and update the metadata
+        self.cache.insert(key.clone(), Arc::clone(block));
+        self.policy.access(key);
+        self.policy.set_evictable(key, true);
+    }
+
+    /// Get a block from the cache
+    pub fn get(&self, key: &K) -> Option<Arc<RwLock<Block>>> {
+        if let Some(block) = self.cache.get(key) {
+            // Get the block from the cache and update the policy
+            self.policy.access(key);
+            Some(Arc::clone(block))
+        } else {
+            None
+        }
+    }
+
+    /// Remove a block from the cache
+    pub fn remove(&mut self, key: &K) -> Option<Arc<RwLock<Block>>> {
+        if let Some(block) = self.cache.remove(key) {
+            // Remove the block from the cache and update the policy
+            self.policy.remove(key);
+            Some(block)
+        } else {
+            None
+        }
+    }
+}
+
+/// `BlockManager` is a general-purpose struct for managing blocks at the file level.
+/// It is designed to interact with a storage backend (e.g., local filesystem) and
+/// includes a caching layer to manage block metadata.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct BlockManager {
+    /// CacheManager to manage blocks and metadata
+    cache: Arc<RwLock<CacheManager<MetaData, LRUPolicy<MetaData>>>>,
+    /// Backend to interact with the storage, default is FSBackend, we need to flush block to local fs
+    backend: Arc<dyn Backend>,
+}
+
+impl Default for BlockManager {
+    /// Create a new `KVBlockManager` with default `FSBackend`
+    #[must_use]
+    fn default() -> Self {
+        let backend = Arc::new(FSBackend::default());
+        Self::new(2000, backend)
+    }
+}
+
+impl BlockManager {
+    /// Create a new `BlockManager`
+    pub fn new(capacity: usize, backend: Arc<dyn Backend>) -> Self {
+        // Create a new LRUPolicy with a capacity of capacity
+        // It will evict the least recently used block when the cache is full
+        // TODO: Support mem limit and block size limit， current is block count limit
+        let policy = LRUPolicy::new(capacity);
+        let cache = Arc::new(RwLock::new(CacheManager::new(policy)));
+        BlockManager { cache, backend }
+    }
+
+    /// Try to read the block from the cache, if not found, try to read from the storage
+    /// TODO: We need to compare the meta data version with the latest version in the storage
+    /// If the version is old, we need to read the block from the storage
+    /// If the version is the latest, client need to fetch the latest version
+    #[allow(dead_code)]
+    pub async fn read(&self, meta_data: MetaData) -> StorageResult<Option<Block>> {
+        // Try to read the block from the cache
+        {
+            if let Some(block_ref) = self
+                .cache
+                .read()
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "failed to read the block from the cache, the error is: {}",
+                        e
+                    )
+                })?
+                .get(&meta_data)
+            {
+                let block = block_ref.read().map_err(|e| {
+                    anyhow::anyhow!(
+                        "failed to read the block from the cache, the error is: {}",
+                        e
+                    )
+                })?;
+                return Ok(Some(block.clone()));
+            }
+        }
+
+        // Try to fetch data and update local cache
+        {
+            // Try to read file from fs backend
+            let relative_path = meta_data.to_id();
+            debug!("Read block from backend: {}", relative_path);
+            #[allow(clippy::large_stack_arrays)]
+            let mut buf = [0; BLOCK_SIZE];
+            let size = self
+                .backend
+                .read(&relative_path, &mut buf)
+                .await
+                .unwrap_or_default();
+
+            debug!("Read block size: {}", size);
+
+            // If the size is not equal to BLOCK_SIZE, the block is invalid
+            if size != BLOCK_SIZE {
+                // Remove the invalid block from fs backend
+                self.backend
+                    .remove(&relative_path)
+                    .await
+                    .unwrap_or_default();
+                debug!("Invalid block: {}", relative_path);
+                return Ok(None);
+            }
+
+            let block = Block::new(meta_data.clone(), bytes::Bytes::from(buf.to_vec()));
+
+            // error!("Read block: {:?}", block);
+
+            // Write the block to the cache
+            let block_ref = Arc::new(RwLock::new(block.clone()));
+            self.cache
+                .write()
+                .map_err(|e| anyhow::anyhow!("Failed to write to cache, the error is: {e}"))?
+                .put(&meta_data, &block_ref);
+
+            // error!("Read block: {:?}", block);
+
+            Ok(Some(block))
+        }
+    }
+
+    /// Write the block to the cache
+    /// TODO: Now this operation only support store block to cache and fs storage
+    #[allow(dead_code)]
+    #[allow(clippy::unused_async)]
+    pub async fn write(&mut self, block: &Block) -> StorageResult<()> {
+        let meta = block.get_meta_data();
+        // let relative_path = meta.to_id();
+
+        // Write the block to the cache
+        let block_ref = Arc::new(RwLock::new(block.clone()));
+        self.cache
+            .write()
+            .map_err(|e| anyhow::anyhow!("{e}"))?
+            .put(&meta, &block_ref);
+
+        // Write the block to the storage
+        // 20241210 ignore this op
+        // let _ = self
+        //     .backend
+        //     .store(&relative_path, block.get_data().as_slice())
+        //     .await
+        //     .map_err(|e| format!("Failed to write block: {e}"));
+
+        Ok(())
+    }
+
+    /// Invalidate the block
+    #[allow(dead_code)]
+    pub async fn invalid(&mut self, meta_data: MetaData) -> StorageResult<()> {
+        // Remove the block from the cache
+        self.cache
+            .write()
+            .map_err(|e| anyhow::anyhow!(format!("Failed to remove block: {e}")))?
+            .remove(&meta_data);
+
+        // Remove the block from the storage
+        let relative_path = meta_data.to_id();
+        self.backend.remove(&relative_path).await
+    }
+}
+
+/// `KVBlockManager` is a dedicated structure for managing blocks used in the `KVCache`.
+/// Unlike `BlockManager`, which handles file-level block management, `KVBlockManager`
+/// follows a different usage pattern. Therefore, it is separated into its own struct
+/// for better modularity and maintainability.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct KVBlockManager {
+    /// CacheManager to manage blocks and metadata
+    cache: Arc<RwLock<CacheManager<MetaData, LRUPolicy<MetaData>>>>,
+    /// Backend to interact with the storage, default is FSBackend, we need to flush block to local fs
+    backend: Arc<dyn Backend>,
+}
+
+impl Default for KVBlockManager {
+    /// Create a new `KVBlockManager` with default `FSBackend`
+    #[must_use]
+    fn default() -> Self {
+        let backend = Arc::new(FSBackend::default());
+        Self::new(2000, backend)
+    }
+}
+
+impl KVBlockManager {
+    /// Create a new `KVBlockManager`
+    pub fn new(capacity: usize, backend: Arc<dyn Backend>) -> Self {
+        // Create a new LRUPolicy with a capacity of capacity
+        // It will evict the least recently used block when the cache is full
+        // TODO: Support mem limit and block size limit， current is block count limit
+        // let policy = LRUPolicy::new(10);
+        let policy = LRUPolicy::new(capacity);
+        let cache = Arc::new(RwLock::new(CacheManager::new(policy)));
+        KVBlockManager { cache, backend }
+    }
+
+    /// Try to read the block from the cache, if not found, try to read from the storage
+    /// TODO: We need to compare the meta data version with the latest version in the storage
+    /// If the version is old, we need to read the block from the storage
+    /// If the version is the latest, client need to fetch the latest version
+    #[allow(dead_code)]
+    #[allow(clippy::unused_async)] // We will move to async read
+    pub async fn read(&self, meta_data: MetaData) -> StorageResult<Option<Arc<RwLock<Block>>>> {
+        // Try to read the block from the cache
+        if let Some(block_ref) = self
+            .cache
+            .read()
+            .map_err(|e| anyhow::anyhow!("Failed to read the cache: {:?}", e))?
+            .get(&meta_data)
+        {
+            // let block = block_ref.read().unwrap();
+            return Ok(Some(block_ref));
+        }
+
+        Ok(None)
+    }
+
+    /// Write the block to the cache
+    /// TODO: Now this operation only support store block to cache and fs storage
+    #[allow(dead_code)]
+    #[allow(clippy::unused_async)] // We will move to async write
+    pub async fn write(&self, block: Block) -> StorageResult<()> {
+        let meta = block.get_meta_data();
+        debug!("Write block to cache: {}", meta.to_id());
+        // let relative_path = meta.to_id();
+
+        // Write the block to the cache
+        let block_ref = Arc::new(RwLock::new(block));
+        self.cache
+            .write()
+            .map_err(|e| anyhow::anyhow!("Failed to write block to cache: {e}"))?
+            .put(&meta, &block_ref);
+
+        Ok(())
+    }
+
+    /// Invalidate the block
+    #[allow(dead_code)]
+    pub async fn invalid(&mut self, meta_data: MetaData) -> StorageResult<()> {
+        // Remove the block from the cache
+        self.cache
+            .write()
+            .map_err(|e| anyhow::anyhow!("Failed to write block to cache: {e}"))?
+            .remove(&meta_data);
+
+        // Remove the block from the storage
+        let relative_path = meta_data.to_id();
+        self.backend.remove(&relative_path).await
+    }
+}
+
+/// `IndexManager` struct to manage kv cache index.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct IndexManager<K> {
+    /// Global Radix tree to store prefix index, key is prompt, value is (block id, offset, size, address)
+    index: Arc<RwLock<Trie<Vec<K>, String>>>,
+    /// Global block id allocator
+    id_allocator: AtomicU64,
+}
+
+impl<K> Default for IndexManager<K>
+where
+    K: num::Num + Eq,
+    Vec<K>: radix_trie::TrieKey + Clone,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K> IndexManager<K>
+where
+    K: num::Num + Eq,
+    Vec<K>: radix_trie::TrieKey + Clone,
+{
+    /// Create a new `IndexManager`
+    #[must_use]
+    pub fn new() -> Self {
+        IndexManager {
+            index: Arc::new(RwLock::new(Trie::<Vec<K>, String>::new())),
+            id_allocator: AtomicU64::new(0),
+        }
+    }
+
+    /// Allocate a new block id
+    pub fn allocate_id(&self) -> u64 {
+        self.id_allocator
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Insert a new key-value pair into the index
+    pub fn insert(&self, key: Vec<K>, value: String) {
+        match self.index.write() {
+            Ok(mut write_lock) => {
+                write_lock.insert(key, value);
+            }
+            Err(e) => {
+                error!("Failed to get write lock: {e}");
+            }
+        }
+    }
+
+    /// Remove a key-value pair from the index
+    pub fn remove(&self, key: &Vec<K>) {
+        match self.index.write() {
+            Ok(mut write_lock) => {
+                write_lock.remove(key);
+            }
+            Err(e) => {
+                error!("Failed to get write lock: {e}");
+            }
+        }
+    }
+
+    /// Get the value by key from the index
+    pub fn get(&self, key: &Vec<K>) -> Option<String> {
+        match self.index.read() {
+            Ok(read_lock) => read_lock.get(key).cloned(),
+            Err(e) => {
+                error!("Failed to get read lock: {e}");
+                None
+            }
+        }
+    }
+
+    /// Get longest prefix match value by key from the index and value
+    pub fn get_longest_kv(&self, key: &Vec<K>) -> Option<(Vec<K>, String)> {
+        match self.index.read() {
+            Ok(read_lock) => match read_lock.get_ancestor_key(key) {
+                Some(ancestor_key) => read_lock
+                    .get_ancestor_value(key)
+                    .map(|value| (ancestor_key.clone(), value.clone())),
+                None => None,
+            },
+            Err(e) => {
+                error!("Failed to get read lock: {e}");
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_index_manager() {
+        let index_manager = IndexManager::new();
+        let test_key = vec![1_u32, 2_u32, 3_u32];
+        index_manager.insert(test_key.clone(), "123".to_owned());
+        assert_eq!(index_manager.get(&test_key), Some("123".to_owned()));
+        index_manager.remove(&test_key);
+        assert_eq!(index_manager.get(&test_key), None);
+
+        // Test longest prefix match
+        let test_key = vec![1_u32, 2_u32, 3_u32];
+        let test1_key = vec![1_u32, 2_u32, 3_u32, 4_u32];
+        let test2_key = vec![1_u32, 2_u32, 3_u32, 5_u32];
+        let test3_key = vec![1_u32, 2_u32, 3_u32, 6_u32];
+        index_manager.insert(test_key.clone(), "123".to_owned());
+        index_manager.insert(test1_key.clone(), "1234".to_owned());
+        index_manager.insert(test2_key.clone(), "12345".to_owned());
+        assert_eq!(
+            index_manager.get_longest_kv(&test_key),
+            Some((test_key.clone(), "123".to_owned()))
+        );
+        assert_eq!(
+            index_manager.get_longest_kv(&test1_key),
+            Some((test1_key.clone(), "1234".to_owned()))
+        );
+        assert_eq!(
+            index_manager.get_longest_kv(&test2_key),
+            Some((test2_key.clone(), "12345".to_owned()))
+        );
+        assert_eq!(
+            index_manager.get_longest_kv(&test3_key),
+            Some((test_key.clone(), "123".to_owned()))
+        );
+    }
+}

--- a/src/distribute_kv_cache/local_cache/mod.rs
+++ b/src/distribute_kv_cache/local_cache/mod.rs
@@ -1,0 +1,38 @@
+use thiserror::Error;
+
+/// The backend wrapper of `openDAL` operator.
+pub mod backend;
+
+/// The block module.
+pub mod block;
+
+/// The manager of memory cache module.
+pub mod manager;
+
+/// The policy module.
+pub mod policy;
+
+/// The result of storage operation.
+pub type StorageResult<T> = Result<T, StorageError>;
+
+/// An error occurs in storage operation.
+#[derive(Debug, Error)]
+pub enum StorageError {
+    /// The storage operation is out of range of a block
+    #[error("{found} is out of range of {maximum}")]
+    OutOfRange {
+        /// The maximum size of the operated block
+        maximum: usize,
+        /// The size or offset found in argument
+        found: usize,
+    },
+    /// An error caused by [`std::io::Error`]
+    #[error("{0}")]
+    StdIoError(#[from] std::io::Error),
+    /// An error caused by [`opendal::Error`]
+    #[error("{0}")]
+    OpenDalError(#[from] opendal::Error),
+    /// A internal storage error.
+    #[error("{0}")]
+    Internal(#[from] anyhow::Error),
+}

--- a/src/distribute_kv_cache/local_cache/policy.rs
+++ b/src/distribute_kv_cache/local_cache/policy.rs
@@ -1,0 +1,224 @@
+//! The LRU policy implementation.
+
+use std::hash::Hash;
+
+use hashlink::LinkedHashMap;
+use parking_lot::Mutex;
+
+/// The evict policy trait.
+pub trait EvictPolicy<K> {
+    /// Create a new policy with the given capacity.
+    fn new(capacity: usize) -> Self;
+
+    /// Create a new non-evictable entry if the key has not been seen before.
+    fn access(&self, key: &K);
+
+    /// Try to evict a evictable key by the policy.
+    fn evict(&self) -> Option<K>;
+
+    /// Toggle whether a key is evictable or non-evictable.
+    fn set_evictable(&self, key: &K, evictable: bool);
+
+    /// Decrement the size of the policy when a key is removed successfully.
+    fn remove(&self, key: &K);
+
+    /// Get the current size of the policy.
+    fn size(&self) -> usize;
+
+    /// Get the capacity of the policy.
+    fn capacity(&self) -> usize;
+}
+
+/// The evict policy based on LRU.
+#[derive(Debug)]
+pub struct LRUPolicy<K>
+where
+    K: Clone + Hash + Eq,
+{
+    /// The inner map
+    inner: Mutex<LinkedHashMap<K, bool>>,
+    /// The capacity of this policy
+    capacity: usize,
+}
+
+impl<K: Clone + Hash + Eq> EvictPolicy<K> for LRUPolicy<K> {
+    #[must_use]
+    #[inline]
+    fn new(capacity: usize) -> Self {
+        LRUPolicy {
+            inner: Mutex::new(LinkedHashMap::with_capacity(capacity)),
+            capacity,
+        }
+    }
+
+    #[inline]
+    fn access(&self, key: &K) {
+        {
+            let mut inner = self.inner.lock();
+            // Move the accessed key to the end to mark it as most recently used.
+            // If the key does not exist, it inserts a new entry marked as non-evictable by
+            // default (false).
+            if inner.contains_key(key) {
+                inner.to_back(key);
+            } else {
+                // Before adding a new key, check if we reach the capacity.
+                // Reach the capacity, panic
+                // This should be handled by the caller, not the policy.
+                assert!(inner.len() != self.capacity, "Capacity reached");
+                inner.insert(key.clone(), false);
+            }
+        }
+        self.set_evictable(key, false);
+    }
+
+    #[inline]
+    fn evict(&self) -> Option<K> {
+        let mut inner = self.inner.lock();
+        let mut evict_key = None;
+        // Find the first evictable key from the beginning.
+        for (key, evictable) in inner.iter() {
+            if *evictable {
+                evict_key = Some(key.clone());
+                break;
+            }
+        }
+        let key = evict_key?;
+        inner.remove(&key); // This automatically decrements the size.
+        Some(key)
+    }
+
+    #[inline]
+    fn set_evictable(&self, key: &K, evictable: bool) {
+        let mut inner = self.inner.lock();
+        if let Some(prev_evictable) = inner.get_mut(key) {
+            *prev_evictable = evictable;
+        } else {
+            // This should not happen.
+            panic!("LRUPolicy::set_evictable : Key not found");
+        }
+    }
+
+    #[inline]
+    fn remove(&self, key: &K) {
+        let mut inner = self.inner.lock();
+        let evictable = inner.get(key);
+        if let Some(evictable) = evictable {
+            if *evictable {
+                inner.remove(key);
+            }
+        } else {
+            // This should not happen.
+            panic!("LRUPolicy::remove : Key not found");
+        }
+    }
+
+    #[inline]
+    fn size(&self) -> usize {
+        self.inner.lock().len()
+    }
+
+    #[inline]
+    fn capacity(&self) -> usize {
+        self.capacity
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::default_numeric_fallback)]
+mod tests {
+    use super::{EvictPolicy, LRUPolicy};
+
+    /// Create a `LruPolicy` of `i32`, with keys `1 -> 2 -> 3`.
+    fn create_lru() -> LRUPolicy<i32> {
+        let cache = LRUPolicy::<i32>::new(3);
+
+        cache.access(&1);
+        cache.access(&2);
+        cache.access(&3);
+
+        cache.set_evictable(&1, true);
+        cache.set_evictable(&2, true);
+        cache.set_evictable(&3, true);
+        assert!(cache.size() == 3);
+        cache
+    }
+
+    #[test]
+    #[should_panic(expected = "Capacity reached")]
+    fn test_insert_full() {
+        let cache = create_lru();
+        cache.access(&4);
+    }
+
+    #[test]
+    fn test_evict() {
+        let cache = create_lru();
+
+        let evicted = cache.evict();
+        assert_eq!(evicted, Some(1));
+
+        // 2 -> 3
+        cache.access(&4);
+    }
+
+    #[test]
+    fn test_touch() {
+        let cache = create_lru();
+
+        cache.access(&1);
+
+        // 2 -> 3 -> 1
+        let evicted = cache.evict();
+        assert_eq!(evicted, Some(2));
+    }
+
+    #[test]
+    fn test_remove() {
+        let cache = create_lru();
+
+        cache.remove(&1);
+        assert_eq!(cache.size(), 2);
+    }
+
+    #[test]
+    fn sample_evict_test() {
+        let cache = LRUPolicy::<i32>::new(7);
+
+        for i in 1..7 {
+            cache.access(&i);
+            cache.set_evictable(&i, true);
+        }
+        assert_eq!(cache.size(), 6);
+        cache.access(&1);
+
+        assert_eq!(cache.evict(), Some(2));
+        assert_eq!(cache.evict(), Some(3));
+        assert_eq!(cache.evict(), Some(4));
+
+        // 5-> 6 -> 1
+        assert_eq!(cache.size(), 3);
+
+        // 5 -> 6 -> 1 -> 7
+        cache.access(&7);
+
+        // 5 -> 6 -> 7 -> 1
+        cache.access(&1);
+
+        // 5 -> 7 -> 1 -> 6
+        cache.access(&6);
+
+        cache.set_evictable(&5, true);
+        cache.set_evictable(&6, true);
+        cache.set_evictable(&1, true);
+
+        // Since 7 is not evictable, it should be evicted.
+        assert_eq!(cache.evict(), Some(5));
+        assert_eq!(cache.evict(), Some(1));
+        assert_eq!(cache.evict(), Some(6));
+        assert_eq!(cache.evict(), None);
+
+        // Set 7 as evictable
+        cache.set_evictable(&7, true);
+        assert_eq!(cache.evict(), Some(7));
+    }
+}

--- a/src/distribute_kv_cache/mod.rs
+++ b/src/distribute_kv_cache/mod.rs
@@ -1,0 +1,4 @@
+//! Distributed cache module
+
+/// Local in-memory cache
+pub mod local_cache;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ pub mod async_fuse;
 pub mod common;
 /// Configurations
 pub mod config;
+pub mod distribute_kv_cache;
 pub mod fs;
 pub mod metrics;
 pub mod new_storage;


### PR DESCRIPTION
# Background

Implement `Backend` trait and `FSBackend` struct for filesystem-based storage

### Design

- Added `Backend` trait with `read`, `store`, and `remove` methods.
- Implemented `FSBackend` struct using `opendal::services::Fs` for filesystem operations.
- Added tests to verify `FSBackend` functionality with basic storage operations.