### PR TITLE
feat: add cluster manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,6 +794,7 @@ dependencies = [
  "etcd-client",
  "event-listener 2.5.3",
  "flate2",
+ "flume",
  "futures",
  "grpcio",
  "hashbrown 0.14.5",
@@ -808,6 +809,7 @@ dependencies = [
  "mock-etcd",
  "mockall",
  "nix",
+ "num",
  "once_cell",
  "opendal",
  "parking_lot 0.12.2",
@@ -1091,6 +1093,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1836,6 +1850,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,6 +1885,20 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -1892,6 +1929,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1913,6 +1959,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3175,6 +3232,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,6 +818,7 @@ dependencies = [
  "prometheus",
  "protobuf",
  "protoc-grpcio",
+ "radix_trie",
  "rand",
  "rand_distr",
  "ring-io",
@@ -910,6 +911,12 @@ checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "env_logger"
@@ -1859,6 +1866,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,6 +2546,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "git+https://github.com/IRONICBo/rust_radix_trie#68d7db82e240daf8ff41a5edabbf9eaf8187a945"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ hashbrown = "0.14.3"
 rand_distr = "0.4.3"
 serfig = "0.1.0"
 arc-swap = "1.7.1"
+radix_trie = { git = "https://github.com/IRONICBo/rust_radix_trie" }
 num = "0.4.3"
 flume = "0.11.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,8 @@ hashbrown = "0.14.3"
 rand_distr = "0.4.3"
 serfig = "0.1.0"
 arc-swap = "1.7.1"
+num = "0.4.3"
+flume = "0.11.0"
 
 [build-dependencies]
 protoc-grpcio = "3.0.0"

--- a/src/distribute_kv_cache/cluster/cluster_manager.rs
+++ b/src/distribute_kv_cache/cluster/cluster_manager.rs
@@ -1,0 +1,1256 @@
+//! The utilities of distribute cache cluster management
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use arc_swap::{ArcSwap, ArcSwapOption};
+use futures::StreamExt;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use crate::common::error::{DatenLordError, DatenLordResult};
+use crate::fs::kv_engine::etcd_impl::Session;
+use crate::fs::kv_engine::{KVEngine, SetOption};
+use crate::fs::kv_engine::{KVEngineType, KeyType, ValueType};
+
+use super::node::{MasterNodeInfo, Node, NodeStatus};
+use super::ring::Ring;
+
+/// The timeout for current node's session
+const SESSION_TIMEOUT_SEC: u64 = 10;
+
+/// This struct is used to interact with etcd server and manager the cluster.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct ClusterManager {
+    /// inner struct
+    inner: Arc<ClusterManagerInner>,
+}
+
+impl ClusterManager {
+    /// Create new cluster manager
+    pub fn new(kv_engine: Arc<KVEngineType>, node: Node) -> Self {
+        let inner = Arc::new(ClusterManagerInner::new(kv_engine, node));
+        Self { inner }
+    }
+
+    /// Get current node
+    #[must_use]
+    pub fn get_current_node(&self) -> Node {
+        self.inner.get_current_node()
+    }
+
+    /// Get master node
+    #[must_use]
+    pub async fn get_master_node(&self) -> DatenLordResult<MasterNodeInfo> {
+        self.inner.get_master_node().await
+    }
+
+    /// Get current hashring
+    pub async fn get_ring(&self) -> DatenLordResult<Ring<Node>> {
+        self.inner.get_ring(false).await
+    }
+
+    /// Get all nodes
+    pub async fn get_nodes(&self) -> DatenLordResult<Vec<Node>> {
+        self.inner.get_nodes(false).await
+    }
+
+    /// Get node by hashring index
+    pub async fn get_node(&self, key: String) -> DatenLordResult<Node> {
+        let ring = self.get_ring().await?;
+        debug!("Get node by key: {:?} ring: {:?}", key, ring);
+        if let Some(node) = ring.get_node(&key) {
+            return Ok(node.clone());
+        }
+
+        return Err(DatenLordError::CacheClusterErr {
+            context: vec![format!("Failed to get node by key: {:?}", key)],
+        });
+    }
+
+    /// Watch the distribute cache nodes info,
+    /// this function is used for client to watch the ring update
+    pub async fn watch_ring(&self, token: CancellationToken) -> DatenLordResult<()> {
+        self.inner.watch_ring(token).await
+    }
+
+    /// If current hashring version is not matched, we need to update the hashring manaually in client
+    pub async fn get_ring_force(&self) -> DatenLordResult<Ring<Node>> {
+        self.inner.get_ring(true).await
+    }
+
+    ///  Stop the cluster manager
+    pub fn stop(&self) {
+        // In this step, we just to clean session and force down the cluster manager
+        self.inner.clean_sessions();
+    }
+
+    /// Run the cluster manager as state machine
+    ///
+    /// We need to perpare current node info, current node list and generate hash ring info
+    pub async fn run(&self) -> DatenLordResult<()> {
+        loop {
+            // 0. Prepare for the session
+            self.inner.prepare().await?;
+
+            // 1. Init cluster manager
+            debug!(
+                "Cluster manager start to run in node: {:?}",
+                self.inner.get_current_node().endpoint()
+            );
+            let mut current_node_info = self.inner.get_current_node();
+            // Next step is to register the node
+            current_node_info.set_status(NodeStatus::Registering);
+            self.inner.update_node(current_node_info);
+            self.inner.update_node_in_cluster().await?;
+
+            let mut current_node_info = self.inner.get_current_node();
+            // 2. Register node to etcd
+            debug!(
+                "Current node {:?} status: {:?}",
+                current_node_info.endpoint(),
+                current_node_info.status()
+            );
+            while self.inner.register().await.is_err() {
+                warn!("Failed to register node, retry in 5s");
+                // Try to register node to etcd
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+            // Update node status to Registering
+            current_node_info.set_status(NodeStatus::Slave);
+            self.inner.update_node(current_node_info);
+            self.inner.update_node_in_cluster().await?;
+
+            // 2. Register node to etcd
+            let mut current_node_info = self.inner.get_current_node();
+            debug!(
+                "Current node {:?} status: {:?}",
+                current_node_info.endpoint(),
+                current_node_info.status()
+            );
+            // 3. Do campaign
+            let (campaign_status, campaign_val) = self.inner.do_campaign().await?;
+            debug!(
+                "Node: {:?} Campaign status: {:?} val: {:?}",
+                current_node_info.endpoint(),
+                campaign_status,
+                campaign_val
+            );
+            if campaign_status {
+                // Update node status to Master
+                current_node_info.set_status(NodeStatus::Master);
+                self.inner.update_node(current_node_info);
+                self.inner.update_node_in_cluster().await?;
+            }
+
+            // 4. Serve as normal status
+            let current_node_info = self.inner.get_current_node();
+            match current_node_info.status() {
+                // Serve as slave node
+                NodeStatus::Slave => match self.do_slave_tasks().await {
+                    Ok(()) => {
+                        debug!(
+                            "Current node {:?} status: {:?} will change to campaign",
+                            current_node_info.endpoint(),
+                            current_node_info.status()
+                        );
+                    }
+                    Err(e) => {
+                        warn!("Failed to do slave tasks: {:?}", e);
+                    }
+                },
+                // Serve as master node
+                NodeStatus::Master => match self.do_master_tasks().await {
+                    Ok(()) => {
+                        debug!(
+                            "Current node {:?} status: {:?} will change to campaign",
+                            current_node_info.endpoint(),
+                            current_node_info.status()
+                        );
+                    }
+                    Err(e) => {
+                        warn!("Failed to do master tasks: {:?}", e);
+                    }
+                },
+                // Other parts can not
+                NodeStatus::Initializing | NodeStatus::Registering => {
+                    // Clean up tasks
+                    self.inner.clean_sessions();
+                }
+            }
+        }
+    }
+
+    /// Do master tasks
+    ///
+    /// 1. Master node will watch the node list update, and update the ring
+    /// 2. Master will check self
+    async fn do_master_tasks(&self) -> DatenLordResult<()> {
+        let current_node_info = self.inner.get_current_node();
+        debug!(
+            "do_master_tasks: {:?} will watch the node list update, and update the ring",
+            current_node_info.endpoint()
+        );
+
+        // Keep alive master key
+        // Check current status
+        if current_node_info.status() != NodeStatus::Master {
+            // If the node status is not master, clean up master tasks and return
+            warn!(
+                "Current node {:?} status is not master, return to endpoint",
+                current_node_info.endpoint()
+            );
+
+            return Ok(());
+        }
+
+        // Check current cluster hashring info, try to update it or init it
+        match self.inner.update_cluster_topo().await {
+            Ok(()) => {
+                debug!("Update cluster topo success");
+            }
+            Err(e) => {
+                warn!("Failed to update cluster topo: {:?}", e);
+                return Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Failed to update cluster topo: {:?}", e)],
+                });
+            }
+        }
+
+        // Do watch node list update task
+        // This task will block until the master status changed
+        self.inner.watch_nodes().await.with_context(|| {
+            format!(
+                "Current node {:?} Failed to watch the node list update, and update the ring",
+                current_node_info.endpoint()
+            )
+        })?;
+
+        Ok(())
+    }
+
+    /// Do slave tasks
+    ///
+    /// Slave node will watch the ring update and campaign master
+    #[allow(clippy::arithmetic_side_effects, clippy::pattern_type_mismatch)] // The `select!` macro will generate code that goes against these rules.
+    async fn do_slave_tasks(&self) -> DatenLordResult<()> {
+        // Try to watch master and hashring
+        // Wait for status update
+        let current_node_info = self.inner.get_current_node();
+        debug!(
+            "do_slave_tasks: Node {:?} will watch the ring update and campaign master",
+            current_node_info.endpoint()
+        );
+        // Check the node status
+        if current_node_info.status() != NodeStatus::Slave {
+            return Ok(());
+        }
+
+        // Block here, try to watch master
+        // If the master is down and return ok, the slave node will try to get the master lock
+        // If watch_master failed, we will retry to watch master
+        self.inner.watch_master().await?;
+
+        Ok(())
+    }
+}
+
+/// Inner struct of cluster manager
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct ClusterManagerInner {
+    /// Etcd client
+    kv_engine: Arc<KVEngineType>,
+    /// Node session, try to keep the session alive, we will set the session in run method
+    node_session: ArcSwapOption<Session>,
+    /// current node info
+    node: ArcSwap<Node>,
+    /// current node list, we will set the session in run method
+    node_list: ArcSwap<Vec<Node>>,
+    /// current hash ring, we will set the session in run method
+    hash_ring: ArcSwap<Ring<Node>>,
+    // TODO: Support distribute cluster config here
+}
+
+#[allow(dead_code)]
+impl ClusterManagerInner {
+    /// Create a new cluster manager
+    pub fn new(kv_engine: Arc<KVEngineType>, node: Node) -> Self {
+        let node_session = ArcSwapOption::empty();
+        let node = ArcSwap::<Node>::new(Arc::new(node));
+        let node_list = ArcSwap::<Vec<Node>>::new(Arc::new(Vec::new()));
+        let hash_ring = ArcSwap::<Ring<Node>>::new(Arc::new(Ring::default()));
+
+        Self {
+            kv_engine,
+            node_session,
+            node,
+            node_list,
+            hash_ring,
+        }
+    }
+
+    /// Prepare for the session and other data
+    pub async fn prepare(&self) -> DatenLordResult<()> {
+        // Prepare session
+        let session = self
+            .kv_engine
+            .create_session(SESSION_TIMEOUT_SEC)
+            .await
+            .with_context(|| format!("{} failed to create session", self.node.load().endpoint()))?;
+        self.node_session.store(Some(session));
+        Ok(())
+    }
+
+    /// Update node info
+    pub async fn update_node_in_cluster(&self) -> DatenLordResult<()> {
+        let node = self.node.load();
+        let key = &KeyType::CacheNode(node.endpoint().to_owned());
+        let node_session = self.node_session.load();
+        let Some(current_session) = node_session.as_ref().cloned() else {
+            let current_node = self.node.load();
+            warn!(
+                "Current {} session is invalid, return to endpoint",
+                current_node.endpoint()
+            );
+            return Err(DatenLordError::CacheClusterErr {
+                context: vec![format!("Current {} session is invalid", current_node.endpoint())],
+            });
+        };
+
+        self.kv_engine
+            .set(
+                key,
+                &ValueType::Json(serde_json::to_value(node.as_ref())?),
+                Some(SetOption {
+                    session: Some(current_session),
+                    prev_kv: false,
+                }),
+            )
+            .await
+            .with_context(|| "Failed to register node to etcd".to_owned())?;
+
+        Ok(())
+    }
+
+    /// Register current node to etcd and keep alive
+    pub async fn register(&self) -> DatenLordResult<()> {
+        // Get current node info
+        let current_node_info = self.node.load();
+        debug!("register: {} to etcd", current_node_info.endpoint());
+        let node_session = self.node_session.load();
+        let Some(current_session) = node_session.as_ref().cloned() else {
+            let current_node = self.node.load();
+            warn!(
+                "Current {} session is invalid, return to endpoint",
+                current_node.endpoint()
+            );
+            return Err(DatenLordError::CacheClusterErr {
+                context: vec![format!("Current {} session is invalid", current_node.endpoint())],
+            });
+        };
+
+        // Try to register current node to etcd
+        self.kv_engine
+            .set(
+                &KeyType::CacheNode(current_node_info.endpoint().to_owned()),
+                &ValueType::Json(serde_json::to_value(current_node_info.as_ref().clone())?),
+                Some(SetOption {
+                    // Set lease
+                    session: Some(current_session),
+                    prev_kv: false,
+                }),
+            )
+            .await
+            .with_context(|| "Failed to register node to etcd".to_owned())?;
+
+        debug!("register: {} to etcd success", current_node_info.endpoint());
+
+        Ok(())
+    }
+
+    /// Do campaign
+    ///
+    /// Try to campaign master, will return status and master value
+    pub async fn do_campaign(&self) -> DatenLordResult<(bool, String)> {
+        let node = self.get_current_node();
+        let hash_ring = self.get_ring(false).await?;
+
+        let node_session = self.node_session.load();
+        let session = if let Some(session) = node_session.as_ref().cloned() {
+            if session.is_closed() {
+                let current_node = self.node.load();
+                warn!(
+                    "Current {} session is invalid, return to endpoint",
+                    current_node.endpoint()
+                );
+                return Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Current {} session is invalid", current_node.endpoint())],
+                });
+            }
+            session
+        } else {
+            let current_node = self.node.load();
+            warn!(
+                "Current {} session is invalid, return to endpoint",
+                current_node.endpoint()
+            );
+            return Err(DatenLordError::CacheClusterErr {
+                context: vec![format!("Current {} session is invalid", current_node.endpoint())],
+            });
+        };
+
+        // Master key info
+        let master_key = &KeyType::CacheMasterNode;
+        // Create master instance
+        let master_node_info =
+            MasterNodeInfo::new(node.ip().to_owned(), node.port(), hash_ring.version());
+        let master_node_info_json = serde_json::to_value(master_node_info)?;
+        let master_value = &ValueType::Json(master_node_info_json);
+        let master_serial_value = serde_json::to_string(master_value)
+            .with_context(|| format!("failed to serialize value={master_value:?} to string"))?;
+
+        // Try to set campaign
+        let txn = self.kv_engine.new_meta_txn().await;
+        let (campaign_status, campaign_val) = txn
+            .campaign(master_key, master_serial_value, session)
+            .await?;
+
+        Ok((campaign_status, campaign_val))
+    }
+
+    /// Clean up the tasks
+    pub fn clean_sessions(&self) {
+        // Clean up register tasks
+        self.node_session.store(None);
+    }
+
+    /// Try to check current session is valid
+    pub fn check_session_valid(&self) -> bool {
+        let session = self.node_session.load_full();
+        if let Some(session) = session.as_ref() {
+            if session.is_closed() {
+                return false;
+            }
+            return true;
+        }
+
+        false
+    }
+
+    /// Master node will watch the node list update, and update the ring
+    pub async fn watch_nodes(&self) -> DatenLordResult<()> {
+        debug!(
+            "Node: {:?} watch_nodes: will watch the node list update",
+            self.get_current_node().endpoint()
+        );
+        // Write ticker task
+        let mut interval = tokio::time::interval(Duration::from_secs(SESSION_TIMEOUT_SEC));
+        let mut watch_event = false;
+
+        // Get all nodes with prefix and init hash ring list
+        // TODO: Block cluster and do not add any new node when watch_nodes is synced.
+
+        // Get all nodes with prefix
+        let key = &KeyType::CacheNode(String::new());
+        let mut nodes_watch_stream = self.kv_engine.watch(key).await?;
+
+        // Wait for node list update
+        loop {
+            if !self.check_session_valid() {
+                let current_node = self.node.load();
+                warn!(
+                    "Current {} session is invalid, return to endpoint",
+                    current_node.endpoint()
+                );
+                return Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Current {} session is invalid", current_node.endpoint())],
+                });
+            };
+
+            // Check event
+            tokio::select! {
+                // Write event
+                // This future will write all changed events in one task
+                _ = interval.tick() => {
+                    if watch_event {
+                        // Update cluster topo task
+                        match self.update_cluster_topo().await {
+                            Ok(()) => {
+                                debug!("Update cluster topo success");
+                            }
+                            Err(e) => {
+                                warn!("Failed to update cluster topo: {:?}", e);
+                                return Err(DatenLordError::CacheClusterErr {
+                                    context: vec![format!("Failed to update cluster topo: {:?}", e)],
+                                });
+                            }
+                        }
+                        watch_event = false;
+                    }
+                }
+                // Read event
+                stream_event = nodes_watch_stream.next() => {
+                    match stream_event {
+                        Some(Ok(event)) => {
+                            let key = event.0;
+                            let value = event.1;
+
+                            // TODO: We want a meticulous update, we can send the event change to a channel
+                            // Receive event, try to update cluster topo
+                            watch_event = true;
+
+                            if value.is_some() {
+                                // Update event
+                                debug!("Update node list event with key: {:?}", key);
+                            } else {
+                                // Delete event
+                                debug!("Delete node list event with key: {:?}", key);
+                            }
+                        }
+                        None => {
+                            warn!("Failed to get event from watch stream, because of stream channel is closed");
+                            return Err(DatenLordError::CacheClusterErr {
+                                context: vec![format!("Failed to get event from watch stream, because of stream channel is closed")],
+                            });
+                        }
+                        Some(Err(e)) => {
+                            // Raise error and return to upper level, try to rewatch master again
+                            warn!("Failed to watch node list key: {:?}", e);
+                            return Err(DatenLordError::CacheClusterErr {
+                                context: vec![format!("Failed to watch node list key")],
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Update cluster topo
+    ///
+    /// Try to fetch latest nodes and hashring, and update cluster by current master node
+    async fn update_cluster_topo(&self) -> DatenLordResult<()> {
+        // Check session
+        let node_session = self.node_session.load();
+        if let Some(session) = node_session.as_ref().cloned() {
+            if session.is_closed() {
+                let current_node = self.node.load();
+                warn!(
+                    "Current {} session is invalid, return to endpoint",
+                    current_node.endpoint()
+                );
+                return Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Current {} session is invalid", current_node.endpoint())],
+                });
+            }
+
+            // 1. Update node list
+            let node_list = self.get_nodes(true).await?;
+            // We want to update the hashring base on etcd hashring value and version
+            let mut hash_ring = self.get_ring(true).await?;
+            // Try to replace current hashring with new node list
+            // TODO: It will cause a lot of copy, we need to update it in next PR.
+            let ring_res = hash_ring.batch_replace(node_list.clone(), true);
+            if ring_res.is_none() {
+                warn!("Failed to update hash ring");
+                return Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Failed to update hash ring")],
+                });
+            }
+            self.hash_ring.store(Arc::new(hash_ring));
+
+            // 2. Update hashring data and current master version to etcd with txn
+            self.save_ring().await?;
+        } else {
+            let current_node = self.node.load();
+            warn!(
+                "Current {} session is invalid, return to endpoint",
+                current_node.endpoint()
+            );
+            return Err(DatenLordError::CacheClusterErr {
+                context: vec![format!("Current {} session is invalid", current_node.endpoint())],
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Try to watch hashring
+    /// This function is used to watch the hashring update for client side and update local hashring value
+    /// If the hashring is changed, we will try to update the hashring
+    pub async fn watch_ring(&self, token: CancellationToken) -> DatenLordResult<()> {
+        debug!("watch_ring: will watch the hashring and try to update local hashring",);
+
+        // Watch with hashring
+        let ring_key = &KeyType::CacheRing;
+        let mut ring_watch_stream = self.kv_engine.watch(ring_key).await?;
+
+        // Check the ring key is exist
+        // If not existed, this function will block here and wait for cache nodes online
+        loop {
+            if let Ok(ring) = self.load_ring().await {
+                debug!("Current ring: {:?}", ring);
+                // Update local hashring cache
+                self.hash_ring.store(Arc::new(ring.clone()));
+                break;
+            }
+        }
+
+        // Watch ring key events
+        // TODO: add cancel token here
+        let mut interval = tokio::time::interval(Duration::from_secs(SESSION_TIMEOUT_SEC));
+        let mut watch_event = false;
+        loop {
+            tokio::select! {
+                _ = token.cancelled() => {
+                    // Cancelled
+                    break;
+                }
+                _ = interval.tick() => {
+                    if watch_event {
+                        // Fetch and update local cache
+                        let ring = self.load_ring().await?;
+                        self.hash_ring.store(Arc::new(ring.clone()));
+                        watch_event = false;
+                    }
+                }
+                stream_event = ring_watch_stream.next() => {
+                    match stream_event {
+                        Some(Ok(event)) => {
+                            let key = event.0;
+                            let value = event.1;
+                            if value.is_some() {
+                                // Update event
+                                debug!(
+                                    "Receive update ring event with key: {:?} value: {:?}",
+                                    key, value
+                                );
+                                watch_event = true;
+
+                                if value.is_some() {
+                                    // Update event
+                                    debug!("Update node list event with key: {:?}", key);
+                                } else {
+                                    // Delete event
+                                    debug!("Delete node list event with key: {:?}", key);
+                                }
+                            } else {
+                                // Delete event
+                                debug!("delete ring event with key: {:?}", key);
+                                // Master has down, try to campaign master
+                                // Return to main loop
+                                break;
+                            }
+                        }
+                        None => {
+                            warn!("Failed to get event from watch stream, because of stream channel is closed");
+                            return Err(DatenLordError::CacheClusterErr {
+                                context: vec![format!("Failed to get event from watch stream, because of stream channel is closed")],
+                            });
+                        }
+                        Some(Err(e)) => {
+                            // Raise error and return to upper level, try to rewatch master again
+                            warn!("Failed to watch ring key: {:?}", e);
+                            return Err(DatenLordError::CacheClusterErr {
+                                context: vec![format!("Failed to watch ring key")],
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Try to watch the master node
+    /// If the master node is down, the slave node will try to get the master lock
+    /// Then current node will become the master node if operation is successful
+    pub async fn watch_master(&self) -> DatenLordResult<()> {
+        debug!(
+            "Node: {:?} watch_master: will watch the master node and try to update master hashring",
+            self.get_current_node().endpoint()
+        );
+
+        // Watch with prefix
+        let master_key = &KeyType::CacheMasterNode;
+        let mut master_watch_stream = self.kv_engine.watch(master_key).await?;
+
+        // Check the master key is exist
+        // If the master key is not exist, the slave node will be blocked in watch stream and do nothing here
+        // We need to quickly return to the main loop and try to campaign master
+        // 1. Fetch the master node info
+        if let Some(ValueType::Json(master_json)) = self.kv_engine.get(master_key).await? {
+            let master_node_info: MasterNodeInfo = serde_json::from_value(master_json)?;
+            debug!("master node info: {:?}", master_node_info);
+        } else {
+            debug!("Master is not existed, try to campaign master");
+            return Ok(());
+        }
+
+        // Watch master key events
+        // master key is keeped by lease, so the master node will be auto deleted
+        // If master has changed, try to update the value
+        // 1. If master ip changed, try to change the master node
+        // if master node is down.
+        // If the version is changed, try to update the ring
+        // In current case, we just need to detect master key change and update hashring.
+        // 2. If the master key is auto deleted, exit and change current status to slave.
+        loop {
+            match master_watch_stream.next().await {
+                Some(Ok(event)) => {
+                    let key = event.0;
+                    let value = event.1;
+                    if value.is_some() {
+                        // Update event
+                        debug!(
+                            "Receive update ring event with key: {:?} value: {:?}",
+                            key, value
+                        );
+
+                        // When master update the hashring, we will try to fetch latest ring from etcd
+                        // In this step, we just need to update the ring
+                        // Fetch the latest ring from etcd
+                        // We just ignore the update event in current step
+                    } else {
+                        // Delete event
+                        debug!("delete master event with key: {:?}", key);
+                        // Master has down, try to campaign master
+                        // Return to main loop
+                        return Ok(());
+                    }
+                }
+                None => {
+                    warn!("Failed to get event from watch stream, because of stream channel is closed");
+                    return Err(DatenLordError::CacheClusterErr {
+                        context: vec![format!("Failed to get event from watch stream, because of stream channel is closed")],
+                    });
+                }
+                Some(Err(e)) => {
+                    // Raise error and return to upper level, try to rewatch master again
+                    warn!("Failed to watch master key: {:?}", e);
+                    return Err(DatenLordError::CacheClusterErr {
+                        context: vec![format!("Failed to watch master key")],
+                    });
+                }
+            }
+        }
+    }
+
+    /// Save current master node info and hashring to etcd with one txn
+    async fn save_ring(&self) -> DatenLordResult<()> {
+        // Only master node can save ring to etcd
+        // We need to make sure current node is master and only one master can save ring to etcd
+        if self.node.load().status() != NodeStatus::Master {
+            warn!("Current node is not master, can not save ring to etcd");
+            return Err(DatenLordError::CacheClusterErr {
+                context: vec![format!(
+                    "Current node is not master, can not save ring to etcd"
+                )],
+            });
+        }
+
+        // Add a txn to update ring, update hashring is usually in low priority.
+        // Try to check the ring version and update the ring to etcd
+        // If failed, we need to return upper level and regenerate the hashring
+        let ring_key = &KeyType::CacheRing;
+        let mut txn = self.kv_engine.new_meta_txn().await;
+        let latest_hash_ring = match txn.get(ring_key).await {
+            Ok(Some(ValueType::Json(ring_json))) => {
+                // Get current ring from etcd
+                let ring: Ring<Node> = serde_json::from_value(ring_json)?;
+                ring
+            }
+            Ok(_) => {
+                // Current hashring is not valid or not existed
+                // Try to get current local hash ring as default hashring
+                self.hash_ring.load().as_ref().clone()
+            }
+            Err(e) => {
+                warn!("Failed to get ring from etcd: {:?}", e);
+                return Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Failed to get ring from etcd")],
+                });
+            }
+        };
+
+        // Check current node is the valid master node
+        let master_key = &KeyType::CacheMasterNode;
+        let latest_master_node = match txn.get(master_key).await {
+            Ok(Some(ValueType::Json(master_json))) => {
+                // Get current master node from etcd
+                let master_node: MasterNodeInfo = serde_json::from_value(master_json)?;
+                master_node
+            }
+            Ok(_) => {
+                warn!("Failed to get master node from etcd, because current master node is not existed.");
+                return Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Failed to get master node from etcd, because current master node is not existed.")],
+                });
+            }
+            Err(e) => {
+                warn!("Failed to get master node from etcd: {:?}", e);
+                return Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Failed to get master node from etcd")],
+                });
+            }
+        };
+        // Create master instance
+        let current_node_info = self.node.load();
+        if latest_master_node.endpoint() != current_node_info.endpoint() {
+            warn!("Current node is not the master node, return to endpoint");
+            return Err(DatenLordError::CacheClusterErr {
+                context: vec![format!("Current node is not the master node")],
+            });
+        }
+
+        // Prepare master node info and hashring data
+        let current_hash_ring = self.hash_ring.load();
+        if latest_hash_ring.version() > current_hash_ring.version() {
+            // If the latest ring version is greater than current ring version, we need to return
+            // and regenerate the hashring
+            warn!("Current ring version is not the latest, return to endpoint");
+            return Err(DatenLordError::CacheClusterErr {
+                context: vec![format!("Current ring version is not the latest")],
+            });
+        }
+        let master_node_info = MasterNodeInfo::new(
+            current_node_info.ip().to_owned(),
+            current_node_info.port(),
+            current_hash_ring.version(),
+        );
+        let master_node_info_json = serde_json::to_value(master_node_info)?;
+        let master_value = &ValueType::Json(master_node_info_json);
+        let ring = current_hash_ring.as_ref();
+        let current_json_value = serde_json::to_value(ring.clone())?;
+        let ring_value = &ValueType::Json(current_json_value);
+
+        txn.set(master_key, master_value);
+        txn.set(ring_key, ring_value);
+        txn.commit().await?;
+
+        Ok(())
+    }
+
+    /// Load ring from etcd
+    async fn load_ring(&self) -> DatenLordResult<Ring<Node>> {
+        let key = &KeyType::CacheRing;
+        debug!("Try to load ring from etcd: {}", key);
+
+        // Get ring from etcd
+        match self.kv_engine.get(key).await? {
+            Some(ValueType::Json(ring_json)) => {
+                let new_ring: Ring<Node> = serde_json::from_value(ring_json)?;
+
+                debug!("Load ring from etcd success");
+                Ok(new_ring)
+            }
+            None => {
+                debug!("Ring is not existed, return default ring");
+                Ok(Ring::default())
+            }
+            _ => {
+                warn!("Failed to deserialize ring");
+                Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Failed to deserialize ring")],
+                })
+            }
+        }
+    }
+
+    /// Get node list from etcd
+    async fn load_nodes(&self) -> DatenLordResult<Vec<Node>> {
+        let key = &KeyType::CacheNode(String::new());
+        debug!("Get node list from etcd: {}", key);
+
+        // Get node list from etcd
+        let nodes = self.kv_engine.range(key).await?;
+        let mut node_list = Vec::new();
+        for node in nodes {
+            if let ValueType::Json(node_json) = node {
+                let node: Node = serde_json::from_value(node_json)?;
+                node_list.push(node);
+            } else {
+                warn!("Failed to deserialize node");
+                return Err(DatenLordError::CacheClusterErr {
+                    context: vec![format!("Failed to deserialize node")],
+                });
+            }
+        }
+
+        Ok(node_list)
+    }
+
+    /// Get all nodes
+    ///
+    /// This function is used to get all nodes from etcd
+    /// If we set `must_fetch`, we will also update current node list
+    pub async fn get_nodes(&self, must_fetch: bool) -> DatenLordResult<Vec<Node>> {
+        // Get latest node list from etcd
+        if must_fetch {
+            let latest_nodes = self.load_nodes().await?;
+            self.node_list.store(Arc::new(latest_nodes.clone()));
+            return Ok(latest_nodes);
+        }
+
+        Ok(self.node_list.load().as_ref().clone())
+    }
+
+    /// Get current node
+    pub fn get_current_node(&self) -> Node {
+        self.node.load().as_ref().clone()
+    }
+
+    /// Get master node
+    pub async fn get_master_node(&self) -> DatenLordResult<MasterNodeInfo> {
+        let master_key = &KeyType::CacheMasterNode;
+        let master_node_info = self.kv_engine.get(master_key).await.map_err(|e| {
+            warn!("Failed to get master node from etcd: {:?}", e);
+            DatenLordError::CacheClusterErr {
+                context: vec![format!("Failed to get master node from etcd")],
+            }
+        })?;
+
+        if let Some(ValueType::Json(master_json)) = master_node_info {
+            let master_node: MasterNodeInfo = serde_json::from_value(master_json)?;
+            return Ok(master_node);
+        }
+
+        warn!("Master is not existed, try to campaign master");
+        Err(DatenLordError::CacheClusterErr {
+            context: vec![format!("Master is not existed, try to campaign master")],
+        })
+    }
+
+    /// Update current node
+    pub fn update_node(&self, node: Node) {
+        self.node.store(Arc::new(node));
+    }
+
+    /// Get hashring
+    ///
+    /// This function is used to get current hashring and update current hashring
+    /// If we set `must_fetch`, we will also update current hashring
+    pub async fn get_ring(&self, must_fetch: bool) -> DatenLordResult<Ring<Node>> {
+        // Get latest hashring from etcd and update current hashring
+        if must_fetch {
+            let latest_hash_ring = self.load_ring().await?;
+            self.hash_ring.store(Arc::new(latest_hash_ring.clone()));
+            return Ok(latest_hash_ring);
+        }
+
+        Ok(self.hash_ring.load().as_ref().clone())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::sync::Arc;
+
+    use tracing::{debug, level_filters::LevelFilter};
+    use tracing_subscriber::{
+        self, filter, fmt::layer, layer::SubscriberExt, util::SubscriberInitExt, Layer,
+    };
+
+    use crate::{
+        distribute_kv_cache::cluster::{
+            cluster_manager::{ClusterManager, ClusterManagerInner, SESSION_TIMEOUT_SEC},
+            node::{Node, NodeStatus},
+        },
+        fs::kv_engine::{DeleteOption, KVEngine, KVEngineType, KeyType},
+    };
+
+    const ETCD_ADDRESS: &str = "127.0.0.1:2379";
+
+    /// Helper function to create a new node with a given IP address
+    fn create_node(ip: &str) -> Node {
+        let mut node = Node::default();
+        node.set_ip(ip.to_owned());
+
+        node
+    }
+
+    async fn clean_up_etcd() {
+        // Clean up all `CacheNode` prefix keys in etcd
+        KVEngineType::new(vec![ETCD_ADDRESS.to_owned()])
+            .await
+            .unwrap()
+            .delete(
+                &KeyType::CacheNode(String::new()),
+                Some(DeleteOption {
+                    prev_kv: false,
+                    range_end: Some(vec![0xff]),
+                }),
+            )
+            .await
+            .unwrap();
+
+        // Clean up all `CacheMasterNode` keys in etcd
+        KVEngineType::new(vec![ETCD_ADDRESS.to_owned()])
+            .await
+            .unwrap()
+            .delete(
+                &KeyType::CacheMasterNode,
+                Some(DeleteOption {
+                    prev_kv: false,
+                    range_end: Some(vec![0xff]),
+                }),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_single_master_election() {
+        let filter = filter::Targets::new().with_target(
+            "datenlord::storage::cache_proxy::cluster_manager",
+            LevelFilter::DEBUG,
+        );
+        tracing_subscriber::registry()
+            .with(layer().with_filter(filter))
+            .init();
+        let client = Arc::new(
+            KVEngineType::new(vec![ETCD_ADDRESS.to_owned()])
+                .await
+                .unwrap(),
+        );
+
+        // Clean up etcd
+        clean_up_etcd().await;
+
+        let test_master_node = create_node("192.168.1.2");
+        let master_cluster_manager =
+            ClusterManagerInner::new(Arc::clone(&client), test_master_node.clone());
+        master_cluster_manager.prepare().await.unwrap();
+        let test_slave_node_1 = create_node("192.168.1.3");
+        let slave_1_cluster_manager =
+            ClusterManagerInner::new(Arc::clone(&client), test_slave_node_1.clone());
+        slave_1_cluster_manager.prepare().await.unwrap();
+        let test_slave_node_2 = create_node("192.168.1.4");
+        let slave_2_cluster_manager =
+            ClusterManagerInner::new(Arc::clone(&client), test_slave_node_2.clone());
+        slave_2_cluster_manager.prepare().await.unwrap();
+
+        debug!("test_single_master_election: start to test single master election");
+
+        let (master_res, slave_1_res, slave_2_res) = tokio::join!(
+            async {
+                // Register node
+                master_cluster_manager.register().await.unwrap();
+                // campaign
+                master_cluster_manager.do_campaign().await.unwrap()
+            },
+            async {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                slave_1_cluster_manager.register().await.unwrap();
+                // campaign
+                slave_1_cluster_manager.do_campaign().await.unwrap()
+            },
+            async {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                slave_2_cluster_manager.register().await.unwrap();
+                // campaign
+                slave_2_cluster_manager.do_campaign().await.unwrap()
+            }
+        );
+
+        // Check the result
+        assert!(master_res.0);
+        assert!(!slave_1_res.0);
+        assert!(!slave_2_res.0);
+    }
+
+    #[tokio::test]
+    async fn test_remove_slave_node() {
+        let filter = filter::Targets::new().with_target(
+            "datenlord::storage::cache_proxy::cluster_manager",
+            LevelFilter::DEBUG,
+        );
+        tracing_subscriber::registry()
+            .with(layer().with_filter(filter))
+            .init();
+        let client = Arc::new(
+            KVEngineType::new(vec![ETCD_ADDRESS.to_owned()])
+                .await
+                .unwrap(),
+        );
+
+        // Clean up etcd
+        clean_up_etcd().await;
+
+        // Setup initial state with multiple nodes
+        let test_master_node = create_node("192.168.3.2");
+        let test_slave_node = create_node("192.168.3.3");
+        let test_slave_node_2 = create_node("192.168.3.4");
+
+        let master_client = Arc::clone(&client);
+        let test_master_node_clone = test_master_node.clone();
+        let master_cluster_manager = Arc::new(ClusterManager::new(
+            master_client,
+            test_master_node_clone.clone(),
+        ));
+        let master_cluster_manager_clone = Arc::clone(&master_cluster_manager);
+        let master_handle = tokio::task::spawn(async move {
+            let res = master_cluster_manager_clone.run().await;
+            debug!("master_handle: {:?}", res);
+        });
+
+        // Wait for election
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+        let slave_client = Arc::clone(&client);
+        let test_slave_node_clone = test_slave_node.clone();
+        let slave_cluster_manager_1 = Arc::new(ClusterManager::new(
+            slave_client,
+            test_slave_node_clone.clone(),
+        ));
+        let slave_cluster_manager_1_clone = Arc::clone(&slave_cluster_manager_1);
+        let slave_handle_1 = tokio::task::spawn(async move {
+            let res = slave_cluster_manager_1_clone.run().await;
+            debug!("slave_handle_1: {:?}", res);
+        });
+
+        let slave_client = Arc::clone(&client);
+        let test_slave_node_clone = test_slave_node_2.clone();
+        let slave_cluster_manager_2 = Arc::new(ClusterManager::new(
+            slave_client,
+            test_slave_node_clone.clone(),
+        ));
+        let slave_cluster_manager_2_clone = Arc::clone(&slave_cluster_manager_2);
+        let slave_handle_2 = tokio::task::spawn(async move {
+            let res: Result<(), crate::common::error::DatenLordError> =
+                slave_cluster_manager_2_clone.run().await;
+            debug!("slave_handle_2: {:?}", res);
+        });
+
+        // Wait for node online
+        tokio::time::sleep(std::time::Duration::from_secs(SESSION_TIMEOUT_SEC)).await;
+
+        assert_eq!(
+            Arc::clone(&master_cluster_manager)
+                .get_current_node()
+                .status(),
+            NodeStatus::Master
+        );
+        assert_eq!(
+            Arc::clone(&slave_cluster_manager_1)
+                .get_current_node()
+                .status(),
+            NodeStatus::Slave
+        );
+        assert_eq!(
+            Arc::clone(&slave_cluster_manager_2)
+                .get_current_node()
+                .status(),
+            NodeStatus::Slave
+        );
+        assert_eq!(master_cluster_manager.get_nodes().await.unwrap().len(), 3);
+
+        debug!("test_remove_slave_node: update node list");
+        // Cancel the slave task
+        slave_handle_1.abort();
+        slave_cluster_manager_1.stop();
+        // Wait for slave key is deleted
+        tokio::time::sleep(std::time::Duration::from_secs(2 * SESSION_TIMEOUT_SEC)).await;
+
+        debug!("test_remove_slave_node: start to test remove slave node");
+        debug!(
+            "Get all nodes: {:?}",
+            master_cluster_manager.get_nodes().await.unwrap()
+        );
+
+        assert_eq!(
+            master_cluster_manager.get_current_node().status(),
+            NodeStatus::Master
+        );
+        assert_eq!(master_cluster_manager.get_nodes().await.unwrap().len(), 2);
+
+        slave_handle_2.abort();
+        master_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_remove_master_node() {
+        let filter = filter::Targets::new().with_target(
+            "datenlord::storage::cache_proxy::cluster_manager",
+            LevelFilter::DEBUG,
+        );
+        tracing_subscriber::registry()
+            .with(layer().with_filter(filter))
+            .init();
+        let client = Arc::new(
+            KVEngineType::new(vec![ETCD_ADDRESS.to_owned()])
+                .await
+                .unwrap(),
+        );
+
+        // Clean up etcd
+        clean_up_etcd().await;
+
+        // Setup initial state with multiple nodes
+        let test_master_node = create_node("192.168.3.2");
+        let test_slave_node = create_node("192.168.3.3");
+
+        // Run master
+        let master_client = Arc::clone(&client);
+        let test_master_node_clone = test_master_node.clone();
+        let master_cluster_manager = Arc::new(ClusterManager::new(
+            master_client,
+            test_master_node_clone.clone(),
+        ));
+        let master_cluster_manager_clone = Arc::clone(&master_cluster_manager);
+        let master_handle = tokio::task::spawn(async move {
+            let res = master_cluster_manager_clone.run().await;
+            debug!("master_handle: {:?}", res);
+        });
+
+        // Wait for the election to finish
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+        let slave_client = Arc::clone(&client);
+        let test_slave_node_clone = test_slave_node.clone();
+        let slave_cluster_manager_1 = Arc::new(ClusterManager::new(
+            slave_client,
+            test_slave_node_clone.clone(),
+        ));
+        let slave_cluster_manager_1_clone = Arc::clone(&slave_cluster_manager_1);
+        let slave_handle_1 = tokio::task::spawn(async move {
+            let res = slave_cluster_manager_1_clone.run().await;
+            debug!("slave_handle_1: {:?}", res);
+        });
+
+        // Wait for node online
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+        assert_eq!(
+            Arc::clone(&master_cluster_manager)
+                .get_current_node()
+                .status(),
+            NodeStatus::Master
+        );
+        assert_eq!(
+            Arc::clone(&slave_cluster_manager_1)
+                .get_current_node()
+                .status(),
+            NodeStatus::Slave
+        );
+
+        // Simulate master node removal
+        debug!("Simulate master node removal");
+        master_cluster_manager.stop();
+        master_handle.abort();
+        // Wait for the system to detect the master node removal
+        tokio::time::sleep(std::time::Duration::from_secs(SESSION_TIMEOUT_SEC + 1)).await;
+
+        // Check if the slave node has become the new master
+        let new_master_status = slave_cluster_manager_1.get_current_node().status();
+        assert_eq!(new_master_status, NodeStatus::Master);
+
+        debug!("test_remove_master_node: slave node has taken over as master");
+        slave_handle_1.abort();
+    }
+}

--- a/src/distribute_kv_cache/cluster/mod.rs
+++ b/src/distribute_kv_cache/cluster/mod.rs
@@ -1,0 +1,10 @@
+/// This module contains the distribute cache implementation.
+
+/// Hash ring module
+pub mod ring;
+
+/// Node module
+pub mod node;
+
+/// Cluster informer module, use metadata to manage the nodes
+pub mod cluster_manager;

--- a/src/distribute_kv_cache/cluster/node.rs
+++ b/src/distribute_kv_cache/cluster/node.rs
@@ -1,0 +1,195 @@
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use super::ring::NodeType;
+
+/// Master node info
+///
+/// The master node info is used to store the master node information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MasterNodeInfo {
+    /// The ip of the master node
+    pub ip: String,
+    /// The port of the master node
+    pub port: u16,
+    /// The version of the hash ring
+    pub version: u64,
+}
+
+impl PartialEq for MasterNodeInfo {
+    fn eq(&self, other: &Self) -> bool {
+        self.ip == other.ip && self.port == other.port && self.version == other.version
+    }
+}
+
+impl MasterNodeInfo {
+    /// Create a new master node info
+    #[must_use]
+    pub fn new(ip: String, port: u16, version: u64) -> Self {
+        Self { ip, port, version }
+    }
+
+    /// Get the ip of the master node
+    #[must_use]
+    pub fn ip(&self) -> &str {
+        &self.ip
+    }
+
+    /// Get the port of the master node
+    #[must_use]
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Get the endpoint of the master node
+    #[must_use]
+    pub fn endpoint(&self) -> String {
+        format!("{}:{}", self.ip, self.port)
+    }
+
+    /// Get the version of the hash ring
+    #[must_use]
+    pub fn version(&self) -> u64 {
+        self.version
+    }
+}
+
+/// Physical node struct
+///
+/// physical node is the node in the slot mapping
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Node {
+    /// We assume that ip is unique in our system
+    /// TODO: Use hash set to judge the uniqueness?
+    /// The ip of the node
+    ip: String,
+    /// The port of the node
+    port: u16,
+    /// The weight of the node
+    weight: u32,
+    /// The status of the node
+    status: NodeStatus,
+}
+
+impl NodeType for Node {}
+
+impl PartialEq for Node {
+    fn eq(&self, other: &Self) -> bool {
+        self.ip == other.ip && self.port == other.port && self.weight == other.weight
+    }
+}
+
+impl Eq for Node {}
+
+impl std::hash::Hash for Node {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.ip.hash(state);
+        self.port.hash(state);
+        self.weight.hash(state);
+    }
+}
+
+impl Default for Node {
+    fn default() -> Self {
+        Self {
+            ip: String::new(),
+            port: 0,
+            weight: 0,
+            status: NodeStatus::Initializing,
+        }
+    }
+}
+
+impl Node {
+    /// Create a new node
+    #[must_use]
+    pub fn new(ip: String, port: u16, weight: u32, status: NodeStatus) -> Self {
+        Self {
+            ip,
+            port,
+            weight,
+            status,
+        }
+    }
+
+    /// Get the ip of the node
+    #[must_use]
+    pub fn ip(&self) -> &str {
+        &self.ip
+    }
+
+    /// Get the port of the node
+    #[must_use]
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Get the endpoint of the node
+    #[must_use]
+    pub fn endpoint(&self) -> String {
+        format!("{}:{}", self.ip, self.port)
+    }
+
+    /// Get the weight of the node
+    #[must_use]
+    pub fn weight(&self) -> u32 {
+        self.weight
+    }
+
+    /// Set the ip of the node
+    pub fn set_ip(&mut self, ip: String) {
+        self.ip = ip;
+    }
+
+    /// Set the port of the node
+    pub fn set_port(&mut self, port: u16) {
+        self.port = port;
+    }
+
+    /// Set the weight of the node
+    pub fn set_weight(&mut self, weight: u32) {
+        self.weight = weight;
+    }
+
+    /// Get the status of the node
+    #[must_use]
+    pub fn status(&self) -> NodeStatus {
+        self.status
+    }
+
+    /// Change the status of the node
+    /// We export this function to change the status of the node,
+    /// The state machine is managed by the cluster manager
+    pub fn set_status(&mut self, status: NodeStatus) {
+        self.status = status;
+    }
+}
+
+/// Node status
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Copy)]
+pub enum NodeStatus {
+    /// The node is preparing
+    Initializing,
+    /// The node is registering
+    Registering,
+    /// The node is serve as slave
+    Slave,
+    /// The node is serve as master
+    Master,
+}
+
+impl FromStr for NodeStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.to_lowercase();
+        match s.as_str() {
+            "initializing" => Ok(NodeStatus::Initializing),
+            "registering" => Ok(NodeStatus::Registering),
+            "slave" => Ok(NodeStatus::Slave),
+            "master" => Ok(NodeStatus::Master),
+            _ => Err(format!("Unknown node status: {s}")),
+        }
+    }
+}

--- a/src/distribute_kv_cache/cluster/ring.rs
+++ b/src/distribute_kv_cache/cluster/ring.rs
@@ -1,0 +1,744 @@
+//! The hash ring data structure
+
+use core::fmt;
+use std::cmp;
+use std::collections::HashSet;
+use std::hash::BuildHasher;
+use std::hash::Hash;
+
+use clippy_utilities::OverflowArithmetic;
+use serde::{Deserialize, Serialize};
+use std::collections::hash_map::DefaultHasher;
+use tracing::warn;
+
+use crate::async_fuse::util::usize_to_u64;
+
+/// The default slot size
+/// We use `u64::MAX` as the default slot size
+/// And we do not need to worry about the overflow
+const DEFAULT_SLOT_SIZE: u64 = std::u64::MAX;
+
+/// A trait for types that support clone, and print
+pub trait NodeType: Clone + PartialEq + Hash + Eq {}
+
+// impl<T> NodeType for T where T: Clone + std::fmt::Debug {}
+
+/// A slot definition in the hash ring
+#[derive(Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub struct Slot<T>
+where
+    T: NodeType,
+{
+    /// The start offset of the slot
+    start: u64,
+    /// The end offset of the slot
+    end: u64,
+    /// The slot data, contains mapping info
+    inner: T,
+}
+
+impl<T> Slot<T>
+where
+    T: NodeType,
+{
+    /// Create a new slot
+    pub fn new(start: u64, end: u64, inner: T) -> Self {
+        Self { start, end, inner }
+    }
+
+    /// Get the start offset of the slot
+    pub fn start(&self) -> u64 {
+        self.start
+    }
+
+    /// Get the end offset of the slot
+    pub fn end(&self) -> u64 {
+        self.end
+    }
+
+    /// Get the slot data
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Slot<T>
+where
+    T: NodeType,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Slot: start: {}, end: {}, data: {:?}",
+            self.start, self.end, self.inner
+        )
+    }
+}
+
+impl<T> PartialEq for Slot<T>
+where
+    T: NodeType,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.start == other.start && self.end == other.end
+    }
+}
+
+impl<T> Eq for Slot<T> where T: NodeType {}
+
+impl<T> Ord for Slot<T>
+where
+    T: NodeType,
+{
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.start.cmp(&other.start)
+    }
+}
+
+impl<T> PartialOrd for Slot<T>
+where
+    T: NodeType,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.start.cmp(&other.start))
+    }
+}
+
+/// The default hash builder
+#[derive(Debug, Clone)]
+pub struct DefaultHashBuilder;
+
+impl BuildHasher for DefaultHashBuilder {
+    type Hasher = DefaultHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        DefaultHasher::new()
+    }
+}
+
+impl Default for DefaultHashBuilder {
+    fn default() -> Self {
+        DefaultHashBuilder
+    }
+}
+
+/// The hash ring data structure
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub struct Ring<T, S = DefaultHashBuilder>
+where
+    T: NodeType,
+    S: BuildHasher + Clone,
+{
+    /// The hash builder
+    #[serde(skip)]
+    hash_builder: S,
+    /// The slots
+    slots: Vec<Slot<T>>,
+    /// T to slot id mapping, accelerate finding the slot and filter the same node
+    node_set: HashSet<T>,
+    /// The slot step of the ring
+    capacity: u64,
+    /// The version of the ring
+    version: u64,
+}
+
+impl<T> Default for Ring<T>
+where
+    T: NodeType,
+{
+    fn default() -> Self {
+        Ring {
+            hash_builder: DefaultHashBuilder,
+            slots: Vec::new(),
+            node_set: HashSet::new(),
+            capacity: DEFAULT_SLOT_SIZE,
+            version: 0,
+        }
+    }
+}
+
+impl<T, S> Ring<T, S>
+where
+    T: NodeType,
+    S: BuildHasher + Clone,
+{
+    /// Create a new hash ring with a given hash builder and capacity
+    #[must_use]
+    pub fn new(hash_builder: S) -> Self {
+        Self {
+            hash_builder,
+            slots: Vec::new(),
+            node_set: HashSet::new(),
+            capacity: DEFAULT_SLOT_SIZE,
+            version: 0,
+        }
+    }
+
+    /// Update the ring with a given ring
+    /// It will node update the hash builder
+    pub fn update(&mut self, ring: &Ring<T, S>) {
+        self.slots = ring.slots.clone();
+        self.node_set = ring.node_set.clone();
+        self.capacity = ring.capacity;
+        self.version = ring.version;
+    }
+
+    /// Get the slot length
+    #[must_use]
+    pub fn len_slots(&self) -> usize {
+        self.slots.len()
+    }
+
+    /// Get the slot at a given index
+    #[must_use]
+    pub fn capacity(&self) -> u64 {
+        self.capacity
+    }
+
+    /// Get version
+    #[must_use]
+    pub fn version(&self) -> u64 {
+        self.version
+    }
+
+    /// Get nodes
+    #[must_use]
+    pub fn nodes(&self) -> Vec<T> {
+        self.slots.iter().map(|slot| slot.inner.clone()).collect()
+    }
+
+    /// Check if the ring is empty
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.slots.is_empty()
+    }
+
+    /// Clear the ring
+    pub fn slots_clear(&mut self) {
+        self.slots.clear();
+    }
+}
+
+impl<T, S: BuildHasher> Ring<T, S>
+where
+    T: NodeType,
+    S: BuildHasher + Clone,
+{
+    /// Add a node to a slot
+    /// We will create a new slot and update slot mapping, then add to the ring
+    /// If must is true, the ring need to be rebalanced or expanded
+    pub fn add(&mut self, node: &T, must: bool) -> Option<T> {
+        if self.node_set.contains(node) {
+            return Some(node.clone());
+        }
+
+        // If the ring is full, return None
+        if usize_to_u64(self.slots.len()) >= self.capacity {
+            return None;
+        }
+
+        // Try to modify the ring, so we need to increase the version
+        // TODO1: if the version is too large, we need to reset it
+        // if th slot allocation failed, we need to keep the version
+        self.version += 1;
+
+        // If there are no slots, add the first one covering the whole range
+        if self.slots.is_empty() {
+            // TODO:Try to use rc to avoid clone?
+            let new_slot = Slot::new(1, self.capacity, node.clone());
+            self.slots.push(new_slot);
+
+            return Some(node.clone());
+        }
+
+        // 1-512 513-1024
+        // 1-512 513-768 769-1024
+        // 1-256 256-512 513-768 769-1024
+        // Find the slot with the largest range
+        let (index, _) = match self
+            .slots
+            .iter()
+            .enumerate()
+            .max_by_key(|&(_, slot)| slot.end - slot.start)
+        {
+            Some((index, slot)) => (index, slot.end - slot.start),
+            None => return None,
+        };
+
+        // Calculate the new ranges for the split
+        let slot_to_split = self.slots.get_mut(index)?;
+        let mid_point = Self::safe_midpoint(slot_to_split.start, slot_to_split.end);
+
+        // Create new slot with the second half of the range
+        let new_slot = Slot::new(mid_point + 1, slot_to_split.end, node.clone());
+
+        // Update the end of the existing slot to the mid_point
+        slot_to_split.end = mid_point;
+
+        // Insert the new slot to index+1, and shift the rest of the slots
+        self.slots.insert(index + 1, new_slot);
+
+        // Try to rebalance the ring
+        // If must is true and the rebalance failed, return None
+        if must && !self.rebalance() {
+            warn!("Rebalance failed");
+
+            return None;
+        }
+
+        self.node_set.insert(node.clone());
+
+        Some(node.clone())
+    }
+
+    /// Calculate the safe midpoint
+    fn safe_midpoint(a: u64, b: u64) -> u64 {
+        match a.cmp(&b) {
+            cmp::Ordering::Greater => {
+                // if a > b and both u64, a - b and a / b will not overflow
+                let a_sub_b = a.overflow_sub(b);
+                let a_div_b = a_sub_b.overflow_div(2);
+                b.overflow_add(a_div_b)
+            }
+            cmp::Ordering::Less => {
+                let b_sub_a = b.overflow_sub(a);
+                let b_div_a = b_sub_a.overflow_div(2);
+                a.overflow_add(b_div_a)
+            }
+            cmp::Ordering::Equal => a,
+        }
+    }
+
+    /// Batch replace
+    ///
+    /// Try to modify current ring and try the best to keep the old ring distribution
+    /// It will return removed nodes here
+    pub fn batch_replace(&mut self, nodes: Vec<T>, must: bool) -> Option<Vec<T>> {
+        let add_set: HashSet<T> = nodes.iter().cloned().collect();
+
+        // Iterate current node_set to find the nodes to remove
+        let remove_nodes: Vec<T> = self
+            .node_set
+            .iter()
+            .filter(|node| !add_set.contains(*node))
+            .cloned()
+            .collect();
+
+        // Add the new nodes
+        self.batch_add(nodes, must).as_ref()?;
+
+        // Remove the old nodes
+        self.batch_remove(&remove_nodes, must).as_ref()?;
+
+        // Update current node_set
+        self.node_set = add_set;
+
+        Some(remove_nodes)
+    }
+
+    /// Add a batch of slots
+    /// If must is true, the ring need to be rebalanced or expanded
+    pub fn batch_add(&mut self, nodes: Vec<T>, must: bool) -> Option<Vec<T>> {
+        // Store the success nodes
+        let mut success_nodes = Vec::new();
+
+        if usize_to_u64(self.slots.len() + nodes.len()) > self.capacity {
+            // If not satisfy the expand condition but too many nodes, return None
+            return None;
+        }
+
+        // Try to modify the ring, so we need to increase the version
+        // TODO1: if the version is too large, we need to reset it
+        // if th slot allocation failed, we need to keep the version
+        // Iterate the nodes to add
+        for node in nodes {
+            // Try to rebalance it later
+            if let Some(n) = self.add(&node.clone(), false) {
+                success_nodes.push(n);
+            }
+        }
+
+        // If must is true, we need to expand the ring
+        // Try to rebalance the ring
+        if must {
+            self.rebalance();
+        }
+
+        Some(success_nodes)
+    }
+
+    /// Remove a slot
+    /// If must is true, the ring need to be rebalanced
+    pub fn remove(&mut self, node: T, must: bool) -> Option<T> {
+        if !self.node_set.contains(&node) {
+            return Some(node);
+        }
+
+        // Find the slot to remove
+        // TODO: Find the slot with faster way?
+        // If the slot is not found, return None
+        let index = self.slots.iter().position(|slot| slot.inner == node)?;
+
+        // Remove the slot by index
+        let _removed = self.remove_by_index(index, false)?;
+
+        // Try to rebalance the ring
+        if must {
+            self.rebalance();
+        }
+
+        self.node_set.remove(&node);
+
+        Some(node)
+    }
+
+    /// Remove a slot by index
+    pub fn remove_by_index(&mut self, index: usize, must: bool) -> Option<T> {
+        // Try to modify the ring, so we need to increase the version
+        // TODO1: if the version is too large, we need to reset it
+        // TODO2: if the slot allocation failed, we need to keep the version
+        // Maybe we need to get the atomic function to update this version
+        self.version += 1;
+
+        // If the slot is not found, return None
+        if index >= self.slots.len() {
+            return None;
+        }
+
+        // Remove the slot, shift the rest of the slots
+        let removed_slot = self.slots.remove(index);
+        self.node_set.remove(&removed_slot.inner);
+
+        if self.slots.is_empty() {
+            return None;
+        }
+
+        // Merge current slot range to previous slot
+        if index > 0 {
+            // other slots
+            let prev_slot = self.slots.get_mut(index - 1)?;
+            prev_slot.end = removed_slot.end;
+        } else if !self.slots.is_empty() {
+            // first slot, try to merge to the next slot
+            let first_slot = self.slots.get_mut(0)?;
+            first_slot.start = removed_slot.start;
+        } else {
+            // no slot left
+            return None;
+        }
+
+        // Try to rebalance the ring
+        if must && !self.rebalance() {
+            warn!("Rebalance failed");
+
+            return None;
+        }
+
+        Some(removed_slot.inner)
+    }
+
+    /// Remove a batch of slots
+    /// If must is true, the ring need to be rebalanced or expanded
+    pub fn batch_remove(&mut self, nodes: &[T], must: bool) -> Option<Vec<T>> {
+        // TODO: Find the slot with faster way?
+        let mut indexes_to_remove: Vec<usize> = nodes
+            .iter()
+            .filter_map(|node| self.slots.iter().position(|slot| &slot.inner == node))
+            .collect();
+
+        // Try to modify the ring, so we need to increase the version
+        indexes_to_remove.sort_unstable_by(|a, b| b.cmp(a));
+
+        let mut success_nodes = Vec::new();
+
+        // If must is true, we need to expand the ring
+        // Find the slot to remove
+        for index in indexes_to_remove {
+            if let Some(n) = self.remove_by_index(index, false) {
+                success_nodes.push(n);
+            }
+        }
+
+        // Try to rebalance the ring
+        if must && !self.rebalance() {
+            warn!("Rebalance failed");
+
+            return None;
+        }
+
+        Some(success_nodes)
+    }
+
+    /// Get the slot of a given key
+    pub fn get_slot<U: Hash>(&self, key: &U) -> Option<&Slot<T>> {
+        if self.slots.is_empty() {
+            return None;
+        }
+
+        // let idx = get_hash(&self.hash_builder, key) % self.capacity;
+        let idx = get_hash(&self.hash_builder, key);
+
+        // Find the slot with binary search
+        match self.slots.binary_search_by(|slot| slot.start.cmp(&idx)) {
+            Err(index) => {
+                if index == 0 {
+                    // redirect to the last slot(ring)
+                    self.slots.last()
+                } else {
+                    // previous start index
+                    self.slots.get(index - 1)
+                }
+            }
+            Ok(index) => self.slots.get(index),
+        }
+    }
+
+    /// Get the node of a given key
+    pub fn get_node<U: Hash>(&self, key: &U) -> Option<&T> {
+        self.get_slot(key).map(Slot::inner)
+    }
+
+    /// Rebalance the ring
+    /// Try to rebalance the ring
+    pub fn rebalance(&mut self) -> bool {
+        if self.slots.is_empty() {
+            return false;
+        }
+
+        // update version
+        self.version += 1;
+
+        // calculate new slot size
+        let total_range = self.capacity;
+        let new_slot_size = total_range.overflow_div(usize_to_u64(self.slots.len()));
+        let mut start = 1_u64;
+
+        // update slot range
+        for slot in &mut self.slots {
+            slot.start = start;
+            // prevent overflow
+            let (start_add, o) = start.overflowing_add(new_slot_size);
+            if o {
+                slot.end = self.capacity;
+                start = self.capacity;
+            } else {
+                slot.end = start_add.overflow_sub(1);
+                start = start_add;
+            }
+        }
+
+        // update the last slot
+        if let Some(last_slot) = self.slots.last_mut() {
+            last_slot.end = self.capacity;
+        }
+
+        true
+    }
+}
+
+/// Get the hash index of a key
+fn get_hash<T, S>(hash_builder: &S, key: T) -> u64
+where
+    T: Hash,
+    S: BuildHasher,
+{
+    hash_builder.hash_one(key)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    struct Node {
+        id: u64,
+    }
+
+    impl NodeType for Node {}
+
+    #[test]
+    fn test_slot() {
+        let node = Node { id: 1 };
+        let slot = Slot::new(1, 10, node);
+
+        assert_eq!(slot.start(), 1);
+        assert_eq!(slot.end(), 10);
+        assert_eq!(slot.inner().id, 1);
+    }
+
+    #[test]
+    fn test_ring() {
+        let node1 = Node { id: 1 };
+        let node2 = Node { id: 2 };
+        let node3 = Node { id: 3 };
+
+        let mut ring = Ring::new(DefaultHashBuilder);
+
+        ring.add(&node1.clone(), false);
+        ring.add(&node2.clone(), false);
+        ring.add(&node3.clone(), false);
+
+        assert_eq!(ring.len_slots(), 3);
+        assert_eq!(ring.capacity(), DEFAULT_SLOT_SIZE);
+        assert_eq!(ring.version(), 3);
+
+        ring.remove(node2.clone(), false);
+
+        assert_eq!(ring.len_slots(), 2);
+        assert_eq!(ring.capacity(), DEFAULT_SLOT_SIZE);
+        assert_eq!(ring.version(), 4);
+    }
+
+    #[test]
+    fn test_batch_add() {
+        let node1 = Node { id: 1 };
+        let node2 = Node { id: 2 };
+        let node3 = Node { id: 3 };
+
+        let mut ring = Ring::new(DefaultHashBuilder);
+
+        let add_result = ring.batch_add(vec![node1.clone(), node2.clone(), node3.clone()], false);
+        assert!(add_result.is_some());
+        assert_eq!(add_result.unwrap().len(), 3);
+
+        assert_eq!(ring.len_slots(), 3);
+        assert_eq!(ring.capacity(), DEFAULT_SLOT_SIZE);
+        assert_eq!(ring.version(), 3);
+
+        // node1
+        assert_eq!(ring.get_slot(&1_i32).unwrap().start, 1);
+        assert_eq!(
+            ring.get_slot(&1_i32).unwrap().end,
+            DEFAULT_SLOT_SIZE.overflow_div(4).overflow_add(1)
+        );
+        // node2
+        assert_eq!(
+            ring.get_slot(&999_i32).unwrap().start,
+            DEFAULT_SLOT_SIZE.overflow_div(2).overflow_add(2)
+        );
+        assert_eq!(ring.get_slot(&999_i32).unwrap().end, DEFAULT_SLOT_SIZE);
+        // node3
+        assert_eq!(
+            ring.get_slot(&90_002_i32).unwrap().start,
+            DEFAULT_SLOT_SIZE.overflow_div(4).overflow_add(2)
+        );
+        assert_eq!(
+            ring.get_slot(&90_002_i32).unwrap().end,
+            DEFAULT_SLOT_SIZE.overflow_div(2).overflow_add(1)
+        );
+
+        ring.slots_clear();
+        assert_eq!(ring.version(), 3);
+
+        let add_result = ring.batch_add(vec![node1.clone(), node2.clone(), node3.clone()], true);
+        assert!(add_result.is_some());
+        assert_eq!(add_result.unwrap().len(), 3);
+
+        assert_eq!(ring.len_slots(), 3);
+        assert_eq!(ring.capacity(), DEFAULT_SLOT_SIZE);
+        assert_eq!(ring.version(), 7); // 3 + 3 + 1(rebalance)
+
+        // node1
+        assert_eq!(ring.get_slot(&1_i32).unwrap().start, 1);
+        assert_eq!(
+            ring.get_slot(&1_i32).unwrap().end,
+            DEFAULT_SLOT_SIZE.overflow_div(3)
+        );
+        // node2
+        assert_eq!(
+            ring.get_slot(&999_i32).unwrap().start,
+            DEFAULT_SLOT_SIZE.overflow_div(3).overflow_add(1)
+        );
+        assert_eq!(
+            ring.get_slot(&999_i32).unwrap().end,
+            DEFAULT_SLOT_SIZE.overflow_div(3).overflow_mul(2)
+        );
+        // node3
+        assert_eq!(
+            ring.get_slot(&99_003_i32).unwrap().start,
+            DEFAULT_SLOT_SIZE
+                .overflow_div(3)
+                .overflow_mul(2)
+                .overflow_add(1)
+        );
+        assert_eq!(ring.get_slot(&99_003_i32).unwrap().end, DEFAULT_SLOT_SIZE);
+    }
+
+    #[test]
+    fn test_batch_remove() {
+        let node1 = Node { id: 1 };
+        let node2 = Node { id: 2 };
+        let node3 = Node { id: 3 };
+
+        let mut ring = Ring::new(DefaultHashBuilder);
+
+        ring.batch_add(vec![node1.clone(), node2.clone(), node3.clone()], true);
+
+        assert_eq!(ring.len_slots(), 3);
+        assert_eq!(ring.capacity(), DEFAULT_SLOT_SIZE);
+        assert_eq!(ring.version(), 4); // 3 + 1
+
+        ring.batch_remove(&[node2.clone()], true);
+
+        assert_eq!(ring.len_slots(), 2);
+        assert_eq!(ring.capacity(), DEFAULT_SLOT_SIZE);
+        assert_eq!(ring.version(), 6); // 4 + 1 + 1(rebalance)
+
+        assert_eq!(ring.get_slot(&1_i32).unwrap().start, 1);
+        assert_eq!(
+            ring.get_slot(&1_i32).unwrap().end,
+            DEFAULT_SLOT_SIZE.overflow_div(2)
+        );
+        assert_eq!(
+            ring.get_slot(&90_000_i32).unwrap().start,
+            DEFAULT_SLOT_SIZE.overflow_div(2).overflow_add(1)
+        );
+        assert_eq!(ring.get_slot(&90_000_i32).unwrap().end, DEFAULT_SLOT_SIZE);
+
+        ring.batch_remove(&[node3.clone()], true);
+
+        assert_eq!(ring.len_slots(), 1);
+        assert_eq!(ring.capacity(), DEFAULT_SLOT_SIZE);
+        assert_eq!(ring.version(), 8); // 6 + 1 + 1(rebalance)
+
+        assert_eq!(ring.get_slot(&1_i32).unwrap().start, 1);
+        assert_eq!(ring.get_slot(&1_i32).unwrap().end, DEFAULT_SLOT_SIZE);
+    }
+
+    /// Test the ring add and remove
+    ///
+    ///
+    /// 3 nodes without balance => [500617, 249146, 250236]
+    /// ```
+    /// let mut node_hit_count = vec![0; 3];
+    /// for i in 1..1000000 {
+    ///    let slot = ring.get_slot(&i).unwrap();
+    ///        node_hit_count[slot.inner().id as usize - 1] += 1;
+    /// }
+    /// println!("{:?}", node_hit_count);
+    /// ```
+    #[test]
+    fn test_ring_get_slot() {
+        let node1 = Node { id: 1 };
+        let node2 = Node { id: 2 };
+        let node3 = Node { id: 3 };
+
+        let mut ring = Ring::new(DefaultHashBuilder);
+
+        ring.add(&node1, false);
+        ring.add(&node2, false);
+        ring.add(&node3, false);
+
+        let slot = ring.get_slot(&1_i32).unwrap();
+        assert_eq!(slot.inner().id, 1);
+
+        let slot = ring.get_slot(&999_i32).unwrap();
+        assert_eq!(slot.inner().id, 2);
+
+        let slot = ring.get_slot(&90_002_i32).unwrap();
+        assert_eq!(slot.inner().id, 3);
+    }
+}

--- a/src/distribute_kv_cache/local_cache/backend.rs
+++ b/src/distribute_kv_cache/local_cache/backend.rs
@@ -1,0 +1,112 @@
+use async_trait::async_trait;
+use opendal::{raw::oio::ReadExt, services::Fs, ErrorKind, Operator};
+use tokio::io::AsyncWriteExt;
+
+use std::fmt::Debug;
+
+use super::StorageResult;
+
+/// The `Backend` trait represents a backend storage system.
+#[async_trait]
+pub trait Backend: Debug + Send + Sync {
+    /// Reads data from the storage system into the given buffer.
+    async fn read(&self, path: &str, buf: &mut [u8]) -> StorageResult<usize>;
+    /// Stores data from the given buffer into the storage system.
+    async fn store(&self, path: &str, buf: &[u8]) -> StorageResult<()>;
+    /// Removes the data from the storage system.
+    async fn remove(&self, path: &str) -> StorageResult<()>;
+}
+
+/// The `FSBackend` struct represents a backend storage system that uses the filesystem.
+#[derive(Debug)]
+pub struct FSBackend {
+    operator: Operator,
+}
+
+impl FSBackend {
+    /// Creates a new `FSBackend` instance with the given `Operator`.
+    pub fn new(operator: Operator) -> Self {
+        Self { operator }
+    }
+
+    /// Create a tmp backend
+    #[allow(clippy::unwrap_used)]
+    pub fn default() -> Self {
+        let mut builder = Fs::default();
+        builder.root("/tmp/backend/");
+        let operator = Operator::new(builder).unwrap().finish();
+        Self { operator }
+    }
+}
+
+#[async_trait]
+impl Backend for FSBackend {
+    /// Reads data from the storage system into the given buffer.
+    #[inline]
+    async fn read(&self, path: &str, buf: &mut [u8]) -> StorageResult<usize> {
+        let mut reader = self.operator.reader(path).await?;
+        let mut read_size = 0;
+
+        loop {
+            // Read data and catch the size
+            let result = reader.read(buf).await;
+            match result {
+                Ok(size) => {
+                    if size == 0 {
+                        break;
+                    }
+                    read_size += size;
+                }
+                Err(e) => {
+                    // If not found just return 0.
+                    if e.kind() == ErrorKind::NotFound {
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(read_size)
+    }
+
+    /// Stores data from the given buffer into the storage system.
+    #[inline]
+    async fn store(&self, path: &str, buf: &[u8]) -> StorageResult<()> {
+        let mut writer = self.operator.writer(path).await?;
+        writer.write_all(buf).await?;
+        writer.close().await?;
+        Ok(())
+    }
+
+    /// Removes the data from the storage system.
+    #[inline]
+    async fn remove(&self, path: &str) -> StorageResult<()> {
+        self.operator.remove_all(path).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use opendal::services::Fs;
+
+    #[tokio::test]
+    async fn test_fs_backend() {
+        let mut builder = Fs::default();
+        builder.root("/tmp/backend/");
+        let operator = Operator::new(builder).unwrap().finish();
+        let backend = FSBackend::new(operator);
+
+        let path = "/tmp/backend/test.txt";
+        let data = b"Hello, world!";
+        backend.store(path, data).await.unwrap();
+
+        let mut buf = vec![0; data.len()];
+        backend.read(path, &mut buf).await.unwrap();
+        assert_eq!(buf, data);
+
+        backend.remove(path).await.unwrap();
+    }
+}

--- a/src/distribute_kv_cache/local_cache/block.rs
+++ b/src/distribute_kv_cache/local_cache/block.rs
@@ -1,0 +1,162 @@
+use std::hash::{Hash, Hasher};
+
+/// Use 512 KB block size
+pub const BLOCK_SIZE: usize = 512 * 1024;
+
+#[derive(Clone, Debug)]
+/// Provide current node meta infos
+pub struct MetaData {
+    /// File attr inum
+    inum: u64,
+    /// Block write time, generated with snowflake
+    version: u64,
+    /// Block offset in file
+    offset: u64,
+    /// Block size
+    size: u64,
+}
+
+impl Eq for MetaData {}
+
+impl PartialEq for MetaData {
+    fn eq(&self, other: &Self) -> bool {
+        self.inum == other.inum
+            && self.version == other.version
+            && self.offset == other.offset
+            && self.size == other.size
+    }
+}
+
+impl Hash for MetaData {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.inum.hash(state);
+        self.version.hash(state);
+        self.offset.hash(state);
+        self.size.hash(state);
+    }
+}
+
+impl MetaData {
+    /// Create a new `MetaData` instance
+    pub fn new(inum: u64, version: u64, offset: u64, size: u64) -> Self {
+        MetaData {
+            inum,
+            version,
+            offset,
+            size,
+        }
+    }
+
+    /// Get the inum of the `MetaData`
+    #[must_use]
+    pub fn get_inum(&self) -> u64 {
+        self.inum
+    }
+
+    /// Get the version of the `MetaData`
+    #[must_use]
+    pub fn get_version(&self) -> u64 {
+        self.version
+    }
+
+    /// Get the offset of the `MetaData`
+    #[must_use]
+    pub fn get_offset(&self) -> u64 {
+        self.offset
+    }
+
+    /// Get the size of the `MetaData`
+    #[must_use]
+    pub fn get_size(&self) -> u64 {
+        self.size
+    }
+
+    /// Convert the `MetaData` to a string
+    #[must_use]
+    pub fn to_id(&self) -> String {
+        format!("{}/{}.block", self.inum, self.offset)
+    }
+
+    /// TODO: Update to use .block
+    /// Create a `MetaData` from a string
+    pub fn from_id(id: &str) -> Option<Self> {
+        let parts: Vec<&str> = id.split('_').collect();
+        if parts.len() != 4 {
+            return None;
+        }
+
+        let inum: u64 = parts.get(0)?.parse().ok()?;
+        let version: u64 = parts.get(1)?.parse().ok()?;
+        let offset: u64 = parts.get(2)?.parse().ok()?;
+        let size: u64 = parts.get(3)?.parse().ok()?;
+
+        return Some(MetaData {
+            inum,
+            version,
+            offset,
+            size,
+        });
+    }
+}
+
+/// Block struct to hold block data and metadata
+#[derive(Clone, Debug)]
+pub struct Block {
+    meta_data: MetaData,
+    data: bytes::Bytes,
+}
+
+impl Block {
+    /// Create a new Block instance
+    pub fn new(meta_data: MetaData, data: bytes::Bytes) -> Self {
+        // Make sure data length is BLOCK_SIZE
+        // debug_assert!(data.len() == BLOCK_SIZE);
+
+        Block { meta_data, data }
+    }
+
+    /// Get the block inner data of the Block
+    pub fn get_data(&self) -> bytes::Bytes {
+        self.data.clone()
+    }
+
+    /// Get the block meta data of the Block
+    pub fn get_meta_data(&self) -> MetaData {
+        self.meta_data.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_id() {
+        let meta_data = MetaData {
+            inum: 123,
+            version: 456,
+            offset: 789,
+            size: 10,
+        };
+        let expected_id = "123_456_789_10".to_owned();
+        assert_eq!(meta_data.to_id(), expected_id);
+    }
+
+    #[test]
+    fn test_from_id_valid() {
+        let id = "123_456_789_10";
+        let expected_meta_data = MetaData {
+            inum: 123,
+            version: 456,
+            offset: 789,
+            size: 10,
+        };
+        assert_eq!(MetaData::from_id(id), Some(expected_meta_data));
+    }
+
+    #[test]
+    fn test_from_id_invalid() {
+        let id = "123_456_789";
+        assert_eq!(MetaData::from_id(id), None);
+    }
+}

--- a/src/distribute_kv_cache/local_cache/manager.rs
+++ b/src/distribute_kv_cache/local_cache/manager.rs
@@ -1,0 +1,415 @@
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    sync::{atomic::AtomicU64, Arc, RwLock},
+};
+
+use radix_trie::Trie;
+use tracing::{debug, error};
+
+use crate::distribute_kv_cache::local_cache::block::BLOCK_SIZE;
+
+use super::{
+    backend::{Backend, FSBackend},
+    block::{Block, MetaData},
+    policy::{EvictPolicy, LRUPolicy},
+    StorageResult,
+};
+
+/// CacheManager struct to manage cache
+#[derive(Debug)]
+pub struct CacheManager<K, P>
+where
+    K: Eq + std::hash::Hash + Clone + Debug,
+    P: EvictPolicy<K>,
+{
+    policy: P,
+    cache: HashMap<K, Arc<RwLock<Block>>>,
+}
+
+impl<K, P> CacheManager<K, P>
+where
+    K: Eq + std::hash::Hash + Clone + Debug,
+    P: EvictPolicy<K>,
+{
+    /// Create a new CacheManager
+    pub fn new(policy: P) -> Self {
+        CacheManager {
+            policy,
+            cache: HashMap::new(),
+        }
+    }
+
+    /// Insert a block into the cache
+    pub fn put(&mut self, key: K, block: Arc<RwLock<Block>>) {
+        // If the cache is full, evict the least recently used block
+        if self.cache.len() >= self.policy.capacity() {
+            println!(
+                "Cache {:?} is full policy is {:?}, evict the least recently used block",
+                self.cache.len(),
+                self.policy.size()
+            );
+            if let Some(evicted_block) = self.policy.evict() {
+                println!("Evict block: {:?}", evicted_block);
+                // self.cache.remove(&evicted_block.clone());
+                // Safe drop
+                if self.cache.contains_key(&evicted_block) {
+                    println!("Evict block: {:?}", evicted_block);
+                    self.cache.remove(&evicted_block);
+                } else {
+                    println!("Evicted block {:?} not found in cache!", evicted_block);
+                }
+            }
+        }
+
+        // Insert the block into the cache and update the metadata
+        self.cache.insert(key.clone(), Arc::clone(&block));
+        self.policy.access(&key);
+        self.policy.set_evictable(&key, true);
+    }
+
+    /// Get a block from the cache
+    pub fn get(&self, key: &K) -> Option<Arc<RwLock<Block>>> {
+        if let Some(block) = self.cache.get(key) {
+            // Get the block from the cache and update the policy
+            self.policy.access(key);
+            Some(Arc::clone(&block))
+        } else {
+            None
+        }
+    }
+
+    /// Remove a block from the cache
+    pub fn remove(&mut self, key: &K) -> Option<Arc<RwLock<Block>>> {
+        if let Some(block) = self.cache.remove(key) {
+            // Remove the block from the cache and update the policy
+            self.policy.remove(key);
+            Some(block)
+        } else {
+            None
+        }
+    }
+}
+
+/// BlockManager struct to manage blocks
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct BlockManager {
+    /// CacheManager to manage blocks and metadata
+    cache: Arc<RwLock<CacheManager<MetaData, LRUPolicy<MetaData>>>>,
+    /// Backend to interact with the storage, default is FSBackend, we need to flush block to local fs
+    backend: Arc<dyn Backend>,
+}
+
+impl BlockManager {
+    /// Create a new BlockManager
+    pub fn new(backend: Arc<dyn Backend>) -> Self {
+        // Create a new LRUPolicy with a capacity of 2000
+        // It will evict the least recently used block when the cache is full
+        // TODO: Support mem limit and block size limit， current is block count limit
+        let policy = LRUPolicy::new(2000);
+        let cache = Arc::new(RwLock::new(CacheManager::new(policy)));
+        BlockManager { cache, backend }
+    }
+
+    /// Create a new KVBlockManager with default FSBackend
+    pub fn default() -> Self {
+        let backend = Arc::new(FSBackend::default());
+        Self::new(backend)
+    }
+
+    /// Try to read the block from the cache, if not found, try to read from the storage
+    /// TODO: We need to compare the meta data version with the latest version in the storage
+    /// If the version is old, we need to read the block from the storage
+    /// If the version is the latest, client need to fetch the latest version
+    #[allow(dead_code)]
+    pub async fn read(&self, meta_data: MetaData) -> StorageResult<Option<Block>> {
+        // Try to read the block from the cache
+        {
+            if let Some(block_ref) = self.cache.read().unwrap().get(&meta_data) {
+                let block = block_ref.read().unwrap();
+                return Ok(Some(block.clone()));
+            }
+        }
+
+        // Try to fetch data and update local cache
+        {
+            // Try to read file from fs backend
+            let relative_path = meta_data.to_id();
+            debug!("Read block from backend: {}", relative_path);
+            let mut buf = [0; BLOCK_SIZE];
+            let size = self
+                .backend
+                .read(&relative_path, &mut buf)
+                .await
+                .unwrap_or_default();
+
+            debug!("Read block size: {}", size);
+
+            // If the size is not equal to BLOCK_SIZE, the block is invalid
+            if size != BLOCK_SIZE {
+                // Remove the invalid block from fs backend
+                self.backend
+                    .remove(&relative_path)
+                    .await
+                    .unwrap_or_default();
+                debug!("Invalid block: {}", relative_path);
+                return Ok(None);
+            }
+
+            // error!("Read block len: {:?}", buf.len());
+            // error!("Read block inner content: {:?}", buf);
+
+            let block = Block::new(meta_data.clone(), bytes::Bytes::from(buf.to_vec()));
+
+            // error!("Read block: {:?}", block);
+
+            // Write the block to the cache
+            let block_ref = Arc::new(RwLock::new(block.clone()));
+            self.cache
+                .write()
+                .unwrap()
+                .put(meta_data.clone(), block_ref);
+
+            // error!("Read block: {:?}", block);
+
+            return Ok(Some(block));
+        }
+    }
+
+    /// Write the block to the cache
+    /// TODO: Now this operation only support store block to cache and fs storage
+    #[allow(dead_code)]
+    pub async fn write(&mut self, block: &Block) -> StorageResult<()> {
+        let meta = block.get_meta_data();
+        // let relative_path = meta.to_id();
+
+        // Write the block to the cache
+        let block_ref = Arc::new(RwLock::new(block.clone()));
+        self.cache.write().unwrap().put(meta.clone(), block_ref);
+
+        // Write the block to the storage
+        // 20241210 ignore this op
+        // let _ = self
+        //     .backend
+        //     .store(&relative_path, block.get_data().as_slice())
+        //     .await
+        //     .map_err(|e| format!("Failed to write block: {}", e));
+
+        Ok(())
+    }
+
+    /// Invalidate the block
+    #[allow(dead_code)]
+    pub async fn invalid(&mut self, meta_data: MetaData) -> StorageResult<()> {
+        // Remove the block from the cache
+        self.cache.write().unwrap().remove(&meta_data);
+
+        // Remove the block from the storage
+        let relative_path = meta_data.to_id();
+        let _ = self
+            .backend
+            .remove(&relative_path)
+            .await
+            .map_err(|e| format!("Failed to remove block: {}", e));
+
+        Ok(())
+    }
+}
+
+/// KVBlockManager struct to manage blocks
+/// TODO: remove disk backend cache.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct KVBlockManager {
+    /// CacheManager to manage blocks and metadata
+    cache: Arc<RwLock<CacheManager<MetaData, LRUPolicy<MetaData>>>>,
+    /// Backend to interact with the storage, default is FSBackend, we need to flush block to local fs
+    backend: Arc<dyn Backend>,
+}
+
+impl KVBlockManager {
+    /// Create a new KVBlockManager
+    pub fn new(backend: Arc<dyn Backend>) -> Self {
+        // Create a new LRUPolicy with a capacity of 2000
+        // It will evict the least recently used block when the cache is full
+        // TODO: Support mem limit and block size limit， current is block count limit
+        // let policy = LRUPolicy::new(10);
+        let policy = LRUPolicy::new(2000);
+        let cache = Arc::new(RwLock::new(CacheManager::new(policy)));
+        KVBlockManager { cache, backend }
+    }
+
+    /// Create a new KVBlockManager with default FSBackend
+    pub fn default() -> Self {
+        let backend = Arc::new(FSBackend::default());
+        Self::new(backend)
+    }
+
+    /// Try to read the block from the cache, if not found, try to read from the storage
+    /// TODO: We need to compare the meta data version with the latest version in the storage
+    /// If the version is old, we need to read the block from the storage
+    /// If the version is the latest, client need to fetch the latest version
+    #[allow(dead_code)]
+    #[allow(clippy::unused_async)] // We will move to async read
+    pub async fn read(&self, meta_data: MetaData) -> StorageResult<Option<Arc<RwLock<Block>>>> {
+        // Try to read the block from the cache
+        {
+            if let Some(block_ref) = self.cache.read().unwrap().get(&meta_data) {
+                // let block = block_ref.read().unwrap();
+                return Ok(Some(block_ref));
+            }
+        }
+
+        return Ok(None);
+    }
+
+    /// Write the block to the cache
+    /// TODO: Now this operation only support store block to cache and fs storage
+    #[allow(dead_code)]
+    #[allow(clippy::unused_async)] // We will move to async write
+    pub async fn write(&self, block: Block) -> StorageResult<()> {
+        let meta = block.get_meta_data();
+        debug!("Write block to cache: {}", meta.to_id());
+        // let relative_path = meta.to_id();
+
+        // Write the block to the cache
+        let block_ref = Arc::new(RwLock::new(block));
+        self.cache.write().unwrap().put(meta.clone(), block_ref);
+
+        Ok(())
+    }
+
+    /// Invalidate the block
+    #[allow(dead_code)]
+    pub async fn invalid(&mut self, meta_data: MetaData) -> StorageResult<()> {
+        // Remove the block from the cache
+        self.cache.write().unwrap().remove(&meta_data);
+
+        // Remove the block from the storage
+        let relative_path = meta_data.to_id();
+        self.backend.remove(&relative_path).await
+    }
+}
+
+/// IndexManager struct to manage kv cache index.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct IndexManager<K> {
+    /// Global Radix tree to store prefix index, key is prompt, value is (block id, offset, size, address)
+    index: Arc<RwLock<Trie<Vec<K>, String>>>,
+    /// Global block id allocator
+    id_allocator: AtomicU64,
+}
+
+impl<K> IndexManager<K>
+where
+    K: num::Num + Eq,
+    Vec<K>: radix_trie::TrieKey + Clone,
+{
+    /// Create a new IndexManager
+    pub fn new() -> Self {
+        IndexManager {
+            index: Arc::new(RwLock::new(Trie::<Vec<K>, String>::new())),
+            id_allocator: AtomicU64::new(0),
+        }
+    }
+
+    /// Allocate a new block id
+    pub fn allocate_id(&self) -> u64 {
+        self.id_allocator
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Insert a new key-value pair into the index
+    pub fn insert(&self, key: Vec<K>, value: String) {
+        match self.index.write() {
+            Ok(mut write_lock) => {
+                write_lock.insert(key, value);
+            }
+            Err(e) => {
+                error!("Failed to get write lock: {}", e);
+            }
+        }
+    }
+
+    /// Remove a key-value pair from the index
+    pub fn remove(&self, key: &Vec<K>) {
+        match self.index.write() {
+            Ok(mut write_lock) => {
+                write_lock.remove(key);
+            }
+            Err(e) => {
+                error!("Failed to get write lock: {}", e);
+            }
+        }
+    }
+
+    /// Get the value by key from the index
+    pub fn get(&self, key: &Vec<K>) -> Option<String> {
+        match self.index.read() {
+            Ok(read_lock) => read_lock.get(key).cloned(),
+            Err(e) => {
+                error!("Failed to get read lock: {}", e);
+                None
+            }
+        }
+    }
+
+    /// Get longest prefix match value by key from the index and value
+    pub fn get_longest_kv(&self, key: &Vec<K>) -> Option<(Vec<K>, String)> {
+        match self.index.read() {
+            Ok(read_lock) => match read_lock.get_ancestor_key(key) {
+                Some(ancestor_key) => match read_lock.get_ancestor_value(key) {
+                    Some(value) => Some((ancestor_key.clone(), value.clone())),
+                    None => None,
+                },
+                None => None,
+            },
+            Err(e) => {
+                error!("Failed to get read lock: {}", e);
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_index_manager() {
+        let index_manager = IndexManager::new();
+        let test_key = vec![1_u32, 2_u32, 3_u32];
+        index_manager.insert(test_key.clone(), "123".to_owned());
+        assert_eq!(index_manager.get(&test_key), Some("123".to_owned()));
+        index_manager.remove(&test_key);
+        assert_eq!(index_manager.get(&test_key), None);
+
+        // Test longest prefix match
+        let test_key = vec![1_u32, 2_u32, 3_u32];
+        let test1_key = vec![1_u32, 2_u32, 3_u32, 4_u32];
+        let test2_key = vec![1_u32, 2_u32, 3_u32, 5_u32];
+        let test3_key = vec![1_u32, 2_u32, 3_u32, 6_u32];
+        index_manager.insert(test_key.clone(), "123".to_owned());
+        index_manager.insert(test1_key.clone(), "1234".to_owned());
+        index_manager.insert(test2_key.clone(), "12345".to_owned());
+        assert_eq!(
+            index_manager.get_longest_kv(&test_key),
+            Some((test_key.clone(), "123".to_owned()))
+        );
+        assert_eq!(
+            index_manager.get_longest_kv(&test1_key),
+            Some((test1_key.clone(), "1234".to_owned()))
+        );
+        assert_eq!(
+            index_manager.get_longest_kv(&test2_key),
+            Some((test2_key.clone(), "12345".to_owned()))
+        );
+        assert_eq!(
+            index_manager.get_longest_kv(&test3_key),
+            Some((test_key.clone(), "123".to_owned()))
+        );
+    }
+}

--- a/src/distribute_kv_cache/local_cache/mod.rs
+++ b/src/distribute_kv_cache/local_cache/mod.rs
@@ -1,0 +1,38 @@
+use thiserror::Error;
+
+/// The backend wrapper of `openDAL` operator.
+pub mod backend;
+
+/// The block module.
+pub mod block;
+
+/// The manager of memory cache module.
+pub mod manager;
+
+/// The policy module.
+pub mod policy;
+
+/// The result of storage operation.
+pub type StorageResult<T> = Result<T, StorageError>;
+
+/// An error occurs in storage operation.
+#[derive(Debug, Error)]
+pub enum StorageError {
+    /// The storage operation is out of range of a block
+    #[error("{found} is out of range of {maximum}")]
+    OutOfRange {
+        /// The maximum size of the operated block
+        maximum: usize,
+        /// The size or offset found in argument
+        found: usize,
+    },
+    /// An error caused by [`std::io::Error`]
+    #[error("{0}")]
+    StdIoError(#[from] std::io::Error),
+    /// An error caused by [`opendal::Error`]
+    #[error("{0}")]
+    OpenDalError(#[from] opendal::Error),
+    /// A internal storage error.
+    #[error("{0}")]
+    Internal(#[from] anyhow::Error),
+}

--- a/src/distribute_kv_cache/local_cache/policy.rs
+++ b/src/distribute_kv_cache/local_cache/policy.rs
@@ -1,0 +1,226 @@
+//! The LRU policy implementation.
+
+use std::hash::Hash;
+
+use hashlink::LinkedHashMap;
+use parking_lot::Mutex;
+
+/// The evict policy trait.
+pub trait EvictPolicy<K> {
+    /// Create a new policy with the given capacity.
+    fn new(capacity: usize) -> Self;
+
+    /// Create a new non-evictable entry if the key has not been seen before.
+    fn access(&self, key: &K);
+
+    /// Try to evict a evictable key by the policy.
+    fn evict(&self) -> Option<K>;
+
+    /// Toggle whether a key is evictable or non-evictable.
+    fn set_evictable(&self, key: &K, evictable: bool);
+
+    /// Decrement the size of the policy when a key is removed successfully.
+    fn remove(&self, key: &K);
+
+    /// Get the current size of the policy.
+    fn size(&self) -> usize;
+
+    /// Get the capacity of the policy.
+    fn capacity(&self) -> usize;
+}
+
+/// The evict policy based on LRU.
+#[derive(Debug)]
+pub struct LRUPolicy<K>
+where
+    K: Clone + Hash + Eq,
+{
+    /// The inner map
+    inner: Mutex<LinkedHashMap<K, bool>>,
+    /// The capacity of this policy
+    capacity: usize,
+}
+
+impl<K: Clone + Hash + Eq> EvictPolicy<K> for LRUPolicy<K> {
+    #[must_use]
+    #[inline]
+    fn new(capacity: usize) -> Self {
+        LRUPolicy {
+            inner: Mutex::new(LinkedHashMap::with_capacity(capacity)),
+            capacity,
+        }
+    }
+
+    #[inline]
+    fn access(&self, key: &K) {
+        {
+            let mut inner = self.inner.lock();
+            // Move the accessed key to the end to mark it as most recently used.
+            // If the key does not exist, it inserts a new entry marked as non-evictable by
+            // default (false).
+            if !inner.contains_key(&key) {
+                // Before adding a new key, check if we reach the capacity.
+                if inner.len() == self.capacity {
+                    // Reach the capacity, panic
+                    // This should be handled by the caller, not the policy.
+                    panic!("Capacity reached");
+                }
+                inner.insert(key.clone(), false);
+            } else {
+                inner.to_back(key);
+            }
+        }
+        self.set_evictable(key, false);
+    }
+
+    #[inline]
+    fn evict(&self) -> Option<K> {
+        let mut inner = self.inner.lock();
+        let mut evict_key = None;
+        // Find the first evictable key from the beginning.
+        for (key, evictable) in inner.iter() {
+            if *evictable {
+                evict_key = Some(key.clone());
+                break;
+            }
+        }
+        let key = evict_key?;
+        inner.remove(&key); // This automatically decrements the size.
+        Some(key)
+    }
+
+    #[inline]
+    fn set_evictable(&self, key: &K, evictable: bool) {
+        let mut inner = self.inner.lock();
+        if let Some(prev_evictable) = inner.get_mut(key) {
+            *prev_evictable = evictable;
+        } else {
+            // This should not happen.
+            panic!("LRUPolicy::set_evictable : Key not found");
+        }
+    }
+
+    #[inline]
+    fn remove(&self, key: &K) {
+        let mut inner = self.inner.lock();
+        let evictable = inner.get(key);
+        if let Some(evictable) = evictable {
+            if *evictable {
+                inner.remove(key);
+            }
+        } else {
+            // This should not happen.
+            panic!("LRUPolicy::remove : Key not found");
+        }
+    }
+
+    #[inline]
+    fn size(&self) -> usize {
+        self.inner.lock().len()
+    }
+
+    #[inline]
+    fn capacity(&self) -> usize {
+        self.capacity
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::default_numeric_fallback)]
+mod tests {
+    use super::{EvictPolicy, LRUPolicy};
+
+    /// Create a `LruPolicy` of `i32`, with keys `1 -> 2 -> 3`.
+    fn create_lru() -> LRUPolicy<i32> {
+        let cache = LRUPolicy::<i32>::new(3);
+
+        cache.access(&1);
+        cache.access(&2);
+        cache.access(&3);
+
+        cache.set_evictable(&1, true);
+        cache.set_evictable(&2, true);
+        cache.set_evictable(&3, true);
+        assert!(cache.size() == 3);
+        cache
+    }
+
+    #[test]
+    #[should_panic(expected = "Capacity reached")]
+    fn test_insert_full() {
+        let cache = create_lru();
+        cache.access(&4);
+    }
+
+    #[test]
+    fn test_evict() {
+        let cache = create_lru();
+
+        let evicted = cache.evict();
+        assert_eq!(evicted, Some(1));
+
+        // 2 -> 3
+        cache.access(&4);
+    }
+
+    #[test]
+    fn test_touch() {
+        let cache = create_lru();
+
+        cache.access(&1);
+
+        // 2 -> 3 -> 1
+        let evicted = cache.evict();
+        assert_eq!(evicted, Some(2));
+    }
+
+    #[test]
+    fn test_remove() {
+        let cache = create_lru();
+
+        cache.remove(&1);
+        assert_eq!(cache.size(), 2);
+    }
+
+    #[test]
+    fn sample_evict_test() {
+        let cache = LRUPolicy::<i32>::new(7);
+
+        for i in 1..7 {
+            cache.access(&i);
+            cache.set_evictable(&i, true);
+        }
+        assert_eq!(cache.size(), 6);
+        cache.access(&1);
+
+        assert_eq!(cache.evict(), Some(2));
+        assert_eq!(cache.evict(), Some(3));
+        assert_eq!(cache.evict(), Some(4));
+
+        // 5-> 6 -> 1
+        assert_eq!(cache.size(), 3);
+
+        // 5 -> 6 -> 1 -> 7
+        cache.access(&7);
+
+        // 5 -> 6 -> 7 -> 1
+        cache.access(&1);
+
+        // 5 -> 7 -> 1 -> 6
+        cache.access(&6);
+
+        cache.set_evictable(&5, true);
+        cache.set_evictable(&6, true);
+        cache.set_evictable(&1, true);
+
+        // Since 7 is not evictable, it should be evicted.
+        assert_eq!(cache.evict(), Some(5));
+        assert_eq!(cache.evict(), Some(1));
+        assert_eq!(cache.evict(), Some(6));
+        assert_eq!(cache.evict(), None);
+
+        // Set 7 as evictable
+        cache.set_evictable(&7, true);
+        assert_eq!(cache.evict(), Some(7));
+    }
+}

--- a/src/distribute_kv_cache/mod.rs
+++ b/src/distribute_kv_cache/mod.rs
@@ -2,3 +2,6 @@
 
 /// RPC module for cache
 pub mod rpc;
+
+/// Local in-memory cache
+pub mod local_cache;

--- a/src/distribute_kv_cache/mod.rs
+++ b/src/distribute_kv_cache/mod.rs
@@ -1,0 +1,4 @@
+//! Distributed cache module
+
+/// RPC module for cache
+pub mod rpc;

--- a/src/distribute_kv_cache/rpc/client.rs
+++ b/src/distribute_kv_cache/rpc/client.rs
@@ -1,0 +1,779 @@
+use std::{
+    cell::UnsafeCell,
+    fmt::Debug,
+    pin::Pin,
+    sync::{atomic::AtomicU64, Arc},
+    task::{Context, Poll},
+};
+
+use bytes::BytesMut;
+use futures::{pin_mut, Future};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+    time::{Instant, Interval},
+};
+use tracing::debug;
+
+use crate::{read_exact_timeout, write_all_timeout};
+
+use super::{
+    common::ClientTimeoutOptions,
+    error::RpcError,
+    message::{ReqType, RespType},
+    packet::{Decode, Encode, Packet, PacketsKeeper, ReqHeader, RespHeader, REQ_HEADER_SIZE},
+    utils::u64_to_usize,
+};
+
+/// The huge body length for the response,
+/// when the response is too large, we need to consider to take user buffer.
+const HUGE_BODY_LEN: u64 = 1024 * 1024;
+
+/// TODO: combine `RpcClientConnectionInner` and `RpcClientConnection`
+struct RpcClientConnectionInner<P>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+{
+    /// The TCP stream for the connection.
+    stream: UnsafeCell<TcpStream>,
+    /// Options for the timeout of the connection
+    timeout_options: ClientTimeoutOptions,
+    /// Stream auto increment sequence number, used to mark the request and response
+    seq: AtomicU64,
+    /// The instant of the connection, used to calculate the keep alive timeout
+    clock_instant: Instant,
+    /// Received keep alive timestamp, will mark the valid keep alive response.
+    /// If the keep alive response is not received in right mestamp, the connection will be closed,
+    /// If we receive other response, we will update the received_keepalive_timestamp too, just treat it as a keep alive response.
+    received_keepalive_timestamp: AtomicU64,
+    /// Send packet task
+    packets_keeper: PacketsKeeper<P>,
+    /// Response buffer, try to reuse same buffer to reduce memory allocation
+    /// In case of the response is too large, we need to consider the buffer size
+    /// Init size is 4MB
+    /// Besides, we want to reduce memory copy, and read/write the response to the same data buffer
+    resp_buf: UnsafeCell<BytesMut>,
+    /// Request encode buffer
+    req_buf: UnsafeCell<BytesMut>,
+    /// The Client ID for the connection
+    client_id: u64,
+}
+
+// TODO: Add markable id for this client
+impl<P> Debug for RpcClientConnectionInner<P>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RpcClientConnectionInner")
+            .field("client id", &self.client_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<P> RpcClientConnectionInner<P>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+{
+    /// Create a new connection.
+    pub fn new(stream: TcpStream, timeout_options: &ClientTimeoutOptions, client_id: u64) -> Self {
+        Self {
+            stream: UnsafeCell::new(stream),
+            timeout_options: timeout_options.clone(),
+            seq: AtomicU64::new(0),
+            clock_instant: Instant::now(),
+            received_keepalive_timestamp: AtomicU64::new(0),
+            packets_keeper: PacketsKeeper::new(timeout_options.clone().task_timeout.as_secs()),
+            // Init buffer with 16MB
+            resp_buf: UnsafeCell::new(BytesMut::with_capacity(16 * 1024 * 1024)),
+            req_buf: UnsafeCell::new(BytesMut::with_capacity(16 * 1024 * 1024)),
+            client_id,
+        }
+    }
+
+    /// Recv request header from the stream
+    pub async fn recv_header(&self) -> Result<RespHeader, RpcError> {
+        // Try to read to buffer
+        match self.recv_len(REQ_HEADER_SIZE).await {
+            Ok(()) => {}
+            Err(err) => {
+                debug!("Failed to receive request header: {:?}", err);
+                return Err(err);
+            }
+        }
+
+        let buffer: &mut BytesMut = unsafe { &mut *self.resp_buf.get() };
+        let req_header = RespHeader::decode(buffer)?;
+        debug!("Received response header: {:?}", req_header);
+
+        Ok(req_header)
+    }
+
+    /// Receive request body from the server.
+    pub async fn recv_len(&self, len: u64) -> Result<(), RpcError> {
+        let start = tokio::time::Instant::now();
+        let mut req_buffer: &mut BytesMut = unsafe { &mut *self.resp_buf.get() };
+        if req_buffer.capacity() < u64_to_usize(len) {
+            req_buffer.reserve(u64_to_usize(len) + 1);
+            debug!(
+                "Client reserve buffer {:?} to size {:?} cost: {:?}",
+                u64_to_usize(len),
+                len,
+                start.elapsed()
+            );
+        }
+        // req_buffer.resize(u64_to_usize(len), 0);
+        // req_buffer.resize(u64_to_usize(len), 0);
+        unsafe {
+            req_buffer.set_len(u64_to_usize(len));
+        }
+        let start_1 = start.elapsed();
+        debug!(
+            "Client resize buffer {:?} to size {:?} cost: {:?}",
+            u64_to_usize(len),
+            len,
+            start_1
+        );
+
+        let reader = self.get_stream_mut();
+        match read_exact_timeout!(reader, &mut req_buffer, self.timeout_options.read_timeout).await
+        {
+            Ok(size) => {
+                debug!("{:?} Received response body len: {:?}", self, size);
+                Ok(())
+            }
+            Err(err) => {
+                debug!("{:?} Failed to receive response header: {:?}", self, err);
+                Err(RpcError::InternalError(err.to_string()))
+            }
+        }
+    }
+
+    /// Receive request body from the server, try to read huge len data with given buffer.
+    pub async fn recv_huge_len(&self, len: u64, req_buffer: &mut BytesMut) -> Result<(), RpcError> {
+        let start = tokio::time::Instant::now();
+        if req_buffer.capacity() < u64_to_usize(len) {
+            req_buffer.reserve(u64_to_usize(len) + 1);
+            debug!(
+                "Client reserve buffer {:?} to size {:?} cost: {:?}",
+                u64_to_usize(len),
+                len,
+                start.elapsed()
+            );
+        }
+        // req_buffer.resize(u64_to_usize(len), 0);
+        // req_buffer.resize(u64_to_usize(len), 0);
+        unsafe {
+            req_buffer.set_len(u64_to_usize(len));
+        }
+        let start_1 = start.elapsed();
+        debug!(
+            "Client resize buffer {:?} to size {:?} cost: {:?}",
+            u64_to_usize(len),
+            len,
+            start_1
+        );
+
+        let reader = self.get_stream_mut();
+        match read_exact_timeout!(reader, req_buffer, self.timeout_options.read_timeout).await {
+            Ok(size) => {
+                debug!("{:?} Received response body len: {:?}", self, size);
+                Ok(())
+            }
+            Err(err) => {
+                debug!("{:?} Failed to receive response header: {:?}", self, err);
+                Err(RpcError::InternalError(err.to_string()))
+            }
+        }
+    }
+
+    /// Send a request to the server.
+    /// We need to make sure
+    /// Current send packet need to be in one task, so if we need to send ping and packet
+    /// we need to make sure only one operation is running, like select.
+    pub async fn send_data(
+        &self,
+        req_header: &dyn Encode,
+        req_body: Option<&dyn Encode>,
+    ) -> Result<(), RpcError> {
+        let start = tokio::time::Instant::now();
+        let buf = unsafe { &mut *self.req_buf.get() };
+        // unsafe {
+        //     buf.set_len(0);
+        // }
+        buf.clear();
+
+        // encode just need to append to buffer, do not clear buffer
+        req_header.encode(buf);
+        // Append the body to the buffer
+        if let Some(body) = req_body {
+            // encode just need to append to buffer, do not clear buffer
+            body.encode(buf);
+        }
+        let start_1 = start.elapsed();
+        debug!("{:?} Encode request cost: {:?}", self, start_1);
+
+        // TODO: If data is very large, we need to send it in multiple times
+        // and do not copy the data
+
+        debug!("{:?} Sent data with length: {:?}", self, buf.len());
+        let writer = self.get_stream_mut();
+        // Copy from user space to tcp stream
+        match write_all_timeout!(writer, buf, self.timeout_options.write_timeout).await {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                debug!("{:?} Failed to send data: {:?}", self, err);
+                Err(RpcError::InternalError(err.to_string()))
+            }
+        }
+    }
+
+    /// Get the next sequence number.
+    pub fn next_seq(&self) -> u64 {
+        self.seq.fetch_add(1, std::sync::atomic::Ordering::AcqRel)
+    }
+
+    /// Send keep alive message to the server
+    pub async fn ping(&self) -> Result<(), RpcError> {
+        // Send keep alive message
+        let current_seq = self.next_seq();
+        let current_timestamp = self.clock_instant.elapsed().as_secs();
+        // Check keepalive is valid
+        let received_keepalive_timestamp = self
+            .received_keepalive_timestamp
+            .load(std::sync::atomic::Ordering::Acquire);
+        if current_timestamp - received_keepalive_timestamp
+            > self.timeout_options.keep_alive_timeout.as_secs()
+        {
+            debug!("{:?} keep alive timeout, close the connection", self);
+            return Err(RpcError::InternalError("Keep alive timeout".to_owned()));
+        }
+
+        // Set to packet task
+        let keep_alive_msg = ReqHeader {
+            seq: current_seq,
+            op: ReqType::KeepAliveRequest.to_u8(),
+            len: 0,
+        };
+
+        if let Ok(()) = self.send_data(&keep_alive_msg, None).await {
+            debug!("{:?} Success to sent keep alive message", self);
+            Ok(())
+        } else {
+            debug!("{:?} Failed to send keep alive message", self);
+            Err(RpcError::InternalError(
+                "Failed to send keep alive message".to_owned(),
+            ))
+        }
+    }
+
+    /// Send packet by the client.
+    pub async fn send_packet(&self, mut req_packet: P) -> Result<(), RpcError> {
+        let current_seq = self.next_seq();
+        req_packet.set_seq(current_seq);
+        debug!("{:?} Try to send request: {:?}", self, current_seq);
+
+        // Send may be used in different threads, so we need to create local buffer to store the request data
+        let req_len = req_packet.get_req_len(); // Try to get request buffer
+        let req_header = ReqHeader {
+            seq: req_packet.seq(),
+            op: req_packet.op(),
+            len: req_len,
+        };
+
+        debug!("{:?} Try to send request: {:?}", self, req_header);
+
+        // concate req_header and req_buffer
+        if let Ok(()) = self.send_data(&req_header, Some(&req_packet)).await {
+            // We have set a copy to keeper and manage the status for the packets keeper
+            // Set to packet task with clone
+            self.packets_keeper.add_task(req_packet)?;
+            debug!("{:?} Sent request success: {:?}", self, current_seq);
+
+            Ok(())
+        } else {
+            debug!("{:?} Failed to send request: {:?}", self, current_seq);
+            Err(RpcError::InternalError("Failed to send request".to_owned()))
+        }
+    }
+
+    /// Receive loop for the client.
+    pub async fn recv_loop(&self) {
+        // Check and clean keeper timeout unused task
+        // The timeout data will be cleaned by the get function
+        // We don't need to clean the timeout data radically
+        let mut tickers = Box::pin(tokio::time::interval(
+            self.timeout_options.task_timeout.div_f32(2.0),
+        ));
+        loop {
+            debug!("{:?} recv_loop Start to receive response", self);
+            // Clean timeout tasks, will block here
+            let recv_header_f = self.recv_header();
+            pin_mut!(recv_header_f);
+            let selector = ReceiveHeaderFuture::new(self, &mut tickers, &mut recv_header_f);
+            match selector.await {
+                Ok(header) => {
+                    // Try to receive the response from the server
+                    let header_seq = header.seq;
+                    debug!("{:?} Received keep alive response or other response.", self);
+                    let current_timestamp = self.clock_instant.elapsed().as_secs();
+                    self.received_keepalive_timestamp
+                        .store(current_timestamp, std::sync::atomic::Ordering::Release);
+                    // Update the received keep alive seq
+                    if let Ok(resp_type) = RespType::from_u8(header.op) {
+                        if let RespType::KeepAliveResponse = resp_type {
+                            // Keep alive response, receive_header will handle this op.
+                            debug!("{:?} Received keep alive response: {:?}", self, header);
+                        } else {
+                            debug!("{:?} Received response header: {:?}", self, header);
+                            // Try to read to buffer
+                            if header.len <= HUGE_BODY_LEN {
+                                debug!("{:?} Try to receive response body with size {:?} in client buffer", self, header.len);
+                                match self.recv_len(header.len).await {
+                                    Ok(()) => {}
+                                    Err(err) => {
+                                        debug!(
+                                            "{:?} Failed to receive request header: {:?}",
+                                            self, err
+                                        );
+                                        break;
+                                    }
+                                }
+
+                                // Take the packet task and recv the response
+                                let resp_buffer: &mut BytesMut =
+                                    unsafe { &mut *self.resp_buf.get() };
+                                // Fix: add a retry here in case of the task is not ready or failed
+                                match self
+                                    .packets_keeper
+                                    .take_task(header_seq, resp_buffer.clone())
+                                    .await
+                                {
+                                    Ok(()) => {
+                                        debug!("{:?} Received response: {:?}", self, header_seq);
+                                    }
+                                    Err(err) => {
+                                        debug!("{:?} Failed to update task: {:?}", self, err);
+                                    }
+                                }
+                            } else {
+                                debug!("{:?} Try to receive huge response body with size {:?} in user buffer", self, header.len);
+                                let mut resp_buffer =
+                                    BytesMut::with_capacity(u64_to_usize(header.len));
+                                match self.recv_huge_len(header.len, &mut resp_buffer).await {
+                                    Ok(()) => {}
+                                    Err(err) => {
+                                        debug!(
+                                            "{:?} Failed to receive request header: {:?}",
+                                            self, err
+                                        );
+                                        break;
+                                    }
+                                }
+
+                                // Fix: add a retry here in case of the task is not ready or failed
+                                // TODO: take a look about take_task is slow
+                                match self.packets_keeper.take_task(header_seq, resp_buffer).await {
+                                    Ok(()) => {
+                                        debug!("{:?} Received response: {:?}", self, header_seq);
+                                    }
+                                    Err(err) => {
+                                        debug!("{:?} Failed to update task: {:?}", self, err);
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        debug!("{:?} Invalid response type: {:?}", self, header.op);
+                        break;
+                    }
+                }
+                Err(err) => {
+                    debug!("{:?} Failed to receive request header: {:?}", self, err);
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Get stream with mutable reference
+    #[allow(clippy::mut_from_ref)]
+    fn get_stream_mut(&self) -> &mut TcpStream {
+        // Current implementation is safe because the stream is only accessed by one thread
+        unsafe { &mut *self.stream.get() }
+    }
+}
+
+unsafe impl<P> Send for RpcClientConnectionInner<P> where P: Packet + Clone + Send + Sync + 'static {}
+
+unsafe impl<P> Sync for RpcClientConnectionInner<P> where P: Packet + Clone + Send + Sync + 'static {}
+
+/// The RPC client definition.
+#[derive(Debug)]
+pub struct RpcClient<P>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+{
+    /// The timeout options for the client.
+    /// TODO:
+    #[allow(dead_code)]
+    timeout_options: ClientTimeoutOptions,
+    /// Inner connection for the client.
+    inner_connection: Arc<RpcClientConnectionInner<P>>,
+    /// Client ID for the connection
+    /// TODO:
+    #[allow(dead_code)]
+    client_id: AtomicU64,
+}
+
+impl<P> RpcClient<P>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+{
+    /// Create a new RPC client.
+    ///
+    /// We don't manage the stream is dead or clean
+    /// The client will be closed if the keep alive message is not received in 100 times
+    /// When the stream is broken, the client will be closed, and we need to recreate a new client
+    pub fn new(stream: TcpStream, timeout_options: &ClientTimeoutOptions) -> Self {
+        let client_id = AtomicU64::new(0);
+        let inner_connection = RpcClientConnectionInner::new(
+            stream,
+            timeout_options,
+            client_id.load(std::sync::atomic::Ordering::Acquire),
+        );
+
+        Self {
+            timeout_options: timeout_options.clone(),
+            inner_connection: Arc::new(inner_connection),
+            client_id,
+        }
+    }
+
+    /// Start client receiver
+    pub fn start_recv(&self) {
+        // Create a receiver loop
+        let inner_connection_clone = Arc::clone(&self.inner_connection);
+        tokio::spawn(async move {
+            inner_connection_clone.recv_loop().await;
+        });
+    }
+
+    /// Send a request to the server.
+    /// Try to send data to channel, if the channel is full, return an error.
+    /// Contains the rezquest header and body.
+    /// WARN: this function does not support concurrent call
+    pub async fn send_request(&self, req: P) -> Result<(), RpcError> {
+        self.inner_connection
+            .send_packet(req)
+            .await
+            .map_err(|err| RpcError::InternalError(err.to_string()))
+    }
+
+    /// Manually send ping by the send request
+    /// The inner can not start two loop, because the stream is unsafe
+    /// we need to start the loop in the client or higher level manually
+    /// WARN: this function does not support concurrent call
+    pub async fn ping(&self) -> Result<(), RpcError> {
+        self.inner_connection.ping().await
+    }
+}
+
+/// The receive stream for the client.
+/// The stream will be used to receive the response from the server,
+/// and clean outdated tasks when the task is timeout.
+struct ReceiveHeaderFuture<'a, P, F>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+    F: Future<Output = Result<RespHeader, RpcError>> + Unpin,
+{
+    /// The inner connection for the client.
+    client_inner: &'a RpcClientConnectionInner<P>,
+    /// The interval for period task.
+    interval: &'a mut Pin<Box<Interval>>,
+    /// The recv_future in the client.
+    recv_future: Pin<&'a mut F>,
+}
+
+impl<'a, P, F> ReceiveHeaderFuture<'a, P, F>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+    F: Future<Output = Result<RespHeader, RpcError>> + Unpin,
+{
+    /// Create a new receive header stream.
+    fn new(
+        client_inner: &'a RpcClientConnectionInner<P>,
+        interval: &'a mut Pin<Box<Interval>>,
+        recv_future: &'a mut F,
+    ) -> Self {
+        Self {
+            client_inner,
+            interval,
+            recv_future: Pin::new(recv_future),
+        }
+    }
+}
+
+impl<'a, P, F> Future for ReceiveHeaderFuture<'a, P, F>
+where
+    P: Packet + Clone + Send + Sync + 'static,
+    F: Future<Output = Result<RespHeader, RpcError>> + Unpin,
+{
+    type Output = Result<RespHeader, RpcError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let self_mut: &mut ReceiveHeaderFuture<'a, P, F> = self.get_mut();
+        let client_inner = self_mut.client_inner;
+
+        // clean timeout tasks
+        let mut tick_ready = false;
+        while self_mut.interval.as_mut().poll_tick(cx).is_ready() {
+            // consume all ticks in once call
+            tick_ready = true;
+        }
+        while tick_ready {
+            let clean_future = client_inner.packets_keeper.clean_timeout_tasks();
+            pin_mut!(clean_future);
+            match clean_future.poll(cx) {
+                Poll::Ready(()) => tick_ready = false,
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+
+        // recv header data
+        self_mut.recv_future.as_mut().poll(cx)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+    use async_trait::async_trait;
+    use bytes::BufMut;
+    use tokio::net::TcpListener;
+
+    use crate::{
+        async_fuse::util::usize_to_u64, distribute_kv_cache::rpc::utils::get_u64_from_buf,
+    };
+
+    use super::*;
+    use std::{mem, time::Duration};
+
+    /// Request struct for test
+    #[derive(Debug, Default, Clone)]
+    pub struct TestRequest {
+        pub id: u64,
+    }
+
+    impl Encode for TestRequest {
+        fn encode(&self, buf: &mut BytesMut) {
+            buf.put_u64(self.id.to_le());
+        }
+    }
+
+    impl Decode for TestRequest {
+        fn decode(buf: &mut BytesMut) -> Result<Self, RpcError> {
+            if buf.len() < 8 {
+                return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+            }
+            let id = get_u64_from_buf(buf, 0)?;
+            Ok(TestRequest { id })
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct TestPacket {
+        pub seq: u64,
+        pub op: u8,
+        pub request: TestRequest,
+        pub timestamp: u64,
+    }
+
+    impl Encode for TestPacket {
+        fn encode(&self, buf: &mut BytesMut) {
+            self.request.encode(buf);
+        }
+    }
+
+    #[async_trait]
+    impl Packet for TestPacket {
+        fn seq(&self) -> u64 {
+            self.seq
+        }
+
+        fn set_seq(&mut self, seq: u64) {
+            self.seq = seq;
+        }
+
+        fn op(&self) -> u8 {
+            self.op
+        }
+
+        fn set_op(&mut self, op: u8) {
+            self.op = op;
+        }
+
+        fn set_timestamp(&mut self, timestamp: u64) {
+            self.timestamp = timestamp;
+        }
+
+        fn get_timestamp(&self) -> u64 {
+            self.timestamp
+        }
+
+        fn set_resp_data(&mut self, _data: BytesMut) -> Result<(), RpcError> {
+            Ok(())
+        }
+
+        async fn set_result(self, _status: Result<(), RpcError>) {}
+
+        fn get_req_len(&self) -> u64 {
+            usize_to_u64(mem::size_of_val(&self.request))
+        }
+    }
+
+    // Helper function to setup a mock server
+    async fn setup_mock_server(addr: String, response: Vec<u8>) -> String {
+        let listener = TcpListener::bind(addr).await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                socket.write_all(&response).await.unwrap(); // Send a predefined response
+                socket.flush().await.unwrap();
+            }
+        });
+        addr
+    }
+
+    #[tokio::test]
+    async fn test_new_connection() {
+        // setup();
+        let local_addr = setup_mock_server("127.0.0.1:50050".to_owned(), vec![]).await;
+        let stream = TcpStream::connect(local_addr).await.unwrap();
+        let timeout_options = ClientTimeoutOptions {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            task_timeout: Duration::from_secs(60),
+            keep_alive_timeout: Duration::from_secs(30),
+        };
+        let client_id = 123;
+        let connection =
+            RpcClientConnectionInner::<TestPacket>::new(stream, &timeout_options, client_id);
+        assert_eq!(connection.client_id, client_id);
+    }
+
+    #[tokio::test]
+    async fn test_recv_header() {
+        // setup();
+        let mut buf = BytesMut::new();
+        RespHeader {
+            seq: 1,
+            op: RespType::KeepAliveResponse.to_u8(),
+            len: 0,
+        }
+        .encode(&mut buf);
+        let addr = setup_mock_server("127.0.0.1:50052".to_owned(), buf.to_vec()).await;
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let timeout_options = ClientTimeoutOptions {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            task_timeout: Duration::from_secs(60),
+            keep_alive_timeout: Duration::from_secs(30),
+        };
+        let connection = RpcClientConnectionInner::<TestPacket>::new(stream, &timeout_options, 123);
+        let header = connection.recv_header().await.unwrap();
+        assert_eq!(header.seq, 1);
+        assert_eq!(header.op, RespType::KeepAliveResponse.to_u8());
+    }
+
+    #[tokio::test]
+    async fn test_recv_len() {
+        // setup();
+        // Create a 10 len vector
+        let response = vec![0; 10];
+        let addr = setup_mock_server("127.0.0.1:50053".to_owned(), response).await;
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let timeout_options = ClientTimeoutOptions {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            task_timeout: Duration::from_secs(60),
+            keep_alive_timeout: Duration::from_secs(30),
+        };
+        let connection = RpcClientConnectionInner::<TestPacket>::new(stream, &timeout_options, 123);
+        connection.recv_len(10).await.unwrap();
+    }
+
+    struct TestData;
+    impl Encode for TestData {
+        fn encode(&self, buf: &mut BytesMut) {
+            let data = b"Hello, world!";
+            buf.extend_from_slice(data);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_data() {
+        // setup();
+        let addr = setup_mock_server("127.0.0.1:50054".to_owned(), vec![]).await;
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let timeout_options = ClientTimeoutOptions {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            task_timeout: Duration::from_secs(60),
+            keep_alive_timeout: Duration::from_secs(30),
+        };
+        let connection = RpcClientConnectionInner::<TestPacket>::new(stream, &timeout_options, 123);
+        let req_header = ReqHeader {
+            seq: 1,
+            op: ReqType::KeepAliveRequest.to_u8(),
+            len: 0,
+        };
+
+        connection
+            .send_data(&req_header, Some(&TestData {}))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_next_seq() {
+        // setup();
+        let addr = setup_mock_server("127.0.0.1:50055".to_owned(), vec![]).await;
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let timeout_options = ClientTimeoutOptions {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            task_timeout: Duration::from_secs(60),
+            keep_alive_timeout: Duration::from_secs(30),
+        };
+        let client_id = 123;
+        let connection =
+            RpcClientConnectionInner::<TestPacket>::new(stream, &timeout_options, client_id);
+        let seq1 = connection.next_seq();
+        let seq2 = connection.next_seq();
+        assert_eq!(seq1 + 1, seq2);
+    }
+
+    #[tokio::test]
+    async fn test_ping() {
+        // setup();
+        let mut buf = BytesMut::new();
+        RespHeader {
+            seq: 1,
+            op: RespType::KeepAliveResponse.to_u8(),
+            len: 0,
+        }
+        .encode(&mut buf);
+        let addr = setup_mock_server("127.0.0.1:50056".to_owned(), buf.to_vec()).await;
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let timeout_options = ClientTimeoutOptions {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            task_timeout: Duration::from_secs(60),
+            keep_alive_timeout: Duration::from_secs(30),
+        };
+        let connection = RpcClientConnectionInner::<TestPacket>::new(stream, &timeout_options, 123);
+        connection.ping().await.unwrap();
+    }
+}

--- a/src/distribute_kv_cache/rpc/common.rs
+++ b/src/distribute_kv_cache/rpc/common.rs
@@ -1,0 +1,46 @@
+use std::time::Duration;
+
+/// Options for the timeout of the connection
+#[derive(Debug, Clone)]
+pub struct ServerTimeoutOptions {
+    /// The timeout for reading data from the connection
+    pub read_timeout: Duration,
+    /// The timeout for writing data to the connection
+    pub write_timeout: Duration,
+    /// The timeout for the idle connection
+    pub task_timeout: Duration,
+}
+
+impl Default for ServerTimeoutOptions {
+    fn default() -> Self {
+        Self {
+            read_timeout: Duration::from_secs(20),
+            write_timeout: Duration::from_secs(20),
+            task_timeout: Duration::from_secs(120),
+        }
+    }
+}
+
+/// Options for the timeout of the connection
+#[derive(Debug, Clone)]
+pub struct ClientTimeoutOptions {
+    /// The timeout for reading data from the connection
+    pub read_timeout: Duration,
+    /// The timeout for writing data to the connection
+    pub write_timeout: Duration,
+    /// The timeout for the idle connection
+    pub task_timeout: Duration,
+    /// The timeout for keep-alive connection
+    pub keep_alive_timeout: Duration,
+}
+
+impl Default for ClientTimeoutOptions {
+    fn default() -> Self {
+        Self {
+            read_timeout: Duration::from_secs(20),
+            write_timeout: Duration::from_secs(20),
+            task_timeout: Duration::from_secs(120),
+            keep_alive_timeout: Duration::from_secs(60),
+        }
+    }
+}

--- a/src/distribute_kv_cache/rpc/error.rs
+++ b/src/distribute_kv_cache/rpc/error.rs
@@ -1,0 +1,25 @@
+use std::fmt;
+
+/// Error types for the RPC server and client
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RpcError {
+    /// The request is invalid.
+    InvalidRequest(String),
+    /// The response is invalid.
+    InvalidResponse(String),
+    /// The server/client meet an internal error.
+    InternalError(String),
+    /// The request is timeout
+    Timeout(String),
+}
+
+impl fmt::Display for RpcError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::InvalidRequest(ref msg) => write!(f, "Invalid request: {msg}"),
+            Self::InvalidResponse(ref msg) => write!(f, "Invalid response: {msg}"),
+            Self::InternalError(ref msg) => write!(f, "Internal error: {msg}"),
+            Self::Timeout(ref msg) => write!(f, "Timeout: {msg}"),
+        }
+    }
+}

--- a/src/distribute_kv_cache/rpc/message.rs
+++ b/src/distribute_kv_cache/rpc/message.rs
@@ -1,0 +1,2086 @@
+use std::{fmt, mem};
+
+use async_trait::async_trait;
+use bytes::{BufMut, BytesMut};
+use clippy_utilities::{Cast, OverflowArithmetic};
+use tracing::{debug, warn};
+
+use crate::async_fuse::util::usize_to_u64;
+
+use super::{
+    error::RpcError,
+    packet::{ActualSize, Decode, Encode, Packet},
+    utils::{get_u64_from_buf, u64_to_usize},
+};
+
+/// Zero copy conversion between num key and u8 buffers.
+#[allow(clippy::mem_forget)]
+#[allow(clippy::as_conversions)]
+fn num_to_u8_buffer<K>(input: Vec<K>) -> Vec<u8>
+where
+    K: num::Num,
+{
+    let len = input.len() * mem::size_of::<K>();
+    let ptr = input.as_ptr();
+    let capacity = input.capacity();
+
+    std::mem::forget(input);
+
+    unsafe { Vec::from_raw_parts(ptr as *mut u8, len, capacity) }
+}
+
+/// Zero copy conversion between u8 and num key buffers.
+#[allow(clippy::mem_forget)]
+#[allow(clippy::as_conversions)]
+#[allow(clippy::integer_division)]
+fn u8_to_num_buffer<K>(input: Vec<u8>) -> Vec<K>
+where
+    K: num::Num,
+{
+    assert_eq!(
+        input.len() % mem::size_of::<K>(),
+        0,
+        "Buffer length must be a multiple of key size"
+    );
+    let len = input.len() / mem::size_of::<K>();
+    let ptr = input.as_ptr();
+    let capacity = input.capacity() / mem::size_of::<K>();
+
+    std::mem::forget(input);
+
+    unsafe { Vec::from_raw_parts(ptr as *mut K, len, capacity) }
+}
+
+/// Zero copy conversion between u32 and u8 buffers.
+#[allow(dead_code)]
+#[allow(clippy::mem_forget)]
+#[allow(clippy::as_conversions)]
+#[allow(clippy::integer_division)]
+fn u32_to_u8_buffer(input: Vec<u32>) -> Vec<u8> {
+    let len = input.len() * 4;
+    let ptr = input.as_ptr();
+    let capacity = input.capacity() * 4;
+
+    std::mem::forget(input);
+
+    unsafe { Vec::from_raw_parts(ptr as *mut u8, len, capacity) }
+}
+
+/// Zero copy conversion between u8 and u32 buffers.
+#[allow(dead_code)]
+#[allow(clippy::mem_forget)]
+#[allow(clippy::cast_ptr_alignment)]
+#[allow(clippy::as_conversions)]
+#[allow(clippy::integer_division)]
+fn u8_to_u32_buffer(input: Vec<u8>) -> Vec<u32> {
+    assert_eq!(input.len() % 4, 0, "Buffer length must be a multiple of 4");
+    let len = input.len() / 4;
+    let ptr = input.as_ptr();
+    let capacity = input.capacity() / 4;
+
+    std::mem::forget(input);
+
+    unsafe { Vec::from_raw_parts(ptr as *mut u32, len, capacity) }
+}
+
+/// The request type of the request.
+#[derive(Debug)]
+pub enum ReqType {
+    /// The keep alive request 0.
+    KeepAliveRequest,
+    /// The file block request 1.
+    FileBlockRequest,
+    /// The block allocate request 2.
+    KVCacheIdAllocateRequest,
+    /// The kv cache index get request 3.
+    KVCacheIndexMatchRequest,
+    /// The kv cache index batch insert request 4.
+    KVCacheIndexBatchInsertRequest,
+    /// The kv cache index remove request 5.
+    KVCacheIndexRemoveRequest,
+    /// The kv block get request 6.
+    KVBlockGetRequest,
+    /// The kv block put request 7.
+    KVBlockBatchPutRequest,
+}
+
+impl ReqType {
+    /// Convert u8 to `ReqType`
+    pub fn from_u8(op: u8) -> Result<Self, RpcError> {
+        match op {
+            0 => Ok(Self::KeepAliveRequest),
+            1 => Ok(Self::FileBlockRequest),
+            2 => Ok(Self::KVCacheIdAllocateRequest),
+            3 => Ok(Self::KVCacheIndexMatchRequest),
+            4 => Ok(Self::KVCacheIndexBatchInsertRequest),
+            5 => Ok(Self::KVCacheIndexRemoveRequest),
+            6 => Ok(Self::KVBlockGetRequest),
+            7 => Ok(Self::KVBlockBatchPutRequest),
+            _ => Err(RpcError::InternalError(format!(
+                "Invalid operation type: {op}"
+            ))),
+        }
+    }
+
+    /// Convert `ReqType` to u8
+    #[must_use]
+    pub fn to_u8(&self) -> u8 {
+        match *self {
+            Self::KeepAliveRequest => 0,
+            Self::FileBlockRequest => 1,
+            Self::KVCacheIdAllocateRequest => 2,
+            Self::KVCacheIndexMatchRequest => 3,
+            Self::KVCacheIndexBatchInsertRequest => 4,
+            Self::KVCacheIndexRemoveRequest => 5,
+            Self::KVBlockGetRequest => 6,
+            Self::KVBlockBatchPutRequest => 7,
+        }
+    }
+}
+
+/// The operation type of the response.
+#[derive(Debug)]
+pub enum RespType {
+    /// The keep alive response.
+    KeepAliveResponse,
+    /// The file block response.
+    FileBlockResponse,
+    /// The block allocate response.
+    KVCacheIdAllocateResponse,
+    /// The kv cache index get response.
+    KVCacheIndexMatchResponse,
+    /// The kv cache index put response.
+    KVCacheIndexInsertResponse,
+    /// The kv cache index remove response.
+    KVCacheIndexRemoveResponse,
+    /// The kv block get response.
+    KVBlockGetResponse,
+    /// The kv block put response.
+    KVBlockBatchPutResponse,
+}
+
+impl RespType {
+    /// Convert u8 to `RespType`
+    pub fn from_u8(op: u8) -> Result<Self, RpcError> {
+        match op {
+            0 => Ok(Self::KeepAliveResponse),
+            1 => Ok(Self::FileBlockResponse),
+            2 => Ok(Self::KVCacheIdAllocateResponse),
+            3 => Ok(Self::KVCacheIndexMatchResponse),
+            4 => Ok(Self::KVCacheIndexInsertResponse),
+            5 => Ok(Self::KVCacheIndexRemoveResponse),
+            6 => Ok(Self::KVBlockGetResponse),
+            7 => Ok(Self::KVBlockBatchPutResponse),
+            _ => Err(RpcError::InternalError(format!(
+                "Invalid operation type: {op}"
+            ))),
+        }
+    }
+
+    /// Convert `RespType` to u8
+    #[must_use]
+    pub fn to_u8(&self) -> u8 {
+        match *self {
+            Self::KeepAliveResponse => 0,
+            Self::FileBlockResponse => 1,
+            Self::KVCacheIdAllocateResponse => 2,
+            Self::KVCacheIndexMatchResponse => 3,
+            Self::KVCacheIndexInsertResponse => 4,
+            Self::KVCacheIndexRemoveResponse => 5,
+            Self::KVBlockGetResponse => 6,
+            Self::KVBlockBatchPutResponse => 7,
+        }
+    }
+}
+
+/// Common data structures shared between the client and server.
+#[derive(Debug, Default, Clone)]
+pub struct FileBlockRequest {
+    /// The file ID.
+    pub file_id: u64,
+    /// The block ID.
+    pub block_id: u64,
+    /// The block size.
+    pub block_size: u64,
+    /// The block version
+    pub block_version: u64,
+    /// The hashring version
+    /// The latest hashring version
+    /// We will return current hashring version in rpc server,
+    /// client will check if the hashring version is old as the latest one.
+    pub hash_ring_version: u64,
+}
+
+impl Encode for FileBlockRequest {
+    /// Encode the file block request into a byte buffer.
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.file_id.to_le());
+        buf.put_u64(self.block_id.to_le());
+        buf.put_u64(self.block_size.to_le());
+        buf.put_u64(self.block_version.to_le());
+        buf.put_u64(self.hash_ring_version.to_le());
+    }
+}
+
+impl Decode for FileBlockRequest {
+    /// Decode the byte buffer into a file block request.
+    fn decode(buf: &mut BytesMut) -> Result<Self, RpcError> {
+        if buf.len() < 32 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let file_id = get_u64_from_buf(buf, 0)?;
+        let block_id = get_u64_from_buf(buf, 8)?;
+        let block_size = get_u64_from_buf(buf, 16)?;
+        let block_version = get_u64_from_buf(buf, 24)?;
+        let hash_ring_version = get_u64_from_buf(buf, 32)?;
+
+        Ok(FileBlockRequest {
+            file_id,
+            block_id,
+            block_size,
+            block_version,
+            hash_ring_version,
+        })
+    }
+}
+
+/// The response to a file block request.
+#[derive(Debug, Default, Clone)]
+pub struct FileBlockResponse {
+    /// The file ID.
+    pub file_id: u64,
+    /// The block ID.
+    pub block_id: u64,
+    /// The block size.
+    pub block_size: u64,
+    /// The block version
+    pub block_version: u64,
+    /// The hashring version
+    /// The latest hashring version
+    /// We will return current hashring version in rpc server,
+    /// client will check if the hashring version is old as the latest one.
+    pub hash_ring_version: u64,
+    /// The status of the response.
+    pub status: StatusCode,
+    /// The data of the block.
+    pub data: Vec<u8>,
+}
+impl Encode for FileBlockResponse {
+    /// Encode the file block response into a byte buffer.
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.file_id.to_le());
+        buf.put_u64(self.block_id.to_le());
+        buf.put_u64(self.block_size.to_le());
+        buf.put_u64(self.block_version.to_le());
+        buf.put_u64(self.hash_ring_version.to_le());
+        match self.status {
+            StatusCode::Success => buf.put_u8(0),
+            StatusCode::NotFound => buf.put_u8(1),
+            StatusCode::InternalError => buf.put_u8(2),
+            StatusCode::VersionMismatch => buf.put_u8(3),
+        }
+        buf.put_slice(&self.data);
+    }
+}
+
+impl Decode for FileBlockResponse {
+    //// Decode the byte buffer into a file block response.
+    fn decode_large_data(buf: bytes::Bytes) -> Result<Self, RpcError> {
+        if buf.len() < 41 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let file_id = get_u64_from_buf(&buf, 0)?;
+        let block_id = get_u64_from_buf(&buf, 8)?;
+        let block_size = get_u64_from_buf(&buf, 16)?;
+        let block_version = get_u64_from_buf(&buf, 24)?;
+        let hash_ring_version = get_u64_from_buf(&buf, 32)?;
+        let status = match buf.get(40) {
+            Some(&0) => StatusCode::Success,
+            Some(&1) => StatusCode::NotFound,
+            Some(&2) => StatusCode::InternalError,
+            Some(&3) => StatusCode::VersionMismatch,
+            _ => return Err(RpcError::InternalError("Invalid status code".to_owned())),
+        };
+        let data = buf.get(41..).unwrap_or(&[]).to_vec();
+        let data_len = usize_to_u64(data.len());
+        if data_len != block_size {
+            return Err(RpcError::InternalError(format!(
+                "Insufficient block size {data_len}"
+            )));
+        }
+
+        Ok(FileBlockResponse {
+            file_id,
+            block_id,
+            block_size,
+            block_version,
+            hash_ring_version,
+            status,
+            data,
+        })
+    }
+}
+
+/// The status code of the response.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum StatusCode {
+    /// The request is successful.
+    Success,
+    /// The request is not found.
+    NotFound,
+    /// The request is invalid.
+    InternalError,
+    /// The request is out dated.
+    VersionMismatch,
+}
+
+impl Default for StatusCode {
+    /// Get the default status code.
+    fn default() -> Self {
+        Self::Success
+    }
+}
+
+/// The file block packet for client
+/// This struct impl packet trait and support file request and response
+#[derive(Debug, Clone)]
+pub struct FileBlockPacket {
+    /// The sequence number of the packet.
+    pub seq: u64,
+    /// The operation type of the packet.
+    pub op: u8,
+    /// The timestamp of the packet.
+    pub timestamp: u64,
+    /// The file block request struct.
+    pub request: FileBlockRequest,
+    /// The buffer of the packet, used to store response data.
+    pub response: Option<FileBlockResponse>,
+    /// The sender to send response back to caller.
+    pub done_tx: flume::Sender<Result<FileBlockResponse, FileBlockRequest>>,
+}
+
+impl FileBlockPacket {
+    /// Create a new file block packet.
+    #[must_use]
+    pub fn new(
+        block_request: &FileBlockRequest,
+        done_tx: flume::Sender<Result<FileBlockResponse, FileBlockRequest>>,
+    ) -> Self {
+        Self {
+            // Will be auto set by client
+            seq: 0,
+            // Set operation
+            op: ReqType::FileBlockRequest.to_u8(),
+            request: block_request.clone(),
+            timestamp: 0,
+            response: None,
+            done_tx,
+        }
+    }
+}
+
+impl Encode for FileBlockPacket {
+    /// Encode the file block packet into a byte buffer.
+    fn encode(&self, buffer: &mut BytesMut) {
+        self.request.encode(buffer);
+    }
+}
+
+#[async_trait]
+impl Packet for FileBlockPacket {
+    /// Get the sequence number of the packet.
+    fn seq(&self) -> u64 {
+        self.seq
+    }
+
+    /// Set the sequence number of the packet.
+    fn set_seq(&mut self, seq: u64) {
+        self.seq = seq;
+    }
+
+    /// Get the operation type of the packet.
+    fn op(&self) -> u8 {
+        self.op
+    }
+
+    /// Set the operation type of the packet.
+    fn set_op(&mut self, op: u8) {
+        self.op = op;
+    }
+
+    /// Get the timestamp of the packet.
+    fn set_timestamp(&mut self, timestamp: u64) {
+        self.timestamp = timestamp;
+    }
+
+    /// get the timestamp of the packet.
+    fn get_timestamp(&self) -> u64 {
+        self.timestamp
+    }
+
+    /// Set response data to current packet
+    fn set_resp_data(&mut self, data: BytesMut) -> Result<(), RpcError> {
+        self.response = Some(FileBlockResponse::decode_large_data(data.freeze())?);
+        Ok(())
+    }
+
+    /// Get the response data of the packet.
+    async fn set_result(self, status: Result<(), RpcError>) {
+        match status {
+            Ok(()) => {
+                if let Some(resp) = self.response {
+                    match self.done_tx.send_async(Ok(resp)).await {
+                        Ok(()) => {}
+                        Err(err) => {
+                            warn!("Failed to set result: {:?}", err);
+                        }
+                    }
+                } else {
+                    warn!("Failed to set result: response is None");
+                    match self.done_tx.send_async(Err(self.request.clone())).await {
+                        Ok(()) => {}
+                        Err(err) => {
+                            warn!("Failed to set result: {:?}", err);
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                warn!("Failed to set result: {:?}", err);
+                match self.done_tx.send_async(Err(self.request.clone())).await {
+                    Ok(()) => {}
+                    Err(err) => {
+                        warn!("Failed to set result: {:?}", err);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Get request size to construct request header
+    fn get_req_len(&self) -> u64 {
+        usize_to_u64(mem::size_of_val(&self.request))
+    }
+}
+
+/// The request to allocate a global kv cache id.
+#[derive(Debug, Default, Clone)]
+pub struct KVCacheIdAllocateRequest {
+    /// The kv block size.
+    pub block_size: u64,
+}
+
+impl Encode for KVCacheIdAllocateRequest {
+    /// Encode the kv cache id allocate request into a byte buffer.
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.block_size.to_le());
+    }
+}
+
+impl Decode for KVCacheIdAllocateRequest {
+    /// Decode the byte buffer into a kv cache id allocate request.
+    fn decode(buf: &mut BytesMut) -> Result<Self, RpcError> {
+        if buf.len() < 8 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let block_size = get_u64_from_buf(buf, 0)?;
+        Ok(KVCacheIdAllocateRequest { block_size })
+    }
+
+    /// Decode the byte buffer into a kv cache id allocate request.
+    fn decode_large_data(buf: bytes::Bytes) -> Result<Self, RpcError> {
+        if buf.len() < 8 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let block_size = get_u64_from_buf(&buf, 0)?;
+        Ok(KVCacheIdAllocateRequest { block_size })
+    }
+}
+
+impl ActualSize for KVCacheIdAllocateRequest {
+    /// Get the actual size of the request.
+    fn actual_size(&self) -> u64 {
+        usize_to_u64(mem::size_of_val(&self.block_size))
+    }
+}
+
+/// The response to allocate a global kv cache id.
+#[derive(Debug, Default, Clone)]
+pub struct KVCacheIdAllocateResponse {
+    /// The kv block size.
+    pub block_size: u64,
+    /// The kv cache id.
+    pub kv_cache_id: u64,
+}
+
+impl Encode for KVCacheIdAllocateResponse {
+    /// Encode the kv cache id allocate response into a byte buffer.
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.block_size.to_le());
+        buf.put_u64(self.kv_cache_id.to_le());
+    }
+}
+
+impl Decode for KVCacheIdAllocateResponse {
+    /// Decode the byte buffer into a kv cache id allocate response.
+    fn decode(buf: &mut BytesMut) -> Result<Self, RpcError> {
+        if buf.len() < 16 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let block_size = get_u64_from_buf(buf, 0)?;
+        let kv_cache_id = get_u64_from_buf(buf, 8)?;
+        Ok(KVCacheIdAllocateResponse {
+            block_size,
+            kv_cache_id,
+        })
+    }
+}
+
+/// The request to match kv cache index.
+#[derive(Debug, Default, Clone)]
+pub struct KVCacheIndexMatchRequest<K> {
+    /// The kv block size.
+    pub block_size: u64,
+    /// The kv cache key.
+    pub kv_cache_key: Vec<K>,
+}
+
+impl<K> Encode for KVCacheIndexMatchRequest<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug,
+{
+    /// Encode the kv cache index match request into a byte buffer.
+    fn encode(&self, buf: &mut BytesMut) {
+        debug!("KVCacheIndexMatchRequest self: {:?}", self);
+        buf.put_u64(self.block_size.to_le());
+        // Zero copy convert u32 to u8 buffer.
+        let buffer = num_to_u8_buffer(self.kv_cache_key.clone());
+        buf.put_slice(&buffer);
+    }
+}
+
+impl<K> Decode for KVCacheIndexMatchRequest<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug,
+{
+    /// Decode the byte buffer into a kv cache index match request.
+    #[allow(clippy::indexing_slicing)]
+    fn decode(buf: &mut BytesMut) -> Result<Self, RpcError> {
+        if buf.len() < 8 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let block_size = get_u64_from_buf(buf, 0)?;
+        let remaining = &buf[8..];
+        if remaining.len() % mem::size_of::<K>() != 0 {
+            return Err(RpcError::InternalError(
+                "Invalid length for kv_cache_key".to_owned(),
+            ));
+        }
+
+        // Convert the remaining bytes into u32 values.
+        let buffer = remaining.to_vec();
+        // Convert to vec<u8>, contains copy here.
+        let kv_cache_key = u8_to_num_buffer(buffer);
+
+        Ok(KVCacheIndexMatchRequest {
+            block_size,
+            kv_cache_key,
+        })
+    }
+
+    /// Decode the byte buffer into a kv cache index match request.
+    #[allow(clippy::indexing_slicing)]
+    fn decode_large_data(buf: bytes::Bytes) -> Result<Self, RpcError> {
+        if buf.len() < 8 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let block_size = get_u64_from_buf(&buf, 0)?;
+        // TODO: change to bytes
+        // Convert the remaining bytes into u32 values.
+        let remaining = &buf[8..];
+        if remaining.len() % mem::size_of::<K>() != 0 {
+            return Err(RpcError::InternalError(
+                "Invalid length for kv_cache_key".to_owned(),
+            ));
+        }
+
+        // Convert to vec<u8>, contains copy here.
+        let buffer = remaining.to_vec();
+        let kv_cache_key = u8_to_num_buffer(buffer);
+
+        Ok(KVCacheIndexMatchRequest {
+            block_size,
+            kv_cache_key,
+        })
+    }
+}
+
+impl<K> ActualSize for KVCacheIndexMatchRequest<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug,
+{
+    /// Get the actual size of the request.
+    fn actual_size(&self) -> u64 {
+        let kv_cache_key_len = usize_to_u64(self.kv_cache_key.len()) * 4;
+        let block_size_len = usize_to_u64(mem::size_of_val(&self.block_size));
+        kv_cache_key_len.overflow_add(block_size_len)
+    }
+}
+
+/// The response to match kv cache index.
+#[derive(Debug, Default, Clone)]
+pub struct KVCacheIndexMatchResponse {
+    /// The kv block size.
+    pub block_size: u64,
+    /// The kv cache key length, used to identify the longest match length.
+    pub kv_cache_key_len: u64,
+    /// The kv cache id, match success return kv cache id, otherwise return 0.
+    pub kv_cache_id: u64,
+    /// The kv cache offset
+    pub offset: u64,
+    /// The kv cache size
+    pub size: u64,
+    /// The status of the response.
+    pub status: StatusCode,
+    /// The node address
+    pub node_address: Vec<u8>,
+}
+
+impl Encode for KVCacheIndexMatchResponse {
+    /// Encode the kv cache index match response into a byte buffer.
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.block_size.to_le());
+        buf.put_u64(self.kv_cache_key_len.to_le());
+        buf.put_u64(self.kv_cache_id.to_le());
+        buf.put_u64(self.offset.to_le());
+        buf.put_u64(self.size.to_le());
+        match self.status {
+            StatusCode::Success => buf.put_u8(0),
+            StatusCode::NotFound => buf.put_u8(1),
+            StatusCode::InternalError => buf.put_u8(2),
+            // Not used here.
+            StatusCode::VersionMismatch => buf.put_u8(3),
+        }
+        buf.put_slice(&self.node_address);
+    }
+}
+
+impl Decode for KVCacheIndexMatchResponse {
+    /// Decode the byte buffer into a kv cache index match response.
+    fn decode(buf: &mut BytesMut) -> Result<Self, RpcError> {
+        if buf.len() < 16 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let block_size = get_u64_from_buf(buf, 0)?;
+        let kv_cache_key_len = get_u64_from_buf(buf, 8)?;
+        let kv_cache_id = get_u64_from_buf(buf, 16)?;
+        let offset = get_u64_from_buf(buf, 24)?;
+        let size = get_u64_from_buf(buf, 32)?;
+        let status = match buf.get(40) {
+            Some(&0) => StatusCode::Success,
+            Some(&1) => StatusCode::NotFound,
+            Some(&2) => StatusCode::InternalError,
+            Some(&3) => StatusCode::VersionMismatch,
+            _ => return Err(RpcError::InternalError("Invalid status code".to_owned())),
+        };
+        let node_address = buf.get(41..).unwrap_or(&[]).to_vec();
+        Ok(KVCacheIndexMatchResponse {
+            block_size,
+            kv_cache_key_len,
+            kv_cache_id,
+            offset,
+            size,
+            status,
+            node_address,
+        })
+    }
+}
+
+/// The request to insert kv cache index.
+#[derive(Debug, Default, Clone)]
+pub struct KVCacheIndexInsertRequest<K> {
+    /// The kv block size.
+    pub block_size: u64,
+    /// The kv cache id, pair with kv cache key.
+    pub kv_cache_id: u64,
+    /// The kv cache offset
+    pub offset: u64,
+    /// The kv cache size
+    pub size: u64,
+    /// The key length
+    pub kv_cache_key_len: u64,
+    /// The kv cache key.
+    // pub kv_cache_key: Vec<u32>,
+    pub kv_cache_key: Vec<K>,
+}
+
+impl<K> Encode for KVCacheIndexInsertRequest<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug,
+{
+    /// Encode the kv cache index insert request into a byte buffer.
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.block_size.to_le());
+        buf.put_u64(self.kv_cache_id.to_le());
+        buf.put_u64(self.offset.to_le());
+        buf.put_u64(self.size.to_le());
+        buf.put_u64(self.kv_cache_key_len.to_le());
+
+        // Zero copy convert u32 to u8 buffer.
+        let buffer = num_to_u8_buffer(self.kv_cache_key.clone());
+        buf.put_slice(&buffer);
+    }
+}
+
+impl<K> Decode for KVCacheIndexInsertRequest<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug,
+{
+    /// Decode the byte buffer into a kv cache index insert request.
+    #[allow(clippy::indexing_slicing)]
+    fn decode(buf: &mut BytesMut) -> Result<Self, RpcError> {
+        if buf.len() < 16 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let block_size = get_u64_from_buf(buf, 0)?;
+        let kv_cache_id = get_u64_from_buf(buf, 8)?;
+        let offset = get_u64_from_buf(buf, 16)?;
+        let size = get_u64_from_buf(buf, 24)?;
+        let kv_cache_key_len = get_u64_from_buf(buf, 32)?;
+        debug!("kv_cache_key_len: {}", kv_cache_key_len);
+        // Give a range to get the remaining bytes.
+        let remaining = &buf[40..40 + u64_to_usize(kv_cache_key_len) * 4];
+        if remaining.len() % mem::size_of::<K>() != 0 {
+            return Err(RpcError::InternalError(
+                "Invalid length for kv_cache_key".to_owned(),
+            ));
+        }
+        // Convert to vec<u8>, contains copy here.
+        // TODO: change to zero copy conversion.
+        let buffer: Vec<u8> = remaining.to_vec();
+        // Convert the remaining bytes into u32 values.
+        let kv_cache_key = u8_to_num_buffer(buffer);
+
+        Ok(KVCacheIndexInsertRequest {
+            block_size,
+            kv_cache_id,
+            offset,
+            size,
+            kv_cache_key_len,
+            kv_cache_key,
+        })
+    }
+
+    /// Decode the byte buffer into a kv cache index insert request.
+    #[allow(clippy::indexing_slicing)]
+    fn decode_large_data(buf: bytes::Bytes) -> Result<Self, RpcError> {
+        if buf.len() < 16 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let block_size = get_u64_from_buf(&buf, 0)?;
+        let kv_cache_id = get_u64_from_buf(&buf, 8)?;
+        let offset = get_u64_from_buf(&buf, 16)?;
+        let size = get_u64_from_buf(&buf, 24)?;
+        let kv_cache_key_len = get_u64_from_buf(&buf, 32)?;
+        // TODO: change to bytes
+        // Convert the remaining bytes into u32 values.
+        let remaining = &buf[40..40 + u64_to_usize(kv_cache_key_len) * 4];
+        if remaining.len() % mem::size_of::<K>() != 0 {
+            return Err(RpcError::InternalError(
+                "Invalid length for kv_cache_key".to_owned(),
+            ));
+        }
+        // Convert to vec<u8>, contains copy here.
+        let buffer = remaining.to_vec();
+        // Convert the remaining bytes into u32 values.
+        let kv_cache_key = u8_to_num_buffer(buffer);
+
+        Ok(KVCacheIndexInsertRequest {
+            block_size,
+            kv_cache_id,
+            offset,
+            size,
+            kv_cache_key_len,
+            kv_cache_key,
+        })
+    }
+}
+
+impl<K> ActualSize for KVCacheIndexInsertRequest<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug,
+{
+    /// Get the actual size of the request.
+    fn actual_size(&self) -> u64 {
+        // Update to u32 ac
+        let kv_cache_key_len = usize_to_u64(self.kv_cache_key.len()) * 4;
+        let block_size_len = usize_to_u64(mem::size_of_val(&self.block_size));
+        let kv_cache_id_len = usize_to_u64(mem::size_of_val(&self.kv_cache_id));
+        let offset_len = usize_to_u64(mem::size_of_val(&self.offset));
+        let size_len = usize_to_u64(mem::size_of_val(&self.size));
+        let kv_cache_key_len_len = usize_to_u64(mem::size_of_val(&self.kv_cache_key_len));
+        debug!(
+            "self.kv_cache_key: {:?} self.kv_cache_key len: {:?}",
+            self.kv_cache_key,
+            self.kv_cache_key.len()
+        );
+        debug!(
+            "kv_cache_key_len: {}, block_size_len: {}, kv_cache_id_len: {}, offset_len: {}, size_len: {}, kv_cache_key_len_len: {}",
+            kv_cache_key_len, block_size_len, kv_cache_id_len, offset_len, size_len, kv_cache_key_len_len
+        );
+        kv_cache_key_len
+            .overflow_add(block_size_len)
+            .overflow_add(kv_cache_id_len)
+            .overflow_add(offset_len)
+            .overflow_add(size_len)
+            .overflow_add(kv_cache_key_len_len)
+    }
+}
+
+/// The response to insert kv cache index.
+#[derive(Debug, Default, Clone)]
+pub struct KVCacheIndexInsertResponse {
+    /// The kv block size.
+    pub block_size: u64,
+    /// The kv cache id.
+    pub kv_cache_id: u64,
+    /// The status of the response.
+    pub status: StatusCode,
+}
+
+impl Encode for KVCacheIndexInsertResponse {
+    /// Encode the kv cache index insert response into a byte buffer.
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.block_size.to_le());
+        buf.put_u64(self.kv_cache_id.to_le());
+        match self.status {
+            StatusCode::Success => buf.put_u8(0),
+            StatusCode::NotFound => buf.put_u8(1),
+            StatusCode::InternalError => buf.put_u8(2),
+            // Not used here.
+            StatusCode::VersionMismatch => buf.put_u8(3),
+        }
+    }
+}
+
+impl Decode for KVCacheIndexInsertResponse {
+    /// Decode the byte buffer into a kv cache index insert response.
+    fn decode(buf: &mut BytesMut) -> Result<Self, RpcError> {
+        if buf.len() < 17 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let block_size = get_u64_from_buf(buf, 0)?;
+        let kv_cache_id = get_u64_from_buf(buf, 8)?;
+        let status = match buf.get(16) {
+            Some(&0) => StatusCode::Success,
+            Some(&1) => StatusCode::NotFound,
+            Some(&2) => StatusCode::InternalError,
+            Some(&3) => StatusCode::VersionMismatch,
+            _ => return Err(RpcError::InternalError("Invalid status code".to_owned())),
+        };
+        Ok(KVCacheIndexInsertResponse {
+            block_size,
+            kv_cache_id,
+            status,
+        })
+    }
+}
+
+/// The request to batch insert kv cache index.
+#[derive(Debug, Default, Clone)]
+pub struct KVCacheIndexBatchInsertRequest<K> {
+    /// The batch size
+    pub batch_size: u64,
+    /// The kv cache index list
+    pub indexes: Vec<KVCacheIndexInsertRequest<K>>,
+    /// The node address
+    pub node_address: Vec<u8>,
+}
+
+impl<K> Encode for KVCacheIndexBatchInsertRequest<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug,
+{
+    /// Encode the kv cache index batch insert request into a byte buffer.
+    fn encode(&self, buf: &mut BytesMut) {
+        debug!("KVCacheIndexBatchInsertRequest self: {:?}", self);
+        buf.put_u64(self.batch_size.to_le());
+        for index in &self.indexes {
+            index.encode(buf);
+        }
+        buf.put_slice(&self.node_address);
+    }
+}
+
+impl<K> Decode for KVCacheIndexBatchInsertRequest<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug,
+{
+    /// Decode the byte buffer into a kv cache index batch insert request.
+    #[allow(clippy::indexing_slicing)]
+    fn decode(buf: &mut BytesMut) -> Result<Self, RpcError> {
+        if buf.len() < 8 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let batch_size = get_u64_from_buf(buf, 0)?;
+        let mut indexes = Vec::new();
+        let mut offset = 8;
+        for _ in 0..batch_size {
+            // TODO: memory copy?
+            let mut sub_buf = buf.split_off(offset);
+            let index = KVCacheIndexInsertRequest::decode(&mut sub_buf)?;
+            debug!("index size: {:?}", index.actual_size());
+            offset += u64_to_usize(index.actual_size());
+            indexes.push(index);
+            // Merge the buffer back, make sure buf is not changed.
+            buf.unsplit(sub_buf);
+        }
+        let node_address = buf[offset..].to_vec();
+        Ok(KVCacheIndexBatchInsertRequest {
+            batch_size,
+            indexes,
+            node_address,
+        })
+    }
+
+    /// Decode the byte buffer into a kv cache index batch insert request.
+    #[allow(clippy::indexing_slicing)]
+    fn decode_large_data(buf: bytes::Bytes) -> Result<Self, RpcError> {
+        if buf.len() < 8 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let batch_size = get_u64_from_buf(&buf, 0)?;
+        let mut indexes = Vec::new();
+        let mut offset = 8;
+        for _ in 0..batch_size {
+            // TODO: memory copy?
+            let sub_buf = buf.slice(offset..);
+            let index = KVCacheIndexInsertRequest::decode_large_data(sub_buf)?;
+            offset += u64_to_usize(index.actual_size());
+            indexes.push(index);
+        }
+        let node_address = buf[offset..].to_vec();
+        Ok(KVCacheIndexBatchInsertRequest {
+            batch_size,
+            indexes,
+            node_address,
+        })
+    }
+}
+
+impl<K> ActualSize for KVCacheIndexBatchInsertRequest<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug,
+{
+    /// Get the actual size of the request.
+    fn actual_size(&self) -> u64 {
+        let mut size = usize_to_u64(mem::size_of_val(&self.batch_size));
+        for index in &self.indexes {
+            size = size.overflow_add(index.actual_size());
+        }
+        size = size.overflow_add(usize_to_u64(self.node_address.len()));
+        size
+    }
+}
+
+/// The request to remove kv cache index.
+/// TODO: check both `kv_cache_id` and `kv_cache_key` to make sure current deletion is correct.
+#[derive(Debug, Default, Clone)]
+pub struct KVCacheIndexRemoveRequest<K> {
+    /// The kv block size.
+    pub block_size: u64,
+    /// The kv cache key.
+    pub kv_cache_key: Vec<K>,
+}
+
+impl<K> Encode for KVCacheIndexRemoveRequest<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug,
+{
+    /// Encode the kv cache index remove request into a byte buffer.
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.block_size.to_le());
+        // Zero copy convert u32 to u8 buffer.
+        let buffer = num_to_u8_buffer(self.kv_cache_key.clone());
+        buf.put_slice(&buffer);
+    }
+}
+
+impl<K> Decode for KVCacheIndexRemoveRequest<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug,
+{
+    /// Decode the byte buffer into a kv cache index remove request.
+    #[allow(clippy::indexing_slicing)]
+    fn decode(buf: &mut BytesMut) -> Result<Self, RpcError> {
+        if buf.len() < 8 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let block_size = get_u64_from_buf(buf, 0)?;
+        let remaining = &buf[8..];
+        if remaining.len() % mem::size_of::<K>() != 0 {
+            return Err(RpcError::InternalError(
+                "Invalid length for kv_cache_key".to_owned(),
+            ));
+        }
+
+        // Convert to vec<u8>, contains copy here.
+        let buffer = remaining.to_vec();
+        // Convert the remaining bytes into u32 values.
+        let kv_cache_key = u8_to_num_buffer(buffer);
+
+        Ok(KVCacheIndexRemoveRequest {
+            block_size,
+            kv_cache_key,
+        })
+    }
+
+    /// Decode the byte buffer into a kv cache index remove request.
+    #[allow(clippy::indexing_slicing)]
+    fn decode_large_data(buf: bytes::Bytes) -> Result<Self, RpcError> {
+        if buf.len() < 8 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let block_size = get_u64_from_buf(&buf, 0)?;
+        let remaining = &buf[8..];
+        if remaining.len() % mem::size_of::<K>() != 0 {
+            return Err(RpcError::InternalError(
+                "Invalid length for kv_cache_key".to_owned(),
+            ));
+        }
+
+        // Convert the remaining bytes into u32 values.
+        // Convert to vec<u8>, contains copy here.
+        let buffer = remaining.to_vec();
+        // Convert the remaining bytes into u32 values.
+        let kv_cache_key = u8_to_num_buffer(buffer);
+
+        Ok(KVCacheIndexRemoveRequest {
+            block_size,
+            kv_cache_key,
+        })
+    }
+}
+
+impl<K> ActualSize for KVCacheIndexRemoveRequest<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug,
+{
+    /// Get the actual size of the request.
+    fn actual_size(&self) -> u64 {
+        let kv_cache_key_len = usize_to_u64(self.kv_cache_key.len() * mem::size_of::<K>());
+        let block_size_len = usize_to_u64(mem::size_of_val(&self.block_size));
+        kv_cache_key_len.overflow_add(block_size_len)
+    }
+}
+
+/// The response to remove kv cache index.
+#[derive(Debug, Default, Clone)]
+pub struct KVCacheIndexRemoveResponse {
+    /// The kv block size.
+    pub block_size: u64,
+    /// The status of the response.
+    pub status: StatusCode,
+}
+
+impl Encode for KVCacheIndexRemoveResponse {
+    /// Encode the kv cache index remove response into a byte buffer.
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.block_size.to_le());
+        match self.status {
+            StatusCode::Success => buf.put_u8(0),
+            StatusCode::NotFound => buf.put_u8(1),
+            StatusCode::InternalError => buf.put_u8(2),
+            // Not used here.
+            StatusCode::VersionMismatch => buf.put_u8(3),
+        }
+    }
+}
+
+impl Decode for KVCacheIndexRemoveResponse {
+    /// Decode the byte buffer into a kv cache index remove response.
+    fn decode(buf: &mut BytesMut) -> Result<Self, RpcError> {
+        if buf.len() < 9 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let block_size = get_u64_from_buf(buf, 0)?;
+        let status = match buf.get(8) {
+            Some(&0) => StatusCode::Success,
+            Some(&1) => StatusCode::NotFound,
+            Some(&2) => StatusCode::InternalError,
+            Some(&3) => StatusCode::VersionMismatch,
+            _ => return Err(RpcError::InternalError("Invalid status code".to_owned())),
+        };
+        Ok(KVCacheIndexRemoveResponse { block_size, status })
+    }
+}
+
+/// The request to get kv block.
+#[derive(Debug, Default, Clone)]
+pub struct KVBlockGetRequest {
+    /// The kv block size.
+    pub block_size: u64,
+    /// The kv cache id.
+    pub kv_cache_id: u64,
+}
+
+impl Encode for KVBlockGetRequest {
+    /// Encode the kv block get request into a byte buffer.
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.block_size.to_le());
+        buf.put_u64(self.kv_cache_id.to_le());
+    }
+}
+
+impl Decode for KVBlockGetRequest {
+    /// Decode the byte buffer into a kv block get request.
+    fn decode(buf: &mut BytesMut) -> Result<Self, RpcError> {
+        if buf.len() < 16 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let block_size = get_u64_from_buf(buf, 0)?;
+        let kv_cache_id = get_u64_from_buf(buf, 8)?;
+        Ok(KVBlockGetRequest {
+            block_size,
+            kv_cache_id,
+        })
+    }
+
+    /// Decode the byte buffer into a kv block get request.
+    fn decode_large_data(buf: bytes::Bytes) -> Result<Self, RpcError> {
+        if buf.len() < 16 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let block_size = get_u64_from_buf(&buf, 0)?;
+        let kv_cache_id = get_u64_from_buf(&buf, 8)?;
+        Ok(KVBlockGetRequest {
+            block_size,
+            kv_cache_id,
+        })
+    }
+}
+
+impl ActualSize for KVBlockGetRequest {
+    /// Get the actual size of the request.
+    fn actual_size(&self) -> u64 {
+        let block_size_len = usize_to_u64(mem::size_of_val(&self.block_size));
+        let kv_cache_id_len = usize_to_u64(mem::size_of_val(&self.kv_cache_id));
+        block_size_len.overflow_add(kv_cache_id_len)
+    }
+}
+
+/// The response to get kv block.
+#[derive(Debug, Default, Clone)]
+pub struct KVBlockGetResponse {
+    /// The kv block size.
+    pub block_size: u64,
+    /// The kv cache id.
+    pub kv_cache_id: u64,
+    /// The status of the response.
+    pub status: StatusCode,
+    /// The data of the block.
+    pub data: bytes::Bytes,
+}
+
+impl Encode for KVBlockGetResponse {
+    /// Encode the kv block get response into a byte buffer.
+    fn encode(&self, buf: &mut BytesMut) {
+        if buf.capacity() < 17 + self.data.len() {
+            buf.reserve(17 + self.data.len());
+        }
+        buf.put_u64(self.block_size.to_le());
+        buf.put_u64(self.kv_cache_id.to_le());
+        match self.status {
+            StatusCode::Success => buf.put_u8(0),
+            StatusCode::NotFound => buf.put_u8(1),
+            StatusCode::InternalError => buf.put_u8(2),
+            // Not used here.
+            StatusCode::VersionMismatch => buf.put_u8(3),
+        }
+        let start = std::time::Instant::now();
+        debug!("buf len: {:?} capacity: {:?}", buf.len(), buf.capacity());
+        // buf = BytesMut::from(&self.data);
+        // buf.copy_from_slice(&self.data);
+        // buf.extend_from_slice(&self.data);
+        // buf.put_slice(&self.data);
+        unsafe {
+            buf.set_len(17 + self.data.len());
+        }
+        debug!("encode KVBlockGetResponse data cost: {:?}", start.elapsed());
+    }
+
+    /// Encode large data
+    fn encode_large_data(&self, buf: &mut BytesMut) -> (u64, Vec<bytes::Bytes>) {
+        let len = self.data.len() + 17;
+        if buf.capacity() < 17 {
+            buf.reserve(17);
+        }
+        buf.put_u64(self.block_size.to_le());
+        buf.put_u64(self.kv_cache_id.to_le());
+        match self.status {
+            StatusCode::Success => buf.put_u8(0),
+            StatusCode::NotFound => buf.put_u8(1),
+            StatusCode::InternalError => buf.put_u8(2),
+            // Not used here.
+            StatusCode::VersionMismatch => buf.put_u8(3),
+        }
+
+        // Return extra large data
+        (len.cast(), vec![self.data.clone()])
+    }
+}
+
+impl Decode for KVBlockGetResponse {
+    /// Decode the byte buffer into a kv block get response.
+    fn decode(buf: &mut BytesMut) -> Result<Self, RpcError> {
+        if buf.len() < 17 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let block_size = get_u64_from_buf(buf, 0)?;
+        let kv_cache_id = get_u64_from_buf(buf, 8)?;
+        let status = match buf.get(16) {
+            Some(&0) => StatusCode::Success,
+            Some(&1) => StatusCode::NotFound,
+            Some(&2) => StatusCode::InternalError,
+            Some(&3) => StatusCode::VersionMismatch,
+            _ => return Err(RpcError::InternalError("Invalid status code".to_owned())),
+        };
+        let start = std::time::Instant::now();
+        let data = buf.get(17..).unwrap_or(&[]).to_vec();
+        // let data = vec![];
+        // Use unsafe to avoid copy
+        debug!("decode KVBlockGetResponse data cost: {:?}", start.elapsed());
+        let data_len = usize_to_u64(data.len());
+        if data_len != block_size {
+            return Err(RpcError::InternalError(format!(
+                "Insufficient block size {data_len}"
+            )));
+        }
+
+        Ok(KVBlockGetResponse {
+            block_size,
+            kv_cache_id,
+            status,
+            data: bytes::Bytes::from(data),
+        })
+    }
+
+    /// Decode the byte buffer into a kv block get response.
+    fn decode_large_data(buf: bytes::Bytes) -> Result<Self, RpcError> {
+        if buf.len() < 17 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let block_size = get_u64_from_buf(&buf, 0)?;
+        let kv_cache_id = get_u64_from_buf(&buf, 8)?;
+        let status = match buf.get(16) {
+            Some(&0) => StatusCode::Success,
+            Some(&1) => StatusCode::NotFound,
+            Some(&2) => StatusCode::InternalError,
+            Some(&3) => StatusCode::VersionMismatch,
+            _ => return Err(RpcError::InternalError("Invalid status code".to_owned())),
+        };
+        let start = std::time::Instant::now();
+        let data = buf.slice(17..);
+
+        // let data = vec![];
+        // Use unsafe to avoid copy
+        debug!(
+            "decode decode_large_data KVBlockGetResponse data cost: {:?}",
+            start.elapsed()
+        );
+        let data_len = usize_to_u64(data.len());
+        if data_len != block_size {
+            return Err(RpcError::InternalError(format!(
+                "Insufficient block size {data_len}"
+            )));
+        }
+
+        Ok(KVBlockGetResponse {
+            block_size,
+            kv_cache_id,
+            status,
+            data,
+        })
+    }
+}
+
+/// The request to put kv block.
+#[derive(Debug, Default, Clone)]
+pub struct KVBlockPutRequest {
+    /// The kv block size.
+    pub block_size: u64,
+    /// The kv cache id.
+    pub kv_cache_id: u64,
+    /// The data of the block.
+    pub data: bytes::Bytes,
+}
+
+impl Encode for KVBlockPutRequest {
+    /// Encode the kv block put request into a byte buffer.
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.block_size.to_le());
+        buf.put_u64(self.kv_cache_id.to_le());
+        let start = std::time::Instant::now();
+        // TODO: change this encode type
+        buf.put_slice(&self.data);
+        debug!(
+            "encode KVBlockPutRequest bytes mut data cost: {:?}",
+            start.elapsed()
+        );
+
+        // let tempdata = self.data.clone();
+        // // Test to copy to Bytes
+        // let start = std::time::Instant::now();
+        // // let _data = bytes::Bytes::from(tempdata);
+        // let _data = bytes::Bytes::copy_from_slice(&tempdata);
+        // debug!("encode KVBlockPutRequest bytes data cost: {:?}", start.elapsed());
+    }
+
+    fn encode_large_data(&self, buf: &mut BytesMut) -> (u64, Vec<bytes::Bytes>) {
+        let len = self.data.len() + 16;
+        if buf.capacity() < 16 {
+            buf.reserve(16);
+        }
+        buf.put_u64(self.block_size.to_le());
+        buf.put_u64(self.kv_cache_id.to_le());
+
+        (len.cast(), vec![self.data.clone()])
+    }
+}
+
+impl Decode for KVBlockPutRequest {
+    /// Decode the byte buffer into a kv block put request.
+    #[allow(clippy::as_conversions)]
+    fn decode_large_data(buf: bytes::Bytes) -> Result<Self, RpcError> {
+        if buf.len() < 16 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let block_size = get_u64_from_buf(&buf, 0)?;
+        let kv_cache_id = get_u64_from_buf(&buf, 8)?;
+        // let buf = &buf[16..block_size as usize + 16];
+        // Get data from bytes slice.
+        let data = buf.slice(16..u64_to_usize(block_size) + 16);
+        let data_len = usize_to_u64(data.len());
+        if data_len != block_size {
+            return Err(RpcError::InternalError(format!(
+                "Insufficient block size {data_len}"
+            )));
+        }
+
+        Ok(KVBlockPutRequest {
+            block_size,
+            kv_cache_id,
+            data,
+        })
+    }
+}
+
+impl ActualSize for KVBlockPutRequest {
+    /// Get the actual size of the request.
+    fn actual_size(&self) -> u64 {
+        let data_len = usize_to_u64(self.data.len());
+        let block_size_len = usize_to_u64(mem::size_of_val(&self.block_size));
+        let kv_cache_id_len = usize_to_u64(mem::size_of_val(&self.kv_cache_id));
+        data_len
+            .overflow_add(block_size_len)
+            .overflow_add(kv_cache_id_len)
+    }
+}
+
+/// The request to put multiple kv blocks.
+#[derive(Debug, Default, Clone)]
+pub struct KVBlockBatchPutRequest {
+    /// The kv block batch size.
+    pub batch_size: u64,
+    /// A list of kv block put requests.
+    pub blocks: Vec<KVBlockPutRequest>,
+}
+
+impl Encode for KVBlockBatchPutRequest {
+    /// Encode the kv block batch put request into a byte buffer.
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.batch_size.to_le());
+        for block in &self.blocks {
+            block.encode(buf);
+        }
+    }
+
+    /// Get large data with Bytes, disable memory copy
+    fn encode_large_data(&self, buf: &mut BytesMut) -> (u64, Vec<bytes::Bytes>) {
+        let len = self.actual_size();
+        let mut data = Vec::new();
+        // (self.batch_size.to_le_bytes());
+        for block in &self.blocks {
+            data.extend(block.encode_large_data(buf).1);
+        }
+        (len, data)
+    }
+}
+
+impl Decode for KVBlockBatchPutRequest {
+    /// Decode the byte buffer into a kv block batch put request.
+    fn decode_large_data(buf: bytes::Bytes) -> Result<Self, RpcError> {
+        if buf.len() < 8 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let batch_size = get_u64_from_buf(&buf, 0)?;
+        let mut blocks = Vec::new();
+        let mut offset = 8;
+        for _ in 0..batch_size {
+            // TODO: give an end pointer.
+            let sub_buf = buf.slice(offset..);
+            let block = KVBlockPutRequest::decode_large_data(sub_buf)?;
+            offset += 16 + block.data.len();
+            blocks.push(block);
+        }
+        Ok(KVBlockBatchPutRequest { batch_size, blocks })
+    }
+}
+
+impl ActualSize for KVBlockBatchPutRequest {
+    /// Get the actual size of the request.
+    fn actual_size(&self) -> u64 {
+        let mut size = usize_to_u64(mem::size_of_val(&self.batch_size));
+        for block in &self.blocks {
+            size = size.overflow_add(block.actual_size());
+        }
+        size
+    }
+}
+
+/// The response to put kv block.
+#[derive(Debug, Default, Clone)]
+pub struct KVBlockBatchPutResponse {
+    /// The kv block size.
+    pub block_size: u64,
+    /// The success batch size.
+    pub success_batch_size: u64,
+    /// The success kv cache ids.
+    pub success_kv_cache_ids: Vec<u64>,
+    /// The failed batch size.
+    pub failed_batch_size: u64,
+    /// The failed kv cache ids.
+    pub failed_kv_cache_ids: Vec<u64>,
+}
+
+impl Encode for KVBlockBatchPutResponse {
+    /// Encode the kv block batch put response into a byte buffer.
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.block_size.to_le());
+        buf.put_u64(self.success_batch_size.to_le());
+        for kv_cache_id in &self.success_kv_cache_ids {
+            buf.put_u64(kv_cache_id.to_le());
+        }
+        buf.put_u64(self.failed_batch_size.to_le());
+        for kv_cache_id in &self.failed_kv_cache_ids {
+            buf.put_u64(kv_cache_id.to_le());
+        }
+    }
+}
+
+impl Decode for KVBlockBatchPutResponse {
+    /// Decode the byte buffer into a kv block batch put response.
+    fn decode(buf: &mut BytesMut) -> Result<Self, RpcError> {
+        if buf.len() < 16 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        let block_size = get_u64_from_buf(buf, 0)?;
+        let success_batch_size = get_u64_from_buf(buf, 8)?;
+        let mut success_kv_cache_ids = Vec::new();
+        let mut offset = 16;
+        for _ in 0..success_batch_size {
+            let kv_cache_id = get_u64_from_buf(buf, offset)?;
+            success_kv_cache_ids.push(kv_cache_id);
+            offset += 8;
+        }
+        let failed_batch_size = get_u64_from_buf(buf, offset)?;
+        offset += 8;
+        let mut failed_kv_cache_ids = Vec::new();
+        for _ in 0..failed_batch_size {
+            let kv_cache_id = get_u64_from_buf(buf, offset)?;
+            failed_kv_cache_ids.push(kv_cache_id);
+            offset += 8;
+        }
+        Ok(KVBlockBatchPutResponse {
+            block_size,
+            success_batch_size,
+            success_kv_cache_ids,
+            failed_batch_size,
+            failed_kv_cache_ids,
+        })
+    }
+}
+
+/// The kv cache request packet type.
+#[derive(Debug, Clone)]
+pub enum KVCacheRequest<K> {
+    /// The request to allocate a global kv cache id.
+    KVCacheIdAllocateRequest(KVCacheIdAllocateRequest),
+    /// The request to match kv cache index.
+    KVCacheIndexMatchRequest(KVCacheIndexMatchRequest<K>),
+    /// The request to insert kv cache index.
+    KVCacheIndexBatchInsertRequest(KVCacheIndexBatchInsertRequest<K>),
+    /// The request to remove kv cache index.
+    KVCacheIndexRemoveRequest(KVCacheIndexRemoveRequest<K>),
+    /// The request to get kv block.
+    KVBlockGetRequest(KVBlockGetRequest),
+    /// The request to put kv block.
+    KVBlockBatchPutRequest(KVBlockBatchPutRequest),
+}
+
+impl<K> Encode for KVCacheRequest<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug + Send + Sync,
+{
+    /// Encode the kv cache request into a byte buffer.
+    #[allow(clippy::pattern_type_mismatch)]
+    fn encode(&self, buf: &mut BytesMut) {
+        match self {
+            Self::KVCacheIdAllocateRequest(request) => request.encode(buf),
+            Self::KVCacheIndexMatchRequest(request) => request.encode(buf),
+            Self::KVCacheIndexBatchInsertRequest(request) => request.encode(buf),
+            Self::KVCacheIndexRemoveRequest(request) => request.encode(buf),
+            Self::KVBlockGetRequest(request) => request.encode(buf),
+            Self::KVBlockBatchPutRequest(request) => request.encode(buf),
+        }
+    }
+}
+
+impl<K> ActualSize for KVCacheRequest<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug,
+{
+    /// Get the actual size of the request.
+    #[allow(clippy::pattern_type_mismatch)]
+    fn actual_size(&self) -> u64 {
+        match self {
+            Self::KVCacheIdAllocateRequest(request) => request.actual_size(),
+            Self::KVCacheIndexMatchRequest(request) => request.actual_size(),
+            Self::KVCacheIndexBatchInsertRequest(request) => request.actual_size(),
+            Self::KVCacheIndexRemoveRequest(request) => request.actual_size(),
+            Self::KVBlockGetRequest(request) => request.actual_size(),
+            Self::KVBlockBatchPutRequest(request) => request.actual_size(),
+        }
+    }
+}
+
+impl<K> KVCacheRequest<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug,
+{
+    /// Decode the byte buffer into a kv cache request.
+    #[allow(unused)]
+    #[allow(clippy::needless_pass_by_value)]
+    fn decode(request_type: ReqType, buf: &mut BytesMut) -> Result<Self, RpcError> {
+        if buf.len() < 8 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        match request_type {
+            ReqType::KVCacheIdAllocateRequest => {
+                let request = KVCacheIdAllocateRequest::decode(buf)?;
+                Ok(Self::KVCacheIdAllocateRequest(request))
+            }
+            ReqType::KVCacheIndexMatchRequest => {
+                let request = KVCacheIndexMatchRequest::decode(buf)?;
+                Ok(Self::KVCacheIndexMatchRequest(request))
+            }
+            ReqType::KVCacheIndexBatchInsertRequest => {
+                let request = KVCacheIndexBatchInsertRequest::decode(buf)?;
+                Ok(Self::KVCacheIndexBatchInsertRequest(request))
+            }
+            ReqType::KVCacheIndexRemoveRequest => {
+                let request = KVCacheIndexRemoveRequest::decode(buf)?;
+                Ok(Self::KVCacheIndexRemoveRequest(request))
+            }
+            ReqType::KVBlockGetRequest => {
+                // unused
+                let request = KVBlockGetRequest::decode(buf)?;
+                Ok(Self::KVBlockGetRequest(request))
+            }
+            ReqType::KVBlockBatchPutRequest => {
+                // unused
+                let request = KVBlockBatchPutRequest::decode(buf)?;
+                Ok(Self::KVBlockBatchPutRequest(request))
+            }
+            ReqType::KeepAliveRequest | ReqType::FileBlockRequest => {
+                Err(RpcError::InternalError("Invalid request type".to_owned()))
+            }
+        }
+    }
+}
+
+/// The kv cache response packet type.
+#[derive(Debug, Clone)]
+pub enum KVCacheResponse {
+    /// The response to allocate a global kv cache id.
+    KVCacheIdAllocateResponse(KVCacheIdAllocateResponse),
+    /// The response to match kv cache index.
+    KVCacheIndexMatchResponse(KVCacheIndexMatchResponse),
+    /// The response to insert kv cache index.
+    KVCacheIndexInsertResponse(KVCacheIndexInsertResponse),
+    /// The response to remove kv cache index.
+    KVCacheIndexRemoveResponse(KVCacheIndexRemoveResponse),
+    /// The response to get kv block.
+    KVBlockGetResponse(KVBlockGetResponse),
+    /// The response to put multiple kv blocks.
+    KVBlockBatchPutResponse(KVBlockBatchPutResponse),
+}
+
+impl Encode for KVCacheResponse {
+    /// Encode the kv cache response into a byte buffer.
+    #[allow(clippy::needless_pass_by_value)]
+    #[allow(clippy::pattern_type_mismatch)]
+    fn encode(&self, buf: &mut BytesMut) {
+        match self {
+            Self::KVCacheIdAllocateResponse(response) => response.encode(buf),
+            Self::KVCacheIndexMatchResponse(response) => response.encode(buf),
+            Self::KVCacheIndexInsertResponse(response) => response.encode(buf),
+            Self::KVCacheIndexRemoveResponse(response) => response.encode(buf),
+            Self::KVBlockGetResponse(response) => response.encode(buf),
+            Self::KVBlockBatchPutResponse(response) => response.encode(buf),
+        }
+    }
+}
+
+impl KVCacheResponse {
+    /// Decode the byte buffer into a kv cache response.
+    #[allow(clippy::needless_pass_by_value)]
+    fn decode(response_type: RespType, mut buf: BytesMut) -> Result<Self, RpcError> {
+        if buf.len() < 8 {
+            return Err(RpcError::InternalError("Insufficient bytes".to_owned()));
+        }
+        match response_type {
+            RespType::KVCacheIdAllocateResponse => {
+                let response = KVCacheIdAllocateResponse::decode(&mut buf)?;
+                Ok(Self::KVCacheIdAllocateResponse(response))
+            }
+            RespType::KVCacheIndexMatchResponse => {
+                let response = KVCacheIndexMatchResponse::decode(&mut buf)?;
+                Ok(Self::KVCacheIndexMatchResponse(response))
+            }
+            RespType::KVCacheIndexInsertResponse => {
+                let response = KVCacheIndexInsertResponse::decode(&mut buf)?;
+                Ok(Self::KVCacheIndexInsertResponse(response))
+            }
+            RespType::KVCacheIndexRemoveResponse => {
+                let response = KVCacheIndexRemoveResponse::decode(&mut buf)?;
+                Ok(Self::KVCacheIndexRemoveResponse(response))
+            }
+            RespType::KVBlockGetResponse => {
+                let response = KVBlockGetResponse::decode_large_data(buf.freeze())?;
+                Ok(Self::KVBlockGetResponse(response))
+            }
+            RespType::KVBlockBatchPutResponse => {
+                let response = KVBlockBatchPutResponse::decode(&mut buf)?;
+                Ok(Self::KVBlockBatchPutResponse(response))
+            }
+            RespType::KeepAliveResponse | RespType::FileBlockResponse => {
+                Err(RpcError::InternalError("Invalid response type".to_owned()))
+            }
+        }
+    }
+}
+
+/// The kv cache request packet for client
+/// This struct impl packet trait and support kv cache request and response
+#[derive(Clone)]
+pub struct KVCachePacket<K> {
+    /// The sequence number of the packet.
+    pub seq: u64,
+    /// The operation type of the packet.
+    pub op: u8,
+    /// The timestamp of the packet.
+    pub timestamp: u64,
+    /// The file block request struct.
+    pub request: KVCacheRequest<K>,
+    /// The buffer of the packet, used to store response data.
+    pub response: Option<KVCacheResponse>,
+    /// The sender to send response back to caller.
+    pub done_tx: flume::Sender<Result<KVCacheResponse, KVCacheRequest<K>>>,
+}
+
+#[allow(clippy::missing_fields_in_debug)]
+impl<K> fmt::Debug for KVCachePacket<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("KVCachePacket")
+            .field("seq", &self.seq)
+            .field("op", &self.op)
+            .field("timestamp", &self.timestamp)
+            .finish()
+    }
+}
+
+impl<K> KVCachePacket<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug,
+{
+    /// Create a new kv cache packet.
+    #[must_use]
+    pub fn new(
+        op: u8,
+        kv_cache_request: KVCacheRequest<K>,
+        done_tx: flume::Sender<Result<KVCacheResponse, KVCacheRequest<K>>>,
+    ) -> Self {
+        Self {
+            op,
+            // Will be auto set by client
+            seq: 0,
+            // TODO: Take owner of this request?
+            request: kv_cache_request,
+            timestamp: 0,
+            response: None,
+            done_tx,
+        }
+    }
+}
+
+impl<K> Encode for KVCachePacket<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug,
+{
+    /// Encode the kv cache packet into a byte buffer.
+    fn encode(&self, buffer: &mut BytesMut) {
+        self.request.encode(buffer);
+    }
+}
+
+#[async_trait]
+impl<K> Packet for KVCachePacket<K>
+where
+    K: num::Num + Send + Sync + Clone + fmt::Debug + Send + Sync + Clone,
+{
+    /// Get the sequence number of the packet.
+    fn seq(&self) -> u64 {
+        self.seq
+    }
+
+    /// Set the sequence number of the packet.
+    fn set_seq(&mut self, seq: u64) {
+        self.seq = seq;
+    }
+
+    /// Get the operation type of the packet.
+    fn op(&self) -> u8 {
+        self.op
+    }
+
+    /// Set the operation type of the packet.
+    fn set_op(&mut self, op: u8) {
+        self.op = op;
+    }
+
+    /// Get the timestamp of the packet.
+    fn set_timestamp(&mut self, timestamp: u64) {
+        self.timestamp = timestamp;
+    }
+
+    /// get the timestamp of the packet.
+    fn get_timestamp(&self) -> u64 {
+        self.timestamp
+    }
+
+    /// Set response data to current packet
+    fn set_resp_data(&mut self, data: BytesMut) -> Result<(), RpcError> {
+        let response_type = RespType::from_u8(self.op)?;
+        match response_type {
+            RespType::KVCacheIdAllocateResponse => {
+                self.response = Some(KVCacheResponse::decode(
+                    RespType::KVCacheIdAllocateResponse,
+                    data,
+                )?);
+            }
+            RespType::KVCacheIndexMatchResponse => {
+                self.response = Some(KVCacheResponse::decode(
+                    RespType::KVCacheIndexMatchResponse,
+                    data,
+                )?);
+            }
+            RespType::KVCacheIndexInsertResponse => {
+                self.response = Some(KVCacheResponse::decode(
+                    RespType::KVCacheIndexInsertResponse,
+                    data,
+                )?);
+            }
+            RespType::KVCacheIndexRemoveResponse => {
+                self.response = Some(KVCacheResponse::decode(
+                    RespType::KVCacheIndexRemoveResponse,
+                    data,
+                )?);
+            }
+            RespType::KVBlockGetResponse => {
+                self.response = Some(KVCacheResponse::decode(RespType::KVBlockGetResponse, data)?);
+            }
+            RespType::KVBlockBatchPutResponse => {
+                self.response = Some(KVCacheResponse::decode(
+                    RespType::KVBlockBatchPutResponse,
+                    data,
+                )?);
+            }
+            RespType::KeepAliveResponse | RespType::FileBlockResponse => {
+                return Err(RpcError::InternalError("Invalid response type".to_owned()));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get the response data of the packet.
+    async fn set_result(self, status: Result<(), RpcError>) {
+        match status {
+            Ok(()) => {
+                if let Some(resp) = self.response {
+                    match self.done_tx.send_async(Ok(resp)).await {
+                        Ok(()) => {
+                            debug!("Set result in set_result() successfully");
+                        }
+                        Err(err) => {
+                            warn!("Failed to set result: {:?}", err);
+                        }
+                    }
+                } else {
+                    warn!("Failed to set result: response is None");
+                    match self.done_tx.send_async(Err(self.request.clone())).await {
+                        Ok(()) => {}
+                        Err(err) => {
+                            warn!("Failed to set result: {:?}", err);
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                warn!("Failed to set result: {:?}", err);
+                match self.done_tx.send_async(Err(self.request.clone())).await {
+                    Ok(()) => {}
+                    Err(err) => {
+                        warn!("Failed to set result: {:?}", err);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Get request size to construct request header
+    fn get_req_len(&self) -> u64 {
+        self.request.actual_size()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::indexing_slicing)]
+mod test {
+    use crate::distribute_kv_cache::rpc::utils::u64_to_usize;
+
+    use super::*;
+
+    #[test]
+    fn test_file_block_request_encode_decode() {
+        let file_id = 123;
+        let block_id = 456;
+        let block_size = 789;
+        let block_version = 10;
+        let hash_ring_version = 20;
+
+        let request = FileBlockRequest {
+            file_id,
+            block_id,
+            block_size,
+            block_version,
+            hash_ring_version,
+        };
+
+        let mut buffer = BytesMut::new();
+        request.encode(&mut buffer);
+
+        let decoded_request = FileBlockRequest::decode(&mut buffer).unwrap();
+
+        assert_eq!(decoded_request.file_id, file_id);
+        assert_eq!(decoded_request.block_id, block_id);
+        assert_eq!(decoded_request.block_size, block_size);
+        assert_eq!(decoded_request.block_version, block_version);
+        assert_eq!(decoded_request.hash_ring_version, hash_ring_version);
+    }
+
+    #[test]
+    fn test_file_block_response_encode_decode() {
+        let file_id = 123;
+        let block_id = 456;
+        let block_size = 789;
+        let block_version = 10;
+        let hash_ring_version = 20;
+        let status = StatusCode::Success;
+        let data = vec![1, 2, 3, 4, 5];
+
+        let response = FileBlockResponse {
+            file_id,
+            block_id,
+            block_size,
+            block_version,
+            hash_ring_version,
+            status,
+            data: data.clone(),
+        };
+
+        let mut buffer = BytesMut::new();
+        response.encode(&mut buffer);
+
+        let decoded_response = FileBlockResponse::decode(&mut buffer).unwrap();
+
+        assert_eq!(decoded_response.file_id, file_id);
+        assert_eq!(decoded_response.block_id, block_id);
+        assert_eq!(decoded_response.block_size, block_size);
+        assert_eq!(decoded_response.block_version, block_version);
+        assert_eq!(decoded_response.hash_ring_version, hash_ring_version);
+        assert_eq!(decoded_response.status, status);
+        assert_eq!(decoded_response.data, data);
+    }
+
+    #[test]
+    fn test_file_block_packet_encode() {
+        let file_id = 123;
+        let block_id = 456;
+        let block_size = 789;
+        let block_version = 10;
+        let hash_ring_version = 20;
+
+        let request = FileBlockRequest {
+            file_id,
+            block_id,
+            block_size,
+            block_version,
+            hash_ring_version,
+        };
+
+        let (done_tx, _) = flume::unbounded();
+        let packet = FileBlockPacket::new(&request, done_tx);
+
+        let mut buffer = BytesMut::new();
+        packet.encode(&mut buffer);
+
+        let expected_buffer_len = u64_to_usize(packet.get_req_len());
+        assert_eq!(buffer.len(), expected_buffer_len);
+    }
+
+    // KVCacheIndexInsertRequest
+    #[test]
+    fn test_kv_cache_index_insert_request_encode_decode() {
+        let block_size = 123;
+        let kv_cache_id = 123;
+        let offset = 456;
+        let size = 789;
+        let kv_cache_key_len = 3;
+        let kv_cache_key = vec![0_u32, 1_u32, 2_u32];
+
+        let request = KVCacheIndexInsertRequest {
+            block_size,
+            kv_cache_id,
+            offset,
+            size,
+            kv_cache_key_len,
+            kv_cache_key: kv_cache_key.clone(),
+        };
+
+        let mut buffer = BytesMut::new();
+        request.encode(&mut buffer);
+
+        let decoded_request = KVCacheIndexInsertRequest::<u32>::decode(&mut buffer).unwrap();
+
+        assert_eq!(decoded_request.kv_cache_id, kv_cache_id);
+        assert_eq!(decoded_request.offset, offset);
+        assert_eq!(decoded_request.size, size);
+        assert_eq!(decoded_request.kv_cache_key_len, kv_cache_key_len);
+        assert_eq!(decoded_request.kv_cache_key, kv_cache_key);
+    }
+
+    // KVCacheIndexBatchInsertRequest
+    #[test]
+    fn test_kv_cache_index_batch_insert_request_encode_decode() {
+        let batch_size = 1;
+        let node_address = vec![1_u8, 2_u8, 3_u8, 4_u8];
+
+        let block_size = 123;
+        let kv_cache_id = 123;
+        let kv_cache_key_len = 3;
+        let kv_cache_key = vec![0_u32, 1_u32, 2_u32];
+
+        let request = KVCacheIndexBatchInsertRequest {
+            batch_size,
+            node_address: node_address.clone(),
+            indexes: vec![KVCacheIndexInsertRequest {
+                block_size,
+                kv_cache_id,
+                offset: 456,
+                size: 789,
+                kv_cache_key_len,
+                kv_cache_key: kv_cache_key.clone(),
+            }],
+        };
+
+        let mut buffer = BytesMut::new();
+        request.encode(&mut buffer);
+        // buffer len: 64
+        debug!("buffer len: {:?}", buffer.len());
+
+        let decoded_request = KVCacheIndexBatchInsertRequest::<u32>::decode(&mut buffer).unwrap();
+
+        assert_eq!(decoded_request.batch_size, batch_size);
+        assert_eq!(decoded_request.node_address, node_address);
+        assert_eq!(decoded_request.indexes.len(), 1);
+        assert_eq!(decoded_request.indexes[0].block_size, block_size);
+        assert_eq!(decoded_request.indexes[0].kv_cache_id, kv_cache_id);
+        assert_eq!(decoded_request.indexes[0].offset, 456);
+        assert_eq!(decoded_request.indexes[0].size, 789);
+        assert_eq!(
+            decoded_request.indexes[0].kv_cache_key_len,
+            kv_cache_key_len
+        );
+        assert_eq!(decoded_request.indexes[0].kv_cache_key, kv_cache_key);
+    }
+
+    // KVCacheIndexRemoveRequest
+    #[test]
+    fn test_kv_cache_index_remove_request_encode_decode() {
+        let block_size = 123;
+        let kv_cache_key = vec![0_u32, 1_u32, 2_u32];
+
+        let request = KVCacheIndexRemoveRequest {
+            block_size,
+            kv_cache_key: kv_cache_key.clone(),
+        };
+
+        let mut buffer = BytesMut::new();
+        request.encode(&mut buffer);
+
+        let decoded_request = KVCacheIndexRemoveRequest::<u32>::decode(&mut buffer).unwrap();
+
+        assert_eq!(decoded_request.block_size, block_size);
+        assert_eq!(decoded_request.kv_cache_key, kv_cache_key);
+    }
+
+    // KVCacheIndexMatchRequest
+    #[test]
+    fn test_kv_cache_index_match_request_encode_decode() {
+        let block_size = 123;
+        let kv_cache_key = vec![0_u32, 1_u32, 2_u32];
+
+        let request = KVCacheIndexMatchRequest {
+            block_size,
+            kv_cache_key: kv_cache_key.clone(),
+        };
+
+        let mut buffer = BytesMut::new();
+        request.encode(&mut buffer);
+
+        let decoded_request = KVCacheIndexMatchRequest::<u32>::decode(&mut buffer).unwrap();
+        assert_eq!(decoded_request.block_size, block_size);
+        assert_eq!(decoded_request.kv_cache_key, kv_cache_key);
+
+        let decoded_request =
+            KVCacheIndexMatchRequest::<u32>::decode_large_data(buffer.freeze()).unwrap();
+        assert_eq!(decoded_request.block_size, block_size);
+        assert_eq!(decoded_request.kv_cache_key, kv_cache_key);
+    }
+}

--- a/src/distribute_kv_cache/rpc/mod.rs
+++ b/src/distribute_kv_cache/rpc/mod.rs
@@ -1,0 +1,26 @@
+/// This module contains the RPC server and client for the cache service.
+
+/// The client module contains the client implementation for the cache service.
+pub mod client;
+
+/// The common module contains the shared structures and functions for the cache service.
+pub mod common;
+
+/// The error module contains the error types for the cache service.
+pub mod error;
+
+/// The message module contains the data structures shared between the client and server.
+pub mod message;
+
+/// The server module contains the server implementation for the cache service.
+pub mod server;
+
+/// The workerpool module contains the worker pool implementation for the cache service.
+pub mod workerpool;
+
+/// The packet module contains the packet encoding and decoding functions for the cache service.
+pub mod packet;
+
+/// The utils module contains the utility functions for the cache service.
+#[macro_use]
+pub mod utils;

--- a/src/distribute_kv_cache/rpc/packet.rs
+++ b/src/distribute_kv_cache/rpc/packet.rs
@@ -1,0 +1,542 @@
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
+
+use async_trait::async_trait;
+use bytes::{BufMut, BytesMut};
+use tokio::{sync::Mutex, time::Instant};
+use tracing::debug;
+
+use super::{
+    error::RpcError,
+    utils::{get_u64_from_buf, get_u8_from_buf, u64_to_usize},
+};
+
+/// The size of the request header.
+pub const REQ_HEADER_SIZE: u64 = 17;
+/// The size of the response header.
+pub const RESP_HEADER_SIZE: u64 = 17;
+
+/// The Encode trait is used to encode a message structure into a byte buffer.
+pub trait Encode: Sync {
+    /// Encode the message into a byte buffer, this operation will append to buffer
+    /// If you need to encode from start, you should clear the buffer first
+    fn encode(&self, buf: &mut BytesMut);
+
+    /// Get large data with Bytes, disable memory copy
+    fn encode_large_data(&self, _buf: &mut BytesMut) -> (u64, Vec<bytes::Bytes>) {
+        // Default is empty
+        (0, vec![])
+    }
+}
+
+/// The Decode trait is used to message a byte buffer into a data structure.
+#[allow(clippy::unimplemented)]
+pub trait Decode {
+    /// Decode the byte buffer into a data structure
+    fn decode(_buf: &mut BytesMut) -> Result<Self, RpcError>
+    where
+        Self: Sized,
+    {
+        unimplemented!("Not implemented for this type")
+    }
+
+    /// Decode the large data into a data structure
+    fn decode_large_data(_buf: bytes::Bytes) -> Result<Self, RpcError>
+    where
+        Self: Sized,
+    {
+        unimplemented!("Not implemented for this type")
+    }
+}
+
+/// The `ActualSize` trait is used to get the actual size of the data structure.
+pub trait ActualSize {
+    /// Get the actual size of the data structure
+    fn actual_size(&self) -> u64;
+}
+
+/// The message module contains the data structures shared between the client and server.
+/// Assume the cluster only contains one version server, so we won't consider the compatibility
+#[derive(Debug)]
+pub struct ReqHeader {
+    /// The sequence number of the request.
+    pub seq: u64,
+    /// The operation type of the request.
+    /// 0: keepalive
+    /// other is defined by the user
+    pub op: u8,
+    /// The length of the request.
+    pub len: u64,
+}
+
+impl Encode for ReqHeader {
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.seq.to_le());
+        buf.put_u8(self.op.to_le());
+        buf.put_u64(self.len.to_le());
+    }
+}
+
+impl Decode for ReqHeader {
+    fn decode(buf: &mut BytesMut) -> Result<Self, RpcError> {
+        if buf.len() < u64_to_usize(REQ_HEADER_SIZE) {
+            return Err(RpcError::InvalidRequest(
+                "Invalid request header".to_owned(),
+            ));
+        }
+
+        let seq = get_u64_from_buf(buf, 0)?;
+        let op = get_u8_from_buf(buf, 8)?;
+        let len = get_u64_from_buf(buf, 9)?;
+
+        Ok(ReqHeader { seq, op, len })
+    }
+}
+
+/// The message module contains the data structures shared between the client and server.
+/// Assume the cluster only contains one version server, so we won't consider the compatibility
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct RespHeader {
+    /// The sequence number of the response.
+    pub seq: u64,
+    /// The operation type of the response.
+    /// 0: keepalive
+    /// other is defined by the user
+    pub op: u8,
+    /// The length of the response.
+    pub len: u64,
+}
+
+impl Encode for RespHeader {
+    fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u64(self.seq.to_le());
+        buf.put_u8(self.op);
+        buf.put_u64(self.len.to_le());
+    }
+}
+
+impl Decode for RespHeader {
+    fn decode(buf: &mut BytesMut) -> Result<Self, RpcError> {
+        if buf.len() < u64_to_usize(RESP_HEADER_SIZE) {
+            return Err(RpcError::InvalidResponse(
+                "Invalid response header".to_owned(),
+            ));
+        }
+
+        let seq = get_u64_from_buf(buf, 0)?;
+        let op = get_u8_from_buf(buf, 8)?;
+        let len = get_u64_from_buf(buf, 9)?;
+
+        Ok(RespHeader { seq, op, len })
+    }
+}
+
+/// Define the Packet trait, for once send or receive packets
+///
+/// Client will create a packet and serialize it to a byte array,
+/// send it to the server. And create a temp response packet in client.
+///
+/// Server will receive the packet, deserialize it to a packet struct,
+/// and process the request, then create a response packet and serialize.
+///
+/// Client will receive the response packet and deserialize it to a packet struct.
+/// and check the status of the packet and the response.
+#[async_trait]
+pub trait Packet: Sync + Send + Clone + Debug + Encode {
+    /// Get the packet seq number
+    fn seq(&self) -> u64;
+    /// Set the packet seq number
+    fn set_seq(&mut self, seq: u64);
+
+    /// Get packet type
+    fn op(&self) -> u8;
+    /// Set packet type
+    fn set_op(&mut self, op: u8);
+
+    /// Set timestamp
+    fn set_timestamp(&mut self, timestamp: u64);
+    /// Get timestamp
+    fn get_timestamp(&self) -> u64;
+
+    /// Get request buf length
+    /// This function is used to get the length of the request body size.
+    fn get_req_len(&self) -> u64;
+
+    /// Serialize response data to bytes
+    /// We will get the serialized response data by accessing the property of the Packet
+    fn set_resp_data(&mut self, data: BytesMut) -> Result<(), RpcError>;
+
+    /// Set the packet result, and we will send the response buffer to caller, caller and directly decode this buffer
+    /// The buffer is different in req and resp, so we can not hold one buffer in packet
+    async fn set_result(self, status: Result<(), RpcError>);
+}
+/// The `PacketsInner` struct is used to store the current tasks.
+#[derive(Debug)]
+struct PacketsInner<P>
+where
+    P: Packet + Send + Sync,
+{
+    /// current tasks, marked by the seq number
+    packets: HashMap<u64, P>,
+}
+
+impl<P: Packet + Send + Sync> PacketsInner<P> {
+    /// Create a new `PacketsInner`
+    #[must_use]
+    pub fn new() -> Self {
+        PacketsInner {
+            packets: HashMap::new(),
+        }
+    }
+
+    /// Add a task to the packets
+    pub fn add_task(&mut self, seq: u64, packet: P) {
+        self.packets.insert(seq, packet);
+    }
+
+    /// Get a task from the packets and remove it
+    pub fn remove_task(&mut self, seq: u64) -> Option<P> {
+        // remove packet and return it
+        self.packets.remove(&seq)
+    }
+
+    /// Clean pending tasks as timeout
+    /// In first step, we will try to mark the task as timeout if it is pending and timeout
+    /// In 10 * timeout time, we will force to remove the task if the task is not consumed
+    pub async fn clean_timeout_tasks(&mut self, current_timestamp: u64, timeout: u64) {
+        let mut last_timeout_packets = Vec::new();
+        for (seq, packet) in &mut self.packets {
+            // Check if the task is timeout
+            let timestamp = packet.get_timestamp();
+            if current_timestamp - timestamp > timeout {
+                // Set the task as timeout
+                last_timeout_packets.push(*seq);
+            }
+        }
+
+        // clean the timeout packets
+        for seq in last_timeout_packets {
+            if let Some(packet) = self.packets.remove(&seq) {
+                debug!("Task {} is timeout", seq);
+                packet
+                    .set_result(Err(RpcError::Timeout(format!("Task {seq} is timeout"))))
+                    .await;
+            } else {
+                debug!("Task {} is timeout, but not found in the packets", seq);
+                continue;
+            }
+        }
+    }
+
+    /// Purge the outdated tasks when connection is timeout
+    pub async fn purge_outdated_tasks(&mut self) {
+        // Take ownership and pass it to the caller
+        for (seq, packet) in self.packets.drain() {
+            packet
+                .set_result(Err(RpcError::Timeout(format!("Task {seq} is timeout"))))
+                .await;
+        }
+
+        self.packets.clear();
+    }
+}
+
+/// The `PacketsKeeper` struct is used to store the current and previous tasks.
+/// It will be modified by single task, so we don't need to share it.
+#[derive(Debug)]
+pub struct PacketsKeeper<P>
+where
+    P: Packet + Send + Sync,
+{
+    /// current tasks, marked by the seq number
+    inner: Arc<Mutex<PacketsInner<P>>>,
+    /// buffer sender
+    buffer_packets_sender: flume::Sender<P>,
+    /// buffer receiver
+    buffer_packets_receiver: flume::Receiver<P>,
+    /// The maximum number of tasks that can be stored in the previous_tasks
+    /// We will mark the task as timeout if it is in the previous_tasks and the previous_tasks is full
+    timeout: u64,
+    /// current timestamp
+    current_time: Instant,
+}
+
+impl<P: Packet + Send + Sync> PacketsKeeper<P> {
+    /// Create a new `PacketsKeeper`
+    #[must_use]
+    pub fn new(timeout: u64) -> Self {
+        let (buffer_packets_sender, buffer_packets_receiver) = flume::bounded::<P>(1000);
+        let packets_inner = Arc::new(Mutex::new(PacketsInner::new()));
+        let current_time = tokio::time::Instant::now();
+
+        PacketsKeeper {
+            inner: packets_inner,
+            buffer_packets_sender,
+            buffer_packets_receiver,
+            timeout,
+            current_time,
+        }
+    }
+
+    /// Add a task to the packets
+    pub fn add_task(&self, mut packet: P) -> Result<(), RpcError> {
+        // TODO: use a global atomic ticker(updated by check_loop) or read current time?
+        let timestamp = self.current_time.elapsed().as_secs();
+        packet.set_timestamp(timestamp);
+        self.buffer_packets_sender.send(packet).map_err(|e| {
+            RpcError::InternalError(format!("Failed to send packet to buffer: {e:?}"))
+        })?;
+
+        Ok(())
+    }
+
+    /// Clean pending tasks as timeout
+    pub async fn clean_timeout_tasks(&self) {
+        {
+            let mut packets_inner = self.inner.lock().await;
+            while let Ok(packet) = self.buffer_packets_receiver.try_recv() {
+                let seq = packet.seq();
+                packets_inner.add_task(seq, packet);
+            }
+
+            let current_timestamp = self.current_time.elapsed().as_secs();
+            packets_inner
+                .clean_timeout_tasks(current_timestamp, self.timeout)
+                .await;
+        }
+    }
+
+    /// Purge the outdated tasks when connection is timeout
+    pub async fn purge_outdated_tasks(&self) {
+        let mut packets_inner = self.inner.lock().await;
+        while let Ok(packet) = self.buffer_packets_receiver.try_recv() {
+            let seq = packet.seq();
+            packets_inner.add_task(seq, packet);
+        }
+
+        packets_inner.purge_outdated_tasks().await;
+    }
+
+    /// Get a task from the packets, and update data in the task
+    pub async fn take_task(&self, seq: u64, resp_buffer: BytesMut) -> Result<(), RpcError> {
+        // Try to sync from buffer
+        {
+            let mut packets_inner = self.inner.lock().await;
+            while let Ok(packet) = self.buffer_packets_receiver.try_recv() {
+                debug!(
+                    "take_task self.buffer_packets_receiver.try_recv(): {:?}",
+                    packet
+                );
+                let seq = packet.seq();
+                packets_inner.add_task(seq, packet);
+            }
+
+            if let Some(mut packet) = packets_inner.remove_task(seq) {
+                let seq = packet.seq();
+                // Update status data
+                // Try to set result code in `set_resp_data`
+
+                // forget this buffer for raw decode!!! 20241210
+                let set_result = packet.set_resp_data(resp_buffer);
+                match set_result {
+                    Ok(()) => {
+                        debug!("{:?} Success to set response data, seq: {:?}", self, seq);
+                        packet.set_result(Ok(())).await;
+                    }
+                    Err(err) => {
+                        debug!(
+                            "{:?} Failed to set response data: {:?} with error {:?}",
+                            self, seq, err
+                        );
+                        packet
+                            .set_result(Err(RpcError::InternalError(format!(
+                                "Failed to set response data: {seq:?} with error {err:?}"
+                            ))))
+                            .await;
+                    }
+                }
+                packets_inner.remove_task(seq);
+
+                return Ok(());
+            }
+        }
+
+        Err(RpcError::InvalidRequest(format!("can not find seq: {seq}")))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(dead_code)]
+mod tests {
+    use std::{mem, thread::sleep, time};
+
+    use crate::async_fuse::util::usize_to_u64;
+
+    use super::*;
+
+    #[derive(Debug, Clone)]
+    struct TestRequest {
+        pub mock: u64,
+    }
+
+    impl Encode for TestRequest {
+        fn encode(&self, _buf: &mut BytesMut) {}
+    }
+
+    #[derive(Debug, Clone)]
+    struct TestPacket {
+        pub seq: u64,
+        pub op: u8,
+        pub timestamp: u64,
+        pub request: TestRequest,
+        pub buf: BytesMut,
+        pub sender: flume::Sender<Result<(), RpcError>>,
+    }
+
+    impl Encode for TestPacket {
+        fn encode(&self, buf: &mut BytesMut) {
+            self.request.encode(buf);
+        }
+    }
+
+    #[async_trait]
+    impl Packet for TestPacket {
+        fn seq(&self) -> u64 {
+            self.seq
+        }
+
+        fn set_seq(&mut self, seq: u64) {
+            self.seq = seq;
+        }
+
+        fn op(&self) -> u8 {
+            self.op
+        }
+
+        fn set_op(&mut self, op: u8) {
+            self.op = op;
+        }
+
+        fn set_timestamp(&mut self, timestamp: u64) {
+            self.timestamp = timestamp;
+        }
+
+        fn get_timestamp(&self) -> u64 {
+            self.timestamp
+        }
+
+        fn get_req_len(&self) -> u64 {
+            usize_to_u64(mem::size_of_val(&self.request))
+        }
+
+        fn set_resp_data(&mut self, _data: BytesMut) -> Result<(), RpcError> {
+            Ok(())
+        }
+
+        async fn set_result(self, status: Result<(), RpcError>) {
+            self.sender.send(status).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_req_header_encode_and_decode() {
+        let header = ReqHeader {
+            seq: 1,
+            op: 2,
+            len: 3,
+        };
+        let mut buf = BytesMut::new();
+        header.encode(&mut buf);
+        assert_eq!(buf.len(), u64_to_usize(REQ_HEADER_SIZE));
+
+        let header_decoded = ReqHeader::decode(&mut buf).unwrap();
+        assert_eq!(header_decoded.seq, 1);
+        assert_eq!(header_decoded.op, 2);
+        assert_eq!(header_decoded.len, 3);
+    }
+
+    #[test]
+    fn test_resp_header_encode_and_decode() {
+        let header = RespHeader {
+            seq: 1,
+            op: 2,
+            len: 3,
+        };
+        let mut buf = BytesMut::new();
+        header.encode(&mut buf);
+        assert_eq!(buf.len(), u64_to_usize(RESP_HEADER_SIZE));
+
+        let header_decoded = RespHeader::decode(&mut buf).unwrap();
+        assert_eq!(header_decoded.seq, 1);
+        assert_eq!(header_decoded.op, 2);
+        assert_eq!(header_decoded.len, 3);
+    }
+
+    #[tokio::test]
+    async fn test_packets_keeper() {
+        let packets_keeper = PacketsKeeper::<TestPacket>::new(1);
+
+        // You can control what is need to be send.
+        let (tx, rx) = flume::unbounded::<Result<(), RpcError>>();
+
+        // Success
+        let packet = TestPacket {
+            seq: 1,
+            op: 2,
+            timestamp: 0,
+            buf: BytesMut::new(),
+            sender: tx.clone(),
+            request: TestRequest { mock: 0 },
+        };
+        packets_keeper.add_task(packet.clone()).unwrap();
+        packets_keeper
+            .take_task(packet.seq(), BytesMut::new())
+            .await
+            .unwrap();
+        match rx.recv() {
+            Ok(Ok(())) => {
+                debug!("Success to get response");
+            }
+            _ => panic!("Failed to get response"),
+        }
+
+        // Mark timeout
+        let packet_2 = TestPacket {
+            seq: 2,
+            op: 2,
+            timestamp: 0,
+            buf: BytesMut::new(),
+            sender: tx.clone(),
+            request: TestRequest { mock: 0 },
+        };
+        packets_keeper.add_task(packet_2.clone()).unwrap();
+        sleep(time::Duration::from_secs(2));
+        packets_keeper.clean_timeout_tasks().await;
+        match rx.recv() {
+            Ok(res) => {
+                debug!("Task is timeout {:?}", res);
+                assert!(res.is_err());
+            }
+            _ => panic!("Failed to get response"),
+        }
+
+        // Purge the timeout task
+        let packet_3 = TestPacket {
+            seq: 3,
+            op: 2,
+            timestamp: 0,
+            buf: BytesMut::new(),
+            sender: tx.clone(),
+            request: TestRequest { mock: 0 },
+        };
+        packets_keeper.add_task(packet_3.clone()).unwrap();
+        packets_keeper.purge_outdated_tasks().await;
+        match rx.recv() {
+            Ok(res) => {
+                debug!("Task is timeout {:?}", res);
+                assert!(res.is_err());
+            }
+            _ => panic!("Failed to get response"),
+        }
+    }
+}

--- a/src/distribute_kv_cache/rpc/server.rs
+++ b/src/distribute_kv_cache/rpc/server.rs
@@ -1,0 +1,565 @@
+use std::{
+    cell::UnsafeCell,
+    fmt::{self, Debug},
+    io::IoSlice,
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use bytes::BytesMut;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net,
+    sync::mpsc,
+    task,
+};
+
+use crate::{read_exact_timeout, write_all_timeout, write_vectored_timeout};
+
+use super::{
+    common::ServerTimeoutOptions,
+    error::RpcError,
+    message::{ReqType, RespType},
+    packet::{Decode, Encode, ReqHeader, RespHeader, REQ_HEADER_SIZE},
+    utils::u64_to_usize,
+    workerpool::WorkerPool,
+};
+
+use tracing::{debug, warn};
+
+/// The huge body length for the response,
+/// when the response is too large, we need to consider to take user buffer.
+const HUGE_BODY_LEN: u64 = 1024 * 1024;
+
+/// Define trait for implementing the RPC server connection handler.
+#[async_trait]
+pub trait RpcServerConnectionHandler {
+    /// Dispatch the handler for the connection.
+    async fn dispatch(
+        &self,
+        req_header: ReqHeader,
+        req_buffer: BytesMut,
+        done_tx: mpsc::Sender<Vec<bytes::Bytes>>,
+    );
+}
+
+/// The connection for the RPC server.
+#[derive(Clone, Debug)]
+pub struct RpcServerConnection<T>
+where
+    T: RpcServerConnectionHandler + Send + Sync + 'static,
+{
+    /// The inner connection for the RPC server.
+    inner: Arc<RpcServerConnectionInner<T>>,
+}
+
+///
+#[derive(Debug)]
+pub struct RpcServerConnectionInner<T>
+where
+    T: RpcServerConnectionHandler + Send + Sync + 'static,
+{
+    /// The TCP stream for the connection.
+    stream: UnsafeCell<net::TcpStream>,
+    /// The worker pool for the connection.
+    /// TODO:
+    #[allow(dead_code)]
+    worker_pool: Arc<WorkerPool>,
+    /// Options for the timeout of the connection
+    timeout_options: ServerTimeoutOptions,
+    /// The handler for the connection
+    dispatch_handler: T,
+    /// Response buffer, try to reuse same buffer to reduce memory allocation
+    /// In case of the response is too large, we need to consider the buffer size
+    /// Init size is 4MB
+    /// Besides, we want to reduce memory copy, and read/write the response to the same data buffer
+    req_buf: UnsafeCell<BytesMut>,
+}
+
+/// Current implementation is safe because the stream is only accessed by one thread
+unsafe impl<T> Send for RpcServerConnectionInner<T> where
+    T: RpcServerConnectionHandler + Send + Sync + 'static
+{
+}
+
+/// Current implementation is safe because the stream is only accessed by one thread
+unsafe impl<T> Sync for RpcServerConnectionInner<T> where
+    T: RpcServerConnectionHandler + Send + Sync + 'static
+{
+}
+
+impl<T> RpcServerConnectionInner<T>
+where
+    T: RpcServerConnectionHandler + Send + Sync + 'static,
+{
+    /// Create a new RPC server connection.
+    pub fn new(
+        stream: net::TcpStream,
+        worker_pool: Arc<WorkerPool>,
+        timeout_options: ServerTimeoutOptions,
+        dispatch_handler: T,
+    ) -> Self {
+        Self {
+            stream: UnsafeCell::new(stream),
+            worker_pool,
+            timeout_options,
+            dispatch_handler,
+            // Init buffer size is 64MB
+            req_buf: UnsafeCell::new(BytesMut::with_capacity(64 * 1024 * 1024)),
+        }
+    }
+
+    /// Recv request header from the stream
+    pub async fn recv_header(&self) -> Result<ReqHeader, RpcError> {
+        // Try to read to buffer
+        match self.recv_len(REQ_HEADER_SIZE).await {
+            Ok(()) => {}
+            Err(err) => {
+                debug!("Failed to receive request header: {:?}", err);
+                return Err(err);
+            }
+        }
+
+        let buffer: &mut BytesMut = unsafe { &mut *self.req_buf.get() };
+        let req_header = ReqHeader::decode(buffer)?;
+        debug!("Received request header: {:?}", req_header);
+
+        Ok(req_header)
+    }
+
+    /// Recv request body from the stream
+    pub async fn recv_len(&self, len: u64) -> Result<(), RpcError> {
+        let start = tokio::time::Instant::now();
+        let mut req_buffer: &mut BytesMut = unsafe { &mut *self.req_buf.get() };
+        if req_buffer.capacity() < u64_to_usize(len) {
+            req_buffer.reserve(u64_to_usize(len) - req_buffer.capacity());
+        }
+        // req_buffer.resize(u64_to_usize(len), 0);
+        unsafe {
+            req_buffer.set_len(u64_to_usize(len));
+        }
+        let start_1 = start.elapsed();
+        debug!("Server resize buffer to size {:?} cost: {:?}", len, start_1);
+
+        let reader = self.get_stream_mut();
+        match read_exact_timeout!(reader, &mut req_buffer, self.timeout_options.read_timeout).await
+        {
+            Ok(size) => {
+                debug!("Received request body: {:?}", size);
+                Ok(())
+            }
+            Err(err) => {
+                debug!("Failed to receive request: {:?}", err);
+                Err(RpcError::InternalError(err.to_string()))
+            }
+        }
+    }
+
+    /// Recv huge request body from the stream
+    pub async fn recv_huge_len(&self, len: u64, req_buffer: &mut BytesMut) -> Result<(), RpcError> {
+        let start = tokio::time::Instant::now();
+        if req_buffer.capacity() < u64_to_usize(len) {
+            req_buffer.reserve(u64_to_usize(len) - req_buffer.capacity());
+        }
+        // req_buffer.resize(u64_to_usize(len), 0);
+        unsafe {
+            req_buffer.set_len(u64_to_usize(len));
+        }
+        let start_1 = start.elapsed();
+        debug!("Server resize buffer to size {:?} cost: {:?}", len, start_1);
+
+        let reader = self.get_stream_mut();
+        match read_exact_timeout!(reader, req_buffer, self.timeout_options.read_timeout).await {
+            Ok(size) => {
+                debug!("Received request body: {:?}", size);
+                Ok(())
+            }
+            Err(err) => {
+                debug!("Failed to receive request: {:?}", err);
+                Err(RpcError::InternalError(err.to_string()))
+            }
+        }
+    }
+
+    /// Send response to the stream
+    /// The response is a byte array, contains the response header and body.
+    pub async fn send_response(&self, resp: &[u8]) -> Result<(), RpcError> {
+        let writer = self.get_stream_mut();
+        match write_all_timeout!(writer, resp, self.timeout_options.write_timeout).await {
+            Ok(()) => {
+                debug!("Sent response successfully: {:?}", resp.len());
+                Ok(())
+            }
+            Err(err) => {
+                debug!("Failed to send response: {:?}", err);
+                Err(RpcError::InternalError(err.to_string()))
+            }
+        }
+    }
+
+    /// Send vectored response to the stream
+    /// The response is a byte array, contains the response header and body.
+    pub async fn send_vectored_response(&self, resp: &[IoSlice<'_>]) -> Result<usize, RpcError> {
+        let writer = self.get_stream_mut();
+        // writer.write_all_buf(resp).await?;
+        // IoSlice::advance_slices
+        // Ensure the input is a vector of IoSlice
+        match write_vectored_timeout!(writer, resp, self.timeout_options.write_timeout).await {
+            Ok(done_size) => {
+                debug!("Sent response successfully with size: {:?}", done_size);
+                Ok(done_size)
+            }
+            Err(err) => {
+                debug!("Failed to send response: {:?}", err);
+                Err(RpcError::InternalError(err.to_string()))
+            }
+        }
+    }
+
+    /// Get stream with mutable reference
+    #[allow(clippy::mut_from_ref)]
+    fn get_stream_mut(&self) -> &mut net::TcpStream {
+        // Current implementation is safe because the stream is only accessed by one thread
+        unsafe { &mut *self.stream.get() }
+    }
+}
+
+impl<T> RpcServerConnection<T>
+where
+    T: RpcServerConnectionHandler + Send + Sync + 'static,
+{
+    /// Create a new RPC server connection.
+    pub fn new(
+        stream: net::TcpStream,
+        worker_pool: Arc<WorkerPool>,
+        timeout_options: ServerTimeoutOptions,
+        dispatch_handler: T,
+    ) -> Self {
+        let inner = Arc::new(RpcServerConnectionInner::new(
+            stream,
+            worker_pool,
+            timeout_options,
+            dispatch_handler,
+        ));
+        Self { inner }
+    }
+
+    /// Dispatch the handler for the connection.
+    async fn dispatch(&self, req_header: ReqHeader, done_tx: mpsc::Sender<Vec<bytes::Bytes>>) {
+        // Dispatch the handler for the connection
+        let seq = req_header.seq;
+        let body_len = req_header.len;
+        if let Ok(req_type) = ReqType::from_u8(req_header.op) {
+            debug!(
+                "Dispatch request with header type: {:?}, seq: {:?}, body_len: {:?}",
+                req_type, seq, body_len
+            );
+            if let ReqType::KeepAliveRequest = req_type {
+                // Keep-alive request
+                // Directly send keepalive response to client, do not need to submit to worker pool.
+                // In current implementation, we just send keepalive header to the client stream
+                let resp_header = RespHeader {
+                    seq,
+                    op: RespType::KeepAliveResponse.to_u8(),
+                    len: 0,
+                };
+                // Only one process will access this buffer, so we can use this buffer directly.
+                let resp_buffer: &mut BytesMut = unsafe { &mut *self.inner.req_buf.get() };
+                RespHeader::encode(&resp_header, resp_buffer);
+                if let Ok(res) = self.inner.send_response(resp_buffer).await {
+                    debug!("Sent keepalive response: {:?}", res);
+                } else {
+                    warn!("Failed to send keepalive response");
+                }
+            } else if body_len <= HUGE_BODY_LEN {
+                debug!("Request body length is less than 1MB, try to read the request body");
+                // Try to read the request body
+                match self.inner.recv_len(body_len).await {
+                    Ok(()) => {}
+                    Err(err) => {
+                        warn!("Failed to receive request body: {:?}", err);
+                        return;
+                    }
+                };
+                debug!(
+                    "Dispatched handler for the connection, seq: {:?}",
+                    req_header.seq
+                );
+                let req_buffer: &mut BytesMut = unsafe { &mut *self.inner.req_buf.get() };
+                self.inner
+                    .dispatch_handler
+                    .dispatch(req_header, req_buffer.clone(), done_tx)
+                    .await;
+            } else {
+                debug!("Request body length is huge, try to read the request body");
+                // Huge body length, need to consider to take user buffer
+                let mut req_buffer = BytesMut::with_capacity(u64_to_usize(body_len));
+                match self.inner.recv_huge_len(body_len, &mut req_buffer).await {
+                    Ok(()) => {}
+                    Err(err) => {
+                        warn!("Failed to receive huge request body: {:?}", err);
+                        return;
+                    }
+                };
+                debug!(
+                    "Dispatched handler for the connection, seq: {:?}",
+                    req_header.seq
+                );
+                self.inner
+                    .dispatch_handler
+                    .dispatch(req_header, req_buffer, done_tx)
+                    .await;
+            }
+        } else {
+            debug!("Inner request type is not matched: {:?}", req_header.op);
+        }
+    }
+
+    /// Keep the connection and get the handler for the connection.
+    pub async fn run(&self) {
+        // Dispatch the handler for the connection
+        debug!("RpcServerConnection::Received a new TcpStream.");
+
+        // TODO: copy done_tx to the worker pool
+        let (done_tx, mut done_rx) = mpsc::channel::<Vec<bytes::Bytes>>(10000);
+
+        // Send response to the stream from the worker pool
+        // Worker pool will handle the response sending
+        let inner_conn = Arc::clone(&self.inner);
+        tokio::spawn(async move {
+            debug!("Start to send response to the stream from client");
+            loop {
+                if let Some(resp_buffer) = done_rx.recv().await {
+                    debug!("Recv buffer from done_tx channel, try to send response to the stream");
+                    // Send response to the stream
+                    // if let Ok(res) = inner_conn.send_response(&resp_buffer).await {
+
+                    for buf in &resp_buffer {
+                        // Send vectored data to the stream
+                        if let Ok(res) = inner_conn.send_response(buf).await {
+                            debug!("Sent file block response successfully: {:?}", res);
+                        } else {
+                            warn!("Failed to send file block response");
+                        }
+                    }
+                } else {
+                    debug!("done_rx channel is closed, stop sending response to the stream");
+                    break;
+                }
+            }
+        });
+
+        loop {
+            // Receive the request header
+            let req_header = match self.inner.recv_header().await {
+                Ok(header) => {
+                    debug!("Received request header: {:?}", header);
+                    header
+                }
+                Err(err) => {
+                    debug!("Failed to receive request header: {:?}", err);
+                    return;
+                }
+            };
+
+            // Dispatch the handler for the connection
+            self.dispatch(req_header, done_tx.clone()).await;
+        }
+    }
+}
+
+/// The worker factory for the RPC connection.
+#[derive(Clone, Debug)]
+pub struct RpcConnWorkerFactory<T>
+where
+    T: RpcServerConnectionHandler + Send + Sync + 'static,
+{
+    /// Global worker pool for the RPC connection, shared by all connections.
+    worker_pool: Arc<WorkerPool>,
+    /// The handler for the connection
+    dispatch_handler: T,
+}
+
+impl<T> RpcConnWorkerFactory<T>
+where
+    T: RpcServerConnectionHandler + Send + Sync + Debug + Clone + 'static,
+{
+    /// Create a new worker factory for the RPC connection.
+    pub fn new(max_workers: usize, max_jobs: usize, dispatch_handler: T) -> Self {
+        Self {
+            worker_pool: Arc::new(WorkerPool::new(max_workers, max_jobs)),
+            dispatch_handler,
+        }
+    }
+
+    /// Get dispatch handler for the connection.
+    pub fn get_dispatch_handler(&self) -> T {
+        self.dispatch_handler.clone()
+    }
+
+    /// Serve the connection.
+    pub fn serve(&self, conn: RpcServerConnection<T>) {
+        // Run the connection
+        tokio::spawn(async move {
+            conn.run().await;
+        });
+    }
+}
+
+/// The RPC server definition.
+pub struct RpcServer<T>
+where
+    T: RpcServerConnectionHandler + Send + Sync + Debug + Clone + 'static,
+{
+    /// Options for the timeout of the server connection
+    timeout_options: ServerTimeoutOptions,
+    /// Main worker for the server
+    main_worker: Option<task::JoinHandle<()>>,
+    /// The worker factory for the RPC connection
+    rpc_conn_worker_factory: RpcConnWorkerFactory<T>,
+}
+
+impl<T> Debug for RpcServer<T>
+where
+    T: RpcServerConnectionHandler + Send + Sync + Debug + Clone + 'static,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RpcServer")
+            .field("timeout_options", &self.timeout_options)
+            .field("main_worker", &self.main_worker)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> RpcServer<T>
+where
+    T: RpcServerConnectionHandler + Send + Sync + Debug + Clone + 'static,
+{
+    /// Create a new RPC server.
+    pub fn new(
+        timeout_options: &ServerTimeoutOptions,
+        max_workers: usize,
+        max_jobs: usize,
+        dispatch_handler: T,
+    ) -> Self {
+        Self {
+            timeout_options: timeout_options.clone(),
+            main_worker: None,
+            rpc_conn_worker_factory: RpcConnWorkerFactory::<T>::new(
+                max_workers,
+                max_jobs,
+                dispatch_handler,
+            ),
+        }
+    }
+
+    /// Start the RPC server.
+    pub async fn listen(&mut self, addr: &str) -> Result<(), RpcError> {
+        // Start the server
+        let listener = tokio::net::TcpListener::bind(addr)
+            .await
+            .map_err(|err| RpcError::InternalError(err.to_string()))?;
+        debug!("listening on {:?}", addr.to_owned());
+
+        // Accept incoming connections
+        let timeout_options = self.timeout_options.clone();
+        let factory = self.rpc_conn_worker_factory.clone();
+        let handle = tokio::task::spawn(async move {
+            loop {
+                let conn_timeout_options = timeout_options.clone();
+                match listener.accept().await {
+                    Ok((stream, _)) => {
+                        match stream.peer_addr() {
+                            Ok(addr) => {
+                                debug!("Accepted connection from {:?}", addr);
+                            }
+                            Err(err) => {
+                                debug!("Failed to get peer address: {:?}", err);
+                                break;
+                            }
+                        }
+                        factory.serve(RpcServerConnection::<T>::new(
+                            stream,
+                            Arc::clone(&factory.worker_pool),
+                            conn_timeout_options,
+                            factory.get_dispatch_handler(),
+                        ));
+                    }
+                    Err(err) => {
+                        debug!("Failed to accept connection: {:?}", err);
+                        continue;
+                    }
+                }
+            }
+        });
+
+        self.main_worker = Some(handle);
+        Ok(())
+    }
+
+    /// Stop the RPC server.
+    pub fn stop(&mut self) {
+        // TODO: Gracefully stop the server?
+        if let Some(handle) = self.main_worker.take() {
+            handle.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use tokio::time;
+
+    use super::*;
+    use std::time::Duration;
+
+    /// Check if the port is in use
+    async fn is_port_in_use(addr: &str) -> bool {
+        if let Ok(stream) = tokio::net::TcpStream::connect(addr).await {
+            // Port is in use
+            drop(stream);
+            true
+        } else {
+            // Port is not in use
+            false
+        }
+    }
+
+    /// Test handler for the RPC server connection.
+    #[derive(Clone, Debug)]
+    struct TestHandler;
+
+    impl TestHandler {
+        /// Create a new test handler.
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+
+    #[async_trait]
+    impl RpcServerConnectionHandler for TestHandler {
+        async fn dispatch(
+            &self,
+            _req_header: ReqHeader,
+            _req_buffer: BytesMut,
+            _done_tx: mpsc::Sender<Vec<bytes::Bytes>>,
+        ) {
+            // Dispatch the handler for the connection
+            debug!("Dispatched handler for the connection");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rpc_server() {
+        let addr = "127.0.0.1:2888";
+        let handler = TestHandler::new();
+        let mut server = RpcServer::new(&ServerTimeoutOptions::default(), 4, 100, handler);
+        server.listen(addr).await.unwrap();
+        time::sleep(Duration::from_secs(1)).await;
+        assert!(is_port_in_use(addr).await);
+        server.stop();
+        time::sleep(Duration::from_secs(1)).await;
+        assert!(!is_port_in_use(addr).await);
+    }
+}

--- a/src/distribute_kv_cache/rpc/utils.rs
+++ b/src/distribute_kv_cache/rpc/utils.rs
@@ -1,0 +1,103 @@
+use bytes::Buf;
+
+use super::error::RpcError;
+
+/// Read with timeout options from the environment variables
+#[macro_export]
+macro_rules! read_exact_timeout {
+    ($self:expr, $dst:expr, $read_timeout:expr) => {
+        async move {
+            use tokio::time::timeout;
+
+            match timeout($read_timeout, $self.read_exact($dst)).await {
+                Ok(res) => match res {
+                    Ok(size) => Ok(size),
+                    Err(read_err) => Err(read_err),
+                },
+                Err(timeout_err) => Err(timeout_err.into()),
+            }
+        }
+    };
+}
+
+/// Write with timeout options from the environment variables
+#[macro_export]
+macro_rules! write_all_timeout {
+    ($self:expr, $src:expr, $write_timeout:expr) => {
+        async move {
+            use tokio::time::timeout;
+
+            match timeout($write_timeout, $self.write_all($src)).await {
+                Ok(res) => match res {
+                    Ok(size) => Ok(size),
+                    Err(write_err) => Err(write_err),
+                },
+                Err(timeout_err) => Err(timeout_err.into()),
+            }
+        }
+    };
+}
+
+/// Write vectored with timeout options from the environment variables
+#[macro_export]
+macro_rules! write_vectored_timeout {
+    ($self:expr, $src:expr, $write_timeout:expr) => {
+        async move {
+            use tokio::time::timeout;
+
+            // TODO: check all the write_vectored is done
+            match timeout($write_timeout, $self.write_vectored($src)).await {
+                Ok(res) => match res {
+                    Ok(size) => Ok(size),
+                    Err(write_err) => Err(write_err),
+                },
+                Err(timeout_err) => Err(timeout_err.into()),
+            }
+        }
+    };
+}
+
+/// Connect a stream with timeout options from the environment variables
+#[macro_export]
+macro_rules! connect_timeout {
+    ($addr:expr, $connect_timeout:expr) => {
+        async move {
+            use tokio::net::TcpStream;
+            use tokio::time::timeout;
+
+            match timeout($connect_timeout, TcpStream::connect($addr)).await {
+                Ok(res) => match res {
+                    Ok(stream) => Ok(stream),
+                    Err(connect_err) => Err(connect_err),
+                },
+                Err(timeout_err) => Err(timeout_err.into()),
+            }
+        }
+    };
+}
+
+/// Try to get u64 data from buffer with range
+pub fn get_u64_from_buf(buf: &[u8], start: usize) -> Result<u64, RpcError> {
+    buf.get(start..start + 8)
+        .ok_or_else(|| RpcError::InternalError("Invalid range data".to_owned()))
+        .map(|mut slice| u64::from_le(slice.get_u64()))
+}
+
+/// Try to get u8 data from buffer with range
+pub fn get_u8_from_buf(buf: &[u8], start: usize) -> Result<u8, RpcError> {
+    buf.get(start)
+        .ok_or_else(|| RpcError::InternalError("In valid range data".to_owned()))
+        .map(|&byte| u8::from_le(byte))
+}
+
+/// Converts [`u64`] to [`usize`], and panic when the conversion fails.
+#[inline]
+#[must_use]
+pub const fn u64_to_usize(x: u64) -> usize {
+    #[allow(clippy::as_conversions)]
+    #[allow(clippy::cast_possible_truncation)]
+    #[cfg(not(target_pointer_width = "16"))]
+    {
+        x as usize
+    }
+}

--- a/src/distribute_kv_cache/rpc/workerpool.rs
+++ b/src/distribute_kv_cache/rpc/workerpool.rs
@@ -1,0 +1,223 @@
+use std::{
+    fmt::{self, Debug},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use tracing::debug;
+
+use super::error::RpcError;
+
+/// A job that can be executed by a worker.
+type JobImpl = Box<dyn Job + Send + Sync + 'static>;
+
+/// A worker that can execute async jobs.
+#[derive(Clone)]
+pub struct WorkerPool {
+    /// The number of workers in the worker pool.
+    /// Current implementation is that the worker pool with a fixed number of workers.
+    /// TODO: Test if we need a dynamic worker pool.
+    max_workers: usize,
+    /// The maximum number of jobs that can be waiting in the job queue.
+    max_waiting_jobs: usize,
+    /// The job queue for the worker pool, with a maximum buffer capacity of `max_waiting_jobs`.
+    /// 1. When the job queue is full, the worker pool will block to receive new jobs.
+    /// 2. When sender is dropped, the receiver will return `None` and the worker pool will shutdown.
+    /// 3. Check the receiver reference count to determine if the worker pool is still alive.
+    job_sender: Arc<flume::Sender<JobImpl>>,
+    /// The workers in the worker pool.
+    worker_queue: Vec<Worker>,
+}
+
+impl Debug for WorkerPool {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WorkerPool")
+            .field("max_workers", &self.max_workers)
+            .field("max_waiting_jobs", &self.max_waiting_jobs)
+            .field("worker_queue_len", &self.worker_queue.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl WorkerPool {
+    /// Create a new worker pool, which contains a number of max workers and max waiting jobs.
+    #[must_use]
+    pub fn new(max_workers: usize, max_waiting_jobs: usize) -> Self {
+        let (job_sender, job_receiver) = flume::bounded::<JobImpl>(max_waiting_jobs);
+        let mut worker_queue = Vec::new();
+
+        // In current implementation, we create a fixed number of workers.
+        let receiver = Arc::new(job_receiver);
+        for _ in 0..max_workers {
+            let worker = Worker::new(Arc::clone(&receiver));
+            worker.start();
+            worker_queue.push(worker);
+        }
+
+        Self {
+            max_workers,
+            max_waiting_jobs,
+            job_sender: Arc::new(job_sender),
+            worker_queue,
+        }
+    }
+
+    /// Submit a job to the worker pool synchronously, and block until the job is completed.
+    /// Other process will be blocked until the job is completed.
+    /// If all job try to submit the job, the process will be blocked.
+    pub fn submit_job(&self, job: JobImpl) -> Result<(), RpcError> {
+        // Submit the job to the job queue.
+        self.job_sender
+            .send(job)
+            .map_err(|_foo| RpcError::InternalError("Failed to submit job".to_owned()))?;
+
+        Ok(())
+    }
+
+    /// Shutdown
+    ///
+    /// Drop the worker, and the worker will exit.
+    pub fn shutdown(&self) {
+        for worker in &self.worker_queue {
+            worker.exit();
+        }
+    }
+}
+
+/// A worker that can execute async jobs.
+#[allow(dead_code)]
+#[derive(Clone)]
+struct Worker {
+    /// Job recv channel
+    job_rx: Arc<flume::Receiver<JobImpl>>,
+    /// Shutdown recv channel
+    shutdown_rx: flume::Receiver<()>,
+    /// Shutdown send channel
+    shutdown_tx: flume::Sender<()>,
+}
+
+impl Worker {
+    /// Create a new worker.
+    fn new(receiver: Arc<flume::Receiver<JobImpl>>) -> Self {
+        debug!("Create a new worker...");
+        let (shutdown_tx, shutdown_rx) = flume::bounded::<()>(1);
+        Self {
+            job_rx: receiver,
+            shutdown_rx,
+            shutdown_tx,
+        }
+    }
+
+    /// Start the worker.
+    fn start(&self) {
+        let shutdown_rx = self.shutdown_rx.clone();
+        let receiver: Arc<flume::Receiver<Box<dyn Job + Send + Sync>>> = Arc::clone(&self.job_rx);
+        tokio::task::spawn(async move {
+            // Core worker loop
+            loop {
+                debug!("Worker is waiting for a job...");
+                tokio::select! {
+                    // Recv shutdown signal
+                    _ = shutdown_rx.recv_async() => {
+                        debug!("Worker received a shutdown signal...");
+                        break;
+                    }
+                    // Receive a job from the job queue.
+                    job = receiver.recv_async() => {
+                        if let Ok(job) = job {
+                            debug!("Worker received a job...");
+                            // 2. Run the job asynchronously.
+                            job.run().await;
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    /// Exit the worker.
+    fn exit(&self) {
+        match self.shutdown_tx.send(()) {
+            Ok(()) => debug!("Worker is exiting..."),
+            Err(e) => debug!("Failed to send shutdown signal: {:?}", e),
+        }
+    }
+}
+
+impl Drop for Worker {
+    fn drop(&mut self) {
+        self.exit();
+    }
+}
+
+/// A trait that represents a job that can be executed by a worker.
+#[async_trait]
+pub trait Job {
+    /// Run the job.
+    async fn run(&self);
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+
+    use core::time;
+
+    use tokio::{task, time::Instant};
+    use tracing::info;
+
+    use super::*;
+
+    struct TestJob;
+
+    #[async_trait]
+    impl Job for TestJob {
+        async fn run(&self) {
+            debug!("TestJob::run");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_worker_pool() {
+        // setup();
+        let worker_pool = WorkerPool::new(4, 4);
+        for _ in 0_i32..4_i32 {
+            worker_pool.submit_job(Box::new(TestJob)).unwrap();
+        }
+
+        // If submit over 4 jobs, it will be blocked here, because the job queue is full.
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
+        let res = worker_pool.submit_job(Box::new(TestJob));
+        res.unwrap();
+
+        drop(worker_pool);
+    }
+
+    #[tokio::test]
+    async fn benchmark_worker_pool() {
+        // setup();
+
+        // Test to use 4 workers to submit 1000 jobs, and calculate the time cost.
+        let worker_pool = Arc::new(WorkerPool::new(10, 1000));
+        let start = Instant::now();
+        for _ in 0_i32..1_000_i32 {
+            let worker_pool = Arc::clone(&worker_pool);
+            worker_pool.submit_job(Box::new(TestJob)).unwrap();
+        }
+        let end = start.elapsed();
+        info!("Workerpool time cost: {:?}", end);
+
+        // Test direct spawn 1000 tasks, and calculate the time cost.
+        let start = Instant::now();
+        let mut tasks: Vec<task::JoinHandle<()>> = Vec::new();
+        for _ in 0_i32..1_000_i32 {
+            let task = task::spawn(TestJob.run());
+            tasks.push(task);
+        }
+        for task in tasks {
+            task.await.unwrap();
+        }
+        let end = start.elapsed();
+        info!("Direct spawn time cost: {:?}", end);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ pub mod async_fuse;
 pub mod common;
 /// Configurations
 pub mod config;
+pub mod distribute_kv_cache;
 pub mod fs;
 pub mod metrics;
 pub mod new_storage;


### PR DESCRIPTION
## Pull Request Documentation

### Background Design

This Pull Request introduces the implementation of a **distributed cache cluster manager** designed to handle node registration, node status management, and hash ring distribution across multiple nodes in a cluster. The cluster manager ensures that nodes can register with a master node, maintain session states, and update the hash ring as needed. It uses etcd as a key-value store to manage nodes and metadata about the cluster.

#### Key Components

- **ClusterManager**: This is the main entry point to interact with the cache cluster. It manages the current node, handles registration, and maintains the hash ring. The `ClusterManager` class also provides methods to fetch nodes, watch updates, and manage the state transitions (slave, master, etc.).
  
- **Node**: Represents a physical or logical node in the distributed system. It contains information such as the node's IP address, port, weight, and status. The status determines the role of the node (e.g., master, slave, registering).
  
- **Hash Ring**: The hash ring ensures that the nodes are evenly distributed across the system to handle cache operations. This is a crucial part of a distributed cache, ensuring data is consistently and evenly split across multiple nodes. Nodes are added, removed, and rebalanced in the ring as part of cluster management.

- **Cluster Management**: The cluster manager runs as a state machine, continuously updating node statuses, monitoring session validity, and maintaining the cache topology. It handles the election of a master node and ensures that the system can recover from failure.