### PR TITLE
feat: introduce cache c sdk.

### DIFF
--- a/sdk/c/Cargo.lock
+++ b/sdk/c/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aes"
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.12"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -93,44 +93,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "arc-swap"
@@ -182,15 +181,14 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.3.0",
- "futures-lite 2.6.0",
- "pin-project-lite",
+ "fastrand 2.2.0",
+ "futures-lite 2.5.0",
  "slab",
 ]
 
@@ -220,7 +218,7 @@ dependencies = [
  "log",
  "parking",
  "polling 2.8.0",
- "rustix 0.37.28",
+ "rustix 0.37.27",
  "slab",
  "socket2 0.4.10",
  "waker-fn",
@@ -228,18 +226,18 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
 dependencies = [
  "async-lock 3.4.0",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.6.0",
+ "futures-lite 2.5.0",
  "parking",
- "polling 3.8.0",
- "rustix 1.0.7",
+ "polling 3.7.4",
+ "rustix 0.38.41",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -260,7 +258,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener 5.3.1",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -289,23 +287,23 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.44",
+ "rustix 0.38.41",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.11"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7605a4e50d4b06df3898d5a70bf5fde51ed9059b0434b73105193bc27acce0d"
+checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
 dependencies = [
- "async-io 2.4.1",
+ "async-io 2.4.0",
  "async-lock 3.4.0",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 1.0.7",
+ "rustix 0.38.41",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -319,13 +317,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -347,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
@@ -402,7 +400,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d67782c3f868daa71d3533538e98a8e13713231969def7536e8039606fc46bf0"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand 2.2.0",
  "futures-core",
  "pin-project",
  "tokio",
@@ -410,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -443,9 +441,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "better-as"
@@ -470,9 +468,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -501,15 +499,15 @@ dependencies = [
  "async-channel 2.3.1",
  "async-task",
  "futures-io",
- "futures-lite 2.6.0",
+ "futures-lite 2.5.0",
  "piper",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
@@ -519,9 +517,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cbc"
@@ -533,19 +531,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.2.27"
+name = "cbindgen"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "da6bc11b07529f16944307272d5bd9b22530bc7d05751717c9d416586cedab49"
+dependencies = [
+ "clap 3.2.25",
+ "heck 0.4.1",
+ "indexmap 1.9.3",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 1.0.109",
+ "tempfile",
+ "toml 0.5.11",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
 dependencies = [
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
@@ -555,9 +572,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -565,7 +582,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -586,9 +603,24 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "atty",
+ "bitflags 1.3.2",
+ "clap_lex 0.2.4",
+ "indexmap 1.9.3",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -596,33 +628,42 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex",
- "strsim",
+ "clap_lex 0.7.3",
+ "strsim 0.11.1",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 
 [[package]]
 name = "clippy-utilities"
@@ -632,18 +673,18 @@ checksum = "dc5b2535647ee31eb24c1e306dce64401e3dc2a5bce4733b50546d151639b0da"
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "concurrent-queue"
@@ -675,7 +716,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom",
  "once_cell",
  "tiny-keccak",
 ]
@@ -698,9 +739,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
@@ -716,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -734,24 +775,24 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -773,7 +814,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.11",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
@@ -788,7 +829,7 @@ dependencies = [
  "bincode",
  "bytes",
  "chrono",
- "clap",
+ "clap 4.5.21",
  "clippy-utilities",
  "crossbeam-channel",
  "crossbeam-queue",
@@ -797,7 +838,6 @@ dependencies = [
  "etcd-client",
  "event-listener 2.5.3",
  "flate2",
- "flume",
  "futures",
  "grpcio",
  "hashbrown 0.14.5",
@@ -809,24 +849,18 @@ dependencies = [
  "lockfree-cuckoohash",
  "macro-utils",
  "memchr",
- "mock-etcd",
- "mockall",
  "nix",
- "num",
- "num_enum",
  "once_cell",
  "opendal",
- "parking_lot 0.12.4",
+ "parking_lot 0.12.3",
  "pin-project-lite",
  "priority-queue",
  "prometheus",
  "protobuf",
  "protoc-grpcio",
- "radix_trie",
  "rand",
  "rand_distr",
  "ring-io",
- "rstest",
  "serde",
  "serde-xml-rs",
  "serde_json",
@@ -836,12 +870,11 @@ dependencies = [
  "smallvec",
  "smol",
  "tar",
- "tempfile",
- "thiserror 1.0.69",
+ "thiserror",
  "tiny_http",
  "tokio",
  "tokio-util",
- "toml",
+ "toml 0.7.8",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -849,10 +882,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "datenlordsdk"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "cbindgen",
+ "clap 4.5.21",
+ "clippy-utilities",
+ "datenlord",
+ "nix",
+ "once_cell",
+ "opendal",
+ "parking_lot 0.12.3",
+ "pyo3",
+ "serde",
+ "serde-xml-rs",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "der"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -861,18 +921,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
 ]
-
-[[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -894,7 +948,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -907,16 +961,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
 name = "either"
-version = "1.15.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encoding_rs"
@@ -928,38 +976,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "equivalent"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -997,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1008,11 +1037,11 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.4"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener 5.3.1",
  "pin-project-lite",
 ]
 
@@ -1049,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "filetime"
@@ -1073,39 +1102,18 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flagset"
-version = "0.4.7"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+checksum = "b3ea1ec5f8307826a5b71094dd91fc04d4ae75d5709b20ad351c7fb4815c86ec"
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "spin",
 ]
 
 [[package]]
@@ -1122,12 +1130,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fragile"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "futures"
@@ -1194,11 +1196,11 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.6.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand 2.2.0",
  "futures-core",
  "futures-io",
  "parking",
@@ -1213,7 +1215,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1227,12 +1229,6 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -1264,27 +1260,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1292,12 +1276,6 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "glob"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "grpcio"
@@ -1348,7 +1326,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.9.0",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1373,9 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hashlink"
@@ -1415,9 +1393,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -1436,11 +1414,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.11"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1467,9 +1445,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.10.1"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -1478,16 +1456,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
-
-[[package]]
 name = "hyper"
-version = "0.14.32"
+version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1500,7 +1472,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -1535,15 +1507,14 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
- "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -1559,22 +1530,21 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
  "displaydoc",
- "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locale_core"
-version = "2.0.0"
+name = "icu_locid"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1584,10 +1554,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_normalizer"
-version = "2.0.0"
+name = "icu_locid_transform"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1595,52 +1585,65 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locale_core",
+ "icu_locid_transform",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
- "zerotrie",
+ "tinystr",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
 dependencies = [
  "displaydoc",
- "icu_locale_core",
+ "icu_locid",
+ "icu_provider_macros",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
- "zerotrie",
  "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1656,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1676,19 +1679,25 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.4"
+name = "indoc"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "block-padding",
  "generic-array",
@@ -1716,9 +1725,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1737,15 +1746,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1753,11 +1762,11 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "9.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "js-sys",
  "pem",
  "ring",
@@ -1791,15 +1800,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libredox"
@@ -1807,16 +1816,16 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.6.0",
  "libc",
- "redox_syscall 0.5.13",
+ "redox_syscall 0.5.7",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.22"
+version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
 dependencies = [
  "cc",
  "libc",
@@ -1832,27 +1841,21 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1870,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "macro-utils"
@@ -1880,7 +1883,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1901,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
@@ -1922,66 +1925,22 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "mock-etcd"
-version = "0.1.0"
-source = "git+https://github.com/datenlord/etcd-client?rev=f697899#f697899f41523bdb19665957b03867536149767a"
-dependencies = [
- "async-io 1.13.0",
- "async-lock 2.8.0",
- "env_logger",
- "futures",
- "grpcio",
- "log",
- "protobuf",
- "protoc-grpcio",
- "smol",
- "utilities",
-]
-
-[[package]]
-name = "mockall"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "wasi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1991,41 +1950,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.16",
-]
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
 name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.6.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
  "memoffset",
 ]
-
-[[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2035,20 +1970,6 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
-]
-
-[[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
 ]
 
 [[package]]
@@ -2079,15 +2000,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2114,17 +2026,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2135,47 +2036,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
-dependencies = [
- "num_enum_derive",
- "rustversion",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "object"
-version = "0.36.7"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opendal"
@@ -2196,7 +2069,7 @@ dependencies = [
  "log",
  "md-5",
  "once_cell",
- "parking_lot 0.12.4",
+ "parking_lot 0.12.3",
  "percent-encoding",
  "pin-project",
  "prometheus",
@@ -2212,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "ordered-float"
@@ -2234,6 +2107,12 @@ dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "overload"
@@ -2260,12 +2139,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.11",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
@@ -2284,13 +2163,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.13",
+ "redox_syscall 0.5.7",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -2307,9 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "3.0.5"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -2337,34 +2216,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.9.0",
+ "indexmap 2.7.0",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -2379,7 +2258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
- "fastrand 2.3.0",
+ "fastrand 2.2.0",
  "futures-io",
 ]
 
@@ -2423,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "polling"
@@ -2445,26 +2324,17 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.8.0"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.5.2",
+ "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 1.0.7",
+ "rustix 0.38.41",
  "tracing",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "potential_utf"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
-dependencies = [
- "zerovec",
 ]
 
 [[package]]
@@ -2475,41 +2345,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.21"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "predicates"
-version = "2.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
-dependencies = [
- "difflib",
- "float-cmp",
- "itertools",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
-dependencies = [
- "predicates-core",
- "termtree",
 ]
 
 [[package]]
@@ -2533,19 +2373,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
-dependencies = [
- "toml_edit 0.22.27",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -2556,11 +2387,11 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.6.0",
  "hex",
  "lazy_static",
  "procfs-core",
- "rustix 0.38.44",
+ "rustix 0.38.41",
 ]
 
 [[package]]
@@ -2569,7 +2400,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.6.0",
  "hex",
 ]
 
@@ -2584,10 +2415,10 @@ dependencies = [
  "lazy_static",
  "libc",
  "memchr",
- "parking_lot 0.12.4",
+ "parking_lot 0.12.3",
  "procfs",
  "protobuf",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -2684,6 +2515,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3"
+version = "0.16.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0220c44442c9b239dd4357aa856ac468a4f5e1f0df19ddb89b2522952eb4c6ca"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "parking_lot 0.12.3",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.16.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c819d397859445928609d0ec5afc2da5204e0d0f73d6bf9e153b04e83c9cdc2"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.16.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca882703ab55f54702d7bfe1189b41b0af10272389f04cae38fe4cd56c65f75f"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.16.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568749402955ad7be7bad9a09b8593851cd36e549ac90bfd44079cea500f3f21"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.16.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611f64e82d98f447787e82b8e7b0ebc681e1eb78fc1252668b2c605ffb4e1eb8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2705,26 +2595,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "git+https://github.com/datenlord/radix_trie#455672314075fa9108cecb9b5c3a19d76cabf1f3"
-dependencies = [
- "endian-type",
- "nibble_vec",
 ]
 
 [[package]]
@@ -2754,7 +2629,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom",
 ]
 
 [[package]]
@@ -2778,11 +2653,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2815,12 +2690,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
 name = "reqsign"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2831,7 +2700,7 @@ dependencies = [
  "base64 0.21.7",
  "chrono",
  "form_urlencoded",
- "getrandom 0.2.16",
+ "getrandom",
  "hex",
  "hmac",
  "home",
@@ -2896,14 +2765,15 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.14"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom",
  "libc",
+ "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -2920,9 +2790,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.8"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
 dependencies = [
  "const-oid",
  "digest",
@@ -2940,36 +2810,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rstest"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b423f0e62bdd61734b67cd21ff50871dfaeb9cc74f869dcd6af974fbcb19936"
-dependencies = [
- "futures",
- "futures-timer",
- "rstest_macros",
- "rustc_version",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e1711e7d14f74b12a58411c542185ef7fb7f2e7f8ee6e2940a883628522b42"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn 2.0.104",
- "unicode-ident",
-]
-
-[[package]]
 name = "rust-ini"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2981,24 +2821,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.37.28"
+version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519165d378b97752ca44bbe15047d5d3409e875f39327546b42ac81d7e18c1b6"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -3010,28 +2841,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
-dependencies = [
- "bitflags 2.9.1",
- "errno",
- "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "linux-raw-sys 0.4.14",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3079,15 +2897,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "salsa20"
@@ -3149,7 +2967,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3158,25 +2976,19 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
-
-[[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
@@ -3221,26 +3033,26 @@ checksum = "fb3aa78ecda1ebc9ec9847d5d3aba7d618823446a049ba2491940506da6e2782"
 dependencies = [
  "log",
  "serde",
- "thiserror 1.0.69",
+ "thiserror",
  "xml-rs",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
  "memchr",
@@ -3250,9 +3062,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -3281,7 +3093,7 @@ dependencies = [
  "serde",
  "serde-bridge",
  "serde-env",
- "toml",
+ "toml 0.7.8",
 ]
 
 [[package]]
@@ -3297,9 +3109,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3323,9 +3135,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -3333,9 +3145,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -3364,27 +3176,30 @@ dependencies = [
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.12",
+ "thiserror",
  "time",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smol"
@@ -3415,9 +3230,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3428,9 +3243,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spki"
@@ -3447,6 +3259,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -3473,9 +3291,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3502,13 +3320,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3534,9 +3352,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
 dependencies = [
  "filetime",
  "libc",
@@ -3544,15 +3362,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.20.0"
+name = "target-lexicon"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "tempfile"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
- "fastrand 2.3.0",
- "getrandom 0.3.3",
+ "cfg-if",
+ "fastrand 2.2.0",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 0.38.41",
  "windows-sys 0.59.0",
 ]
 
@@ -3566,10 +3390,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "termtree"
-version = "0.5.1"
+name = "textwrap"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
@@ -3577,16 +3401,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
-dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -3597,34 +3412,24 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -3637,15 +3442,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3675,9 +3480,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3685,18 +3490,18 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.4",
+ "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.10",
+ "socket2 0.5.8",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -3713,13 +3518,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3734,9 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3745,15 +3550,24 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3765,14 +3579,14 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.19.15",
+ "toml_edit",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
@@ -3783,22 +3597,11 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.9.0",
- "toml_datetime",
- "winnow 0.7.11",
+ "winnow",
 ]
 
 [[package]]
@@ -3888,20 +3691,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3940,21 +3743,27 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unindent"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
 
 [[package]]
 name = "untrusted"
@@ -3984,6 +3793,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3996,27 +3811,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "utilities"
-version = "0.1.0"
-source = "git+https://github.com/datenlord/utilities?rev=4ef408d#4ef408d703670f7d71c87c26fe21710a705990a1"
-
-[[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
- "getrandom 0.3.3",
- "js-sys",
+ "getrandom",
  "serde",
- "wasm-bindgen",
 ]
 
 [[package]]
 name = "valuable"
-version = "0.1.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -4057,50 +3865,41 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
-dependencies = [
- "wit-bindgen-rt",
-]
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
 dependencies = [
  "cfg-if",
  "once_cell",
- "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
 dependencies = [
  "bumpalo",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4111,9 +3910,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4121,25 +3920,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
-dependencies = [
- "unicode-ident",
-]
+checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 
 [[package]]
 name = "wasm-streams"
@@ -4156,9 +3952,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4173,7 +3969,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.44",
+ "rustix 0.38.41",
 ]
 
 [[package]]
@@ -4209,61 +4005,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4294,15 +4040,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.2",
-]
-
-[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4326,27 +4063,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -4362,12 +4083,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4378,12 +4093,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4398,22 +4107,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4428,12 +4125,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4444,12 +4135,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4464,12 +4149,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4482,25 +4161,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
 name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -4516,41 +4180,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "write16"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.1",
-]
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "xattr"
-version = "1.5.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
- "rustix 1.0.7",
+ "linux-raw-sys 0.4.14",
+ "rustix 0.38.41",
 ]
 
 [[package]]
 name = "xml-rs"
-version = "0.8.26"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
+checksum = "af310deaae937e48a26602b730250b4949e125f468f11e6990be3e5304ddd96f"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -4560,55 +4222,56 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
- "synstructure 0.13.2",
+ "syn 2.0.90",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
- "synstructure 0.13.2",
+ "syn 2.0.90",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -4618,21 +4281,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
-name = "zerotrie"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4641,11 +4293,11 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.90",
 ]

--- a/sdk/c/Cargo.toml
+++ b/sdk/c/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "datenlordsdk"
+version = "0.1.0"
+authors = ["DatenLord <dev@datenlord.io>"]
+edition = "2021"
+description = "Distributed cloud native storage system"
+repository = "https://github.com/datenlord/datenlord"
+readme = "README.md"
+license = "MIT"
+keywords = ["DatenLord", "SDK", "C"]
+categories = ["filesystem"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[build-dependencies]
+cbindgen = "0.26.0"
+
+[lib]
+name = "datenlordsdk"
+crate-type = ["cdylib", "staticlib"]
+doc = false
+
+[dependencies]
+datenlord = { path = "../../" }
+clap = { version = "4", features = ["derive"] }
+once_cell = "1.17.1"
+bytes = "1.6.0"
+parking_lot = "0.12.0"
+tokio = { version = "1.32.0", features = ["full"] }
+tokio-util = "0.7.10"
+async-trait = "0.1.48"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+anyhow = "1.0.31"
+clippy-utilities = "0.1.0"
+nix = { version = "0.28.0", features = ["fs", "ioctl", "signal", "user", "mount", "socket"] }
+serde-xml-rs = "0.6"
+serde = "1.0.126"
+serde_json = "1.0.64"
+serde_derive = "1.0"
+thiserror = "1.0.22"
+opendal = {version = "0.43.0", features = ["layers-prometheus"]}
+pyo3 = { version = "0.16", features = ["extension-module"] }
+
+[package.metadata.maturin]
+bindings = "pyo3"

--- a/sdk/c/Makefile
+++ b/sdk/c/Makefile
@@ -1,0 +1,46 @@
+RPATH=$(PWD)/target/debug
+OBJ_DIR=./build
+DOC_DIR=./docs
+
+CCFLAGS=-I./include
+CXXFLAGS=-I./include -std=c++14
+LDFLAGS=-L$(RPATH) -Wl,-rpath,$(RPATH)
+
+LIBS=-ldatenlord -lgtest -lpthread
+
+.PHONY: all
+all: build test examples
+
+.PHONY: format
+format:
+	cargo fmt
+	find . -name '*.cpp' -exec clang-format -i --style=WebKit --verbose {} \;
+	find . -name '*.c' -exec clang-format -i --style=WebKit --verbose {} \;
+
+.PHONY: build
+build:
+	mkdir -p $(OBJ_DIR)
+	cargo build
+
+# build examples begin
+EXAMPLES=$(wildcard ./examples/*.c)
+EXAMPLE_OBJECTS=$(EXAMPLES:.c=.o)
+EXAMPLE_TARGETS=$(EXAMPLES:.c=)
+.PHONY: examples
+examples: $(EXAMPLE_TARGETS)
+
+$(EXAMPLE_TARGETS): % : %.o
+	$(CC) $(CCFLAGS) -o $@ $< $(LDFLAGS) $(LIBS)
+
+%.o: %.c
+	$(CC) $(CCFLAGS) -c $< -o $@
+# build examples end
+
+.PHONY: clean
+clean:
+	cargo clean
+	rm -rf $(EXAMPLE_OBJECTS)
+	rm -rf $(EXAMPLE_TARGETS)
+	rm -rf $(OBJ_DIR)
+	rm -rf $(DOC_DIR)
+

--- a/sdk/c/README.md
+++ b/sdk/c/README.md
@@ -1,0 +1,15 @@
+# DatenLord C SDK
+
+Current datenlord implementation is based on the fuse filesystem and support basic POSIX api for file operations, but it will introduce some overheads for the data transfer.
+This demo is to show how to use the datenlord sdk to implement a user space client for datenlord, and serve datenlord as daemon process, current demo support c and python language.
+
+### c language demo
+
+Use `cargo build --release` to get dynamic library `libdatenlordsdk.so` in `target/release/`.
+
+Go to `examples` to run the c demo.
+```bash
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../target/release
+g++ -o main test_datenlord_sdk.c -L../target/release -ldatenlordsdk -ldl
+./main
+```

--- a/sdk/c/build.rs
+++ b/sdk/c/build.rs
@@ -1,0 +1,11 @@
+extern crate cbindgen;
+
+use std::path::Path;
+
+fn main() {
+    let header_file = Path::new("include").join("datenlordsdk.h");
+
+    cbindgen::generate(".")
+        .expect("Unable to generate bindings")
+        .write_to_file(header_file);
+}

--- a/sdk/c/examples/benchmark_sdk_read.c
+++ b/sdk/c/examples/benchmark_sdk_read.c
@@ -1,0 +1,118 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <fcntl.h>
+#include "datenlordsdk.h"
+
+#define FILE_SIZE_MB 100
+#define FILE_SIZE (FILE_SIZE_MB * 1024 * 1024)
+
+double get_time_diff(struct timespec start, struct timespec end) {
+    return (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1e9;
+}
+
+int main() {
+    datenlord_sdk *sdk = dl_init_sdk("config.toml");
+    if (!sdk) {
+        printf("Failed to initialize SDK\n");
+        return 1;
+    }
+    printf("SDK initialized successfully\n");
+
+    uint8_t *data = (uint8_t *)malloc(FILE_SIZE);
+    if (!data) {
+        printf("Failed to allocate memory\n");
+        dl_free_sdk(sdk);
+        return 1;
+    }
+    memset(data, 'A', FILE_SIZE);
+
+    const char *file_path = "benchmark_test_file.bin";
+
+    if (!dl_exists(sdk, file_path)) {
+        printf("File is not exists\n");
+        free(data);
+        dl_free_sdk(sdk);
+        return 1;
+    }
+
+    unsigned long long fd = dl_open(sdk, file_path, O_RDWR);
+    if (fd == 0) {
+        printf("Failed to open file\n");
+        free(data);
+        dl_free_sdk(sdk);
+        return 1;
+    }
+    printf("File opened successfully with file descriptor: %llu\n", fd);
+
+    datenlord_file_stat file_stat;
+    long long res = dl_stat(sdk, file_path, &file_stat);
+    if (res < 0) {
+        printf("Failed to get file stat information\n");
+        dl_close(sdk, 0, fd);
+        free(data);
+        dl_free_sdk(sdk);
+        return 1;
+    }
+    printf("File stat retrieved successfully, inode number: %lu\n", file_stat.ino);
+
+    struct timespec start_time, end_time;
+
+    double read_latency[5];
+
+    data = (uint8_t *)malloc(FILE_SIZE);
+    if (!data) {
+        printf("Failed to allocate memory for read content\n");
+        dl_close(sdk, file_stat.ino, fd);
+        free(data);
+        dl_free_sdk(sdk);
+        return 1;
+    }
+
+    for (int i = 0; i < 5; i++) {
+        clock_gettime(CLOCK_MONOTONIC, &start_time);
+
+        res = dl_read(sdk, file_stat.ino, fd, data, FILE_SIZE);
+
+        clock_gettime(CLOCK_MONOTONIC, &end_time);
+        if (res < 0) {
+            printf("Failed to read from file\n");
+            dl_close(sdk, file_stat.ino, fd);
+            free(data);
+            dl_free_sdk(sdk);
+            return 1;
+        }
+
+        read_latency[i] = get_time_diff(start_time, end_time);
+    }
+
+    double total_read_latency = 0;
+    // Igonre the first read operation for preheat
+    for (int i = 1; i < 5; i++) {
+        total_read_latency += read_latency[i];
+    }
+    double avg_read_latency = total_read_latency / 4;
+    printf("Read 5 times, average time: %.6f seconds\n", avg_read_latency);
+
+    clock_gettime(CLOCK_MONOTONIC, &start_time);
+    res = dl_close(sdk, file_stat.ino, fd);
+    clock_gettime(CLOCK_MONOTONIC, &end_time);
+
+    if (res < 0) {
+        printf("Failed to close file\n");
+        free(data);
+        // free((void *)read_content.data);
+        dl_free_sdk(sdk);
+        return 1;
+    }
+
+    double close_latency = get_time_diff(start_time, end_time);
+    printf("File close operation time: %.6f seconds\n", close_latency);
+
+    free(data);
+    // free((void *)read_content.data);
+    dl_free_sdk(sdk);
+
+    return 0;
+}

--- a/sdk/c/examples/benchmark_sdk_write.c
+++ b/sdk/c/examples/benchmark_sdk_write.c
@@ -1,0 +1,120 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "datenlordsdk.h"
+
+#define FILE_SIZE_MB 100
+#define FILE_SIZE (FILE_SIZE_MB * 1024 * 1024)
+
+double get_time_diff(struct timespec start, struct timespec end) {
+    return (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1e9;
+}
+
+int main() {
+    datenlord_sdk *sdk = dl_init_sdk("config.toml");
+    if (!sdk) {
+        printf("Failed to initialize SDK\n");
+        return 1;
+    }
+    printf("SDK initialized successfully\n");
+
+    uint8_t *data = (uint8_t *)malloc(FILE_SIZE);
+    if (!data) {
+        printf("Failed to allocate memory\n");
+        dl_free_sdk(sdk);
+        return 1;
+    }
+    memset(data, 'A', FILE_SIZE);
+
+    const char *file_path = "benchmark_test_file.bin";
+
+    if (dl_exists(sdk, file_path)) {
+        printf("File already exists\n");
+        long long res = dl_remove(sdk, file_path);
+        if (res < 0) {
+            printf("Failed to remove file\n");
+            free(data);
+            dl_free_sdk(sdk);
+            return 1;
+        }
+        printf("File removed successfully\n");
+    }
+
+    long long res = dl_mknod(sdk, file_path);
+    if (res < 0) {
+        printf("Failed to create file\n");
+        free(data);
+        dl_free_sdk(sdk);
+        return 1;
+    }
+    printf("File created successfully\n");
+
+    unsigned long long fd = dl_open(sdk, file_path, O_RDWR);
+    if (fd == 0) {
+        printf("Failed to open file\n");
+        free(data);
+        dl_free_sdk(sdk);
+        return 1;
+    }
+    printf("File opened successfully with file descriptor: %llu\n", fd);
+
+    datenlord_file_stat file_stat;
+    res = dl_stat(sdk, file_path, &file_stat);
+    if (res < 0) {
+        printf("Failed to get file stat information\n");
+        dl_close(sdk, 0, fd);
+        free(data);
+        dl_free_sdk(sdk);
+        return 1;
+    }
+    printf("File stat retrieved successfully, inode number: %lu\n", file_stat.ino);
+
+    struct timespec start_time, end_time;
+    double write_latency[5];
+
+    for (int i = 0; i < 5; i++) {
+        clock_gettime(CLOCK_MONOTONIC, &start_time);
+
+        res = dl_write(sdk, file_stat.ino, fd, data, FILE_SIZE);
+
+        clock_gettime(CLOCK_MONOTONIC, &end_time);
+        if (res < 0) {
+            printf("Failed to write to file\n");
+            dl_close(sdk, file_stat.ino, fd);
+            free(data);
+            dl_free_sdk(sdk);
+            return 1;
+        }
+
+        write_latency[i] = get_time_diff(start_time, end_time);
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &start_time);
+    res = dl_close(sdk, file_stat.ino, fd);
+    clock_gettime(CLOCK_MONOTONIC, &end_time);
+
+    if (res < 0) {
+        printf("Failed to close file\n");
+        free(data);
+        dl_free_sdk(sdk);
+        return 1;
+    }
+
+    double total_write_latency = 0;
+    for (int i = 0; i < 5; i++) {
+        total_write_latency += write_latency[i];
+    }
+    double avg_write_latency = total_write_latency / 5;
+
+    printf("Write 5 times, average time: %.6f seconds\n", avg_write_latency);
+
+    double close_latency = get_time_diff(start_time, end_time);
+    printf("File close operation time: %.6f seconds\n", close_latency);
+
+    free(data);
+    dl_free_sdk(sdk);
+
+    return 0;
+}

--- a/sdk/c/examples/config.toml
+++ b/sdk/c/examples/config.toml
@@ -1,0 +1,33 @@
+config_file = "config.toml"
+role = "sdk"
+node_name = "node222"
+node_ip = "127.0.0.1"
+mount_path = "/tmp/datenlord_data_dir"
+kv_server_list = [
+    "127.0.0.1:2379"
+]
+server_port = 8800
+scheduler_extender_port = 12345
+log_level = "error"
+
+[storage]
+storage_type = "s3"
+block_size = 4194304
+fs_storage_root = "/tmp/datenlord_backend"
+
+[storage.memory_cache_config]
+capacity = 8589934592
+command_queue_limit = 1000
+write_back = true
+soft_limit = "3,5"
+
+[storage.s3_storage_config]
+endpoint_url = "http://localhost:9000"
+access_key_id = "minioadmin"
+secret_access_key = "minioadmin"
+bucket_name = "mybucket"
+
+[csi_config]
+endpoint = "unix:///tmp/node.sock "
+driver_name = "io.datenlord.csi.plugin"
+worker_port = 9001

--- a/sdk/c/examples/datenlordsdk.h
+++ b/sdk/c/examples/datenlordsdk.h
@@ -1,0 +1,184 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+/// DatenLord SDK core data structure
+/// This structure is used to store the SDK instance, which is used to interact with the DatenLord SDK.
+/// We need to use init_sdk to initialize the SDK and free_sdk to release the SDK manually.
+struct datenlord_sdk {
+  void *datenlordfs;
+};
+
+/// File attributes
+/// This structure is used to store the file attributes, which are used to store the file metadata.
+struct datenlord_file_stat {
+  /// Inode number
+  uint64_t ino;
+  /// Size in bytes
+  uint64_t size;
+  /// Size in blocks
+  uint64_t blocks;
+  /// Permissions
+  uint16_t perm;
+  /// Number of hard links
+  uint32_t nlink;
+  /// User id
+  uint32_t uid;
+  /// Group id
+  uint32_t gid;
+  /// Rdev
+  uint32_t rdev;
+};
+
+extern "C" {
+
+/// Open a file return current fd
+///
+/// sdk: datenlord_sdk
+/// pathname: file path
+/// mode_t: file mode and permission bits
+///
+/// If the file is opened successfully, return the file descriptor
+/// Otherwise, return -1.
+long long dl_open(datenlord_sdk *sdk, const char *pathname, mode_t mode);
+
+/// Close a opened file
+///
+/// sdk: datenlord_sdk
+/// ino: file inode, which is returned by stat
+/// fd: file descriptor, which is returned by dl_open
+///
+/// If the file is closed successfully, return 0
+/// Otherwise, return -1.
+long long dl_close(datenlord_sdk *sdk, unsigned long long ino, unsigned long long fd);
+
+/// Write to a opened file
+///
+/// sdk: datenlord_sdk
+/// ino: file inode, which is returned by stat
+/// fd: file descriptor, which is returned by dl_open
+/// buf: data to write
+/// count: data size
+///
+/// If the file is written successfully, return 0
+/// Otherwise, return -1.
+long long dl_write(datenlord_sdk *sdk,
+                   unsigned long long ino,
+                   unsigned long long fd,
+                   const uint8_t *buf,
+                   unsigned long long count);
+
+/// Read from a opened file
+///
+/// sdk: datenlord_sdk
+/// ino: file inode, which is returned by stat
+/// fd: file descriptor, which is returned by dl_open
+/// buf: buffer to store read data
+/// count: buffer size
+///
+/// If the file is read successfully, return the read size
+/// Otherwise, return -1.
+long long dl_read(datenlord_sdk *sdk,
+                  unsigned long long ino,
+                  unsigned long long fd,
+                  uint8_t *buf,
+                  unsigned long long count);
+
+/// Initialize the DatenLord SDK by the given config file
+///
+/// config: path to the config file
+datenlord_sdk *dl_init_sdk(const char *config);
+
+/// Free the SDK instance
+///
+/// sdk: datenlord_sdk instance
+void dl_free_sdk(datenlord_sdk *sdk);
+
+/// Check if the given path exists
+///
+/// sdk: datenlord_sdk instance
+/// dir_path: path to the directory
+///
+/// Return: true if the path exists, otherwise false
+bool dl_exists(datenlord_sdk *sdk, const char *dir_path);
+
+/// Create a directory
+///
+/// sdk: datenlord_sdk instance
+/// dir_path: path to the directory
+///
+/// If the directory is created successfully, return the inode number, otherwise -1
+long long dl_mkdir(datenlord_sdk *sdk, const char *dir_path);
+
+/// Remove a directory
+///
+/// sdk: datenlord_sdk instance
+/// dir_path: path to the directory
+/// recursive: whether to remove the directory recursively, current not used
+///
+/// If the directory is removed successfully, return 0, otherwise -1
+long long dl_rmdir(datenlord_sdk *sdk, const char *dir_path, bool recursive);
+
+/// Remove a file
+///
+/// sdk: datenlord_sdk instance
+/// file_path: path to the file
+///
+/// If the file is removed successfully, return 0, otherwise -1
+long long dl_remove(datenlord_sdk *sdk, const char *file_path);
+
+/// Rename a file
+///
+/// sdk: datenlord_sdk instance
+/// src_path: source file path
+/// dest_path: destination file path
+///
+/// If the file is renamed successfully, return 0, otherwise -1
+long long dl_rename(datenlord_sdk *sdk, const char *src_path, const char *dest_path);
+
+/// Create a file
+///
+/// sdk: datenlord_sdk instance
+/// file_path: path to the file
+///
+/// If the file is created successfully, return the inode number, otherwise -1
+long long dl_mknod(datenlord_sdk *sdk, const char *file_path);
+
+/// Get the file attributes
+///
+/// sdk: datenlord_sdk instance
+/// file_path: path to the file
+/// file_metadata: datenlord_file_stat instance
+///
+/// If the file attributes are retrieved successfully, return 0, otherwise -1
+long long dl_stat(datenlord_sdk *sdk, const char *file_path, datenlord_file_stat *file_metadata);
+
+/// Write data to a file
+///
+/// sdk: datenlord_sdk instance
+/// file_path: path to the file
+/// buf: buffer to store the file content
+/// count: the size of the buffer
+///
+/// If the file is written successfully, return the number of bytes written, otherwise -1
+long long dl_write_file(datenlord_sdk *sdk,
+                        const char *file_path,
+                        const uint8_t *buf,
+                        unsigned long long count);
+
+/// Read a hole file
+///
+/// sdk: datenlord_sdk instance
+/// file_path: path to the file
+/// buf: buffer to store the file content
+/// count: the size of the buffer
+///
+/// If the file is read successfully, return the number of bytes read, otherwise -1
+long long dl_read_file(datenlord_sdk *sdk,
+                       const char *file_path,
+                       const uint8_t *buf,
+                       unsigned long long count);
+
+} // extern "C"

--- a/sdk/c/examples/test_datenlord_sdk.c
+++ b/sdk/c/examples/test_datenlord_sdk.c
@@ -1,0 +1,167 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include "datenlordsdk.h"
+
+#define FILE_SIZE_MB 20
+#define FILE_SIZE (FILE_SIZE_MB * 1024 * 1024)
+#define READ_BUFFER_SIZE FILE_SIZE
+
+double get_time_diff(struct timespec start, struct timespec end) {
+    return (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1e9;
+}
+
+void print_file_stat(const datenlord_file_stat *stat) {
+    printf("File Attributes:\n");
+    printf("Inode: %lu\n", stat->ino);
+    printf("Size: %lu bytes\n", stat->size);
+    printf("Blocks: %lu\n", stat->blocks);
+    printf("Permissions: %u\n", stat->perm);
+    printf("Number of Hard Links: %u\n", stat->nlink);
+    printf("User ID: %u\n", stat->uid);
+    printf("Group ID: %u\n", stat->gid);
+    printf("Rdev: %u\n", stat->rdev);
+}
+
+int main() {
+    // printf("size %ld \n", sizeof(int));
+    datenlord_sdk *sdk = dl_init_sdk("config.toml");
+    if (!sdk) {
+        printf("Failed to initialize SDK\n");
+        return 1;
+    }
+    printf("SDK initialized successfully\n");
+
+    const char *file_path = "test_file.bin";
+    const char *dir_path = "test_directory";
+    const char *new_dir_path = "renamed_directory";
+    const char *new_file_path = "renamed_file.bin";
+
+    printf("\n=== File Operation Tests ===\n");
+
+    if (dl_exists(sdk, file_path)) {
+        printf("File %s already exists, removing it...\n", file_path);
+        dl_remove(sdk, file_path);
+    }
+
+    if (dl_mknod(sdk, file_path) < 0) {
+        printf("Failed to create file");
+        dl_free_sdk(sdk);
+        return 1;
+    }
+    printf("File %s created successfully\n", file_path);
+
+    unsigned long long fd = dl_open(sdk, file_path, O_RDWR);
+    if (fd == 0) {
+        printf("Failed to open file");
+        dl_free_sdk(sdk);
+        return 1;
+    }
+    printf("File %s opened successfully with descriptor %llu\n", file_path, fd);
+
+    datenlord_file_stat file_stat;
+    if (dl_stat(sdk, file_path, &file_stat) < 0) {
+        printf("Failed to get file stat");
+        dl_close(sdk, 0, fd);
+        dl_free_sdk(sdk);
+        return 1;
+    }
+    print_file_stat(&file_stat);
+
+    uint8_t *data = (uint8_t *)malloc(FILE_SIZE);
+    if (!data) {
+        printf("Failed to allocate memory");
+        dl_close(sdk, file_stat.ino, fd);
+        dl_free_sdk(sdk);
+        return 1;
+    }
+    memset(data, 'A', FILE_SIZE);
+
+    struct timespec start_time, end_time;
+    clock_gettime(CLOCK_MONOTONIC, &start_time);
+    if (dl_write(sdk, file_stat.ino, fd, data, FILE_SIZE) < 0) {
+        printf("Failed to write to file");
+        dl_close(sdk, file_stat.ino, fd);
+        free(data);
+        dl_free_sdk(sdk);
+        return 1;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &end_time);
+    double write_time = get_time_diff(start_time, end_time);
+    printf("Write operation completed in %.6f seconds\n", write_time);
+
+    data = (uint8_t *)malloc(READ_BUFFER_SIZE);
+
+    clock_gettime(CLOCK_MONOTONIC, &start_time);
+    if (dl_read(sdk, file_stat.ino, fd, data, READ_BUFFER_SIZE) < 0) {
+        printf("Failed to read file");
+        dl_close(sdk, file_stat.ino, fd);
+        // free(read_content.data);
+        free(data);
+        dl_free_sdk(sdk);
+        return 1;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &end_time);
+    double read_time = get_time_diff(start_time, end_time);
+    printf("Read operation completed in %.6f seconds\n", read_time);
+
+    clock_gettime(CLOCK_MONOTONIC, &start_time);
+    if (dl_close(sdk, file_stat.ino, fd) < 0) {
+        printf("Failed to close file");
+        // free(read_content.data);
+        free(data);
+        dl_free_sdk(sdk);
+        return 1;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &end_time);
+    double close_time = get_time_diff(start_time, end_time);
+    printf("File close operation completed in %.6f seconds\n", close_time);
+
+    free(data);
+    // free(read_content.data);
+
+    if (dl_rename(sdk, file_path, new_file_path) < 0) {
+        printf("Failed to rename file");
+    } else {
+        printf("File %s renamed to %s successfully\n", file_path, new_file_path);
+    }
+
+    if (dl_remove(sdk, new_file_path) < 0) {
+        printf("Failed to remove file");
+    } else {
+        printf("File %s removed successfully\n", new_file_path);
+    }
+
+    printf("\n=== Directory Operation Tests ===\n");
+
+    if (dl_exists(sdk, dir_path)) {
+        printf("Directory %s already exists, removing it...\n", dir_path);
+        dl_rmdir(sdk, dir_path, true);
+    }
+
+    if (dl_mkdir(sdk, dir_path) < 0) {
+        printf("Failed to create directory");
+    } else {
+        printf("Directory %s created successfully\n", dir_path);
+    }
+
+    if (dl_rename(sdk, dir_path, new_dir_path) < 0) {
+        printf("Failed to rename directory");
+    } else {
+        printf("Directory %s renamed to %s successfully\n", dir_path, new_dir_path);
+    }
+
+    if (dl_rmdir(sdk, new_dir_path, true) < 0) {
+        printf("Failed to remove directory");
+    } else {
+        printf("Directory %s removed successfully\n", new_dir_path);
+    }
+
+    dl_free_sdk(sdk);
+    printf("SDK resources freed successfully\n");
+
+    return 0;
+}

--- a/sdk/c/include/datenlordsdk.h
+++ b/sdk/c/include/datenlordsdk.h
@@ -1,0 +1,184 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+/// DatenLord SDK core data structure
+/// This structure is used to store the SDK instance, which is used to interact with the DatenLord SDK.
+/// We need to use init_sdk to initialize the SDK and free_sdk to release the SDK manually.
+struct datenlord_sdk {
+  void *datenlordfs;
+};
+
+/// File attributes
+/// This structure is used to store the file attributes, which are used to store the file metadata.
+struct datenlord_file_stat {
+  /// Inode number
+  uint64_t ino;
+  /// Size in bytes
+  uint64_t size;
+  /// Size in blocks
+  uint64_t blocks;
+  /// Permissions
+  uint16_t perm;
+  /// Number of hard links
+  uint32_t nlink;
+  /// User id
+  uint32_t uid;
+  /// Group id
+  uint32_t gid;
+  /// Rdev
+  uint32_t rdev;
+};
+
+extern "C" {
+
+/// Open a file return current fd
+///
+/// sdk: datenlord_sdk
+/// pathname: file path
+/// mode_t: file mode and permission bits
+///
+/// If the file is opened successfully, return the file descriptor
+/// Otherwise, return -1.
+long long dl_open(datenlord_sdk *sdk, const char *pathname, mode_t mode);
+
+/// Close a opened file
+///
+/// sdk: datenlord_sdk
+/// ino: file inode, which is returned by stat
+/// fd: file descriptor, which is returned by dl_open
+///
+/// If the file is closed successfully, return 0
+/// Otherwise, return -1.
+long long dl_close(datenlord_sdk *sdk, unsigned long long ino, unsigned long long fd);
+
+/// Write to a opened file
+///
+/// sdk: datenlord_sdk
+/// ino: file inode, which is returned by stat
+/// fd: file descriptor, which is returned by dl_open
+/// buf: data to write
+/// count: data size
+///
+/// If the file is written successfully, return 0
+/// Otherwise, return -1.
+long long dl_write(datenlord_sdk *sdk,
+                   unsigned long long ino,
+                   unsigned long long fd,
+                   const uint8_t *buf,
+                   unsigned long long count);
+
+/// Read from a opened file
+///
+/// sdk: datenlord_sdk
+/// ino: file inode, which is returned by stat
+/// fd: file descriptor, which is returned by dl_open
+/// buf: buffer to store read data
+/// count: buffer size
+///
+/// If the file is read successfully, return the read size
+/// Otherwise, return -1.
+long long dl_read(datenlord_sdk *sdk,
+                  unsigned long long ino,
+                  unsigned long long fd,
+                  uint8_t *buf,
+                  unsigned long long count);
+
+/// Initialize the DatenLord SDK by the given config file
+///
+/// config: path to the config file
+datenlord_sdk *dl_init_sdk(const char *config);
+
+/// Free the SDK instance
+///
+/// sdk: datenlord_sdk instance
+void dl_free_sdk(datenlord_sdk *sdk);
+
+/// Check if the given path exists
+///
+/// sdk: datenlord_sdk instance
+/// dir_path: path to the directory
+///
+/// Return: true if the path exists, otherwise false
+bool dl_exists(datenlord_sdk *sdk, const char *dir_path);
+
+/// Create a directory
+///
+/// sdk: datenlord_sdk instance
+/// dir_path: path to the directory
+///
+/// If the directory is created successfully, return the inode number, otherwise -1
+long long dl_mkdir(datenlord_sdk *sdk, const char *dir_path);
+
+/// Remove a directory
+///
+/// sdk: datenlord_sdk instance
+/// dir_path: path to the directory
+/// recursive: whether to remove the directory recursively, current not used
+///
+/// If the directory is removed successfully, return 0, otherwise -1
+long long dl_rmdir(datenlord_sdk *sdk, const char *dir_path, bool recursive);
+
+/// Remove a file
+///
+/// sdk: datenlord_sdk instance
+/// file_path: path to the file
+///
+/// If the file is removed successfully, return 0, otherwise -1
+long long dl_remove(datenlord_sdk *sdk, const char *file_path);
+
+/// Rename a file
+///
+/// sdk: datenlord_sdk instance
+/// src_path: source file path
+/// dest_path: destination file path
+///
+/// If the file is renamed successfully, return 0, otherwise -1
+long long dl_rename(datenlord_sdk *sdk, const char *src_path, const char *dest_path);
+
+/// Create a file
+///
+/// sdk: datenlord_sdk instance
+/// file_path: path to the file
+///
+/// If the file is created successfully, return the inode number, otherwise -1
+long long dl_mknod(datenlord_sdk *sdk, const char *file_path);
+
+/// Get the file attributes
+///
+/// sdk: datenlord_sdk instance
+/// file_path: path to the file
+/// file_metadata: datenlord_file_stat instance
+///
+/// If the file attributes are retrieved successfully, return 0, otherwise -1
+long long dl_stat(datenlord_sdk *sdk, const char *file_path, datenlord_file_stat *file_metadata);
+
+/// Write data to a file
+///
+/// sdk: datenlord_sdk instance
+/// file_path: path to the file
+/// buf: buffer to store the file content
+/// count: the size of the buffer
+///
+/// If the file is written successfully, return the number of bytes written, otherwise -1
+long long dl_write_file(datenlord_sdk *sdk,
+                        const char *file_path,
+                        const uint8_t *buf,
+                        unsigned long long count);
+
+/// Read a hole file
+///
+/// sdk: datenlord_sdk instance
+/// file_path: path to the file
+/// buf: buffer to store the file content
+/// count: the size of the buffer
+///
+/// If the file is read successfully, return the number of bytes read, otherwise -1
+long long dl_read_file(datenlord_sdk *sdk,
+                       const char *file_path,
+                       const uint8_t *buf,
+                       unsigned long long count);
+
+} // extern "C"

--- a/sdk/c/src/file.rs
+++ b/sdk/c/src/file.rs
@@ -1,0 +1,240 @@
+use std::{
+    ffi::CStr, os::raw::{c_char, c_longlong, c_ulonglong}, slice, sync::Arc
+};
+
+use datenlord::fs::{
+    datenlordfs::{DatenLordFs, S3MetaData},
+    virtualfs::VirtualFs,
+};
+use nix::libc::mode_t;
+use tracing::{debug, error};
+
+use crate::{
+    sdk::{datenlord_sdk, RUNTIME},
+    utils::find_parent_attr,
+};
+
+/// Open a file return current fd
+///
+/// sdk: datenlord_sdk
+/// pathname: file path
+/// mode_t: file mode and permission bits
+///
+/// If the file is opened successfully, return the file descriptor
+/// Otherwise, return -1.
+#[no_mangle]
+#[allow(clippy::unwrap_used)]
+pub extern "C" fn dl_open(
+    sdk: *mut datenlord_sdk,
+    pathname: *const c_char,
+    mode: mode_t,
+) -> c_longlong {
+    if sdk.is_null() || pathname.is_null() {
+        return -1;
+    }
+
+    let file_path_str = unsafe { CStr::from_ptr(pathname).to_str().unwrap() };
+    let sdk_ref = unsafe { &*sdk };
+    let fs = unsafe { Arc::from_raw(sdk_ref.datenlordfs as *const DatenLordFs<S3MetaData>) };
+
+    let result = RUNTIME.handle().block_on(async {
+        debug!("Writing file: {:?}", file_path_str);
+        match find_parent_attr(&file_path_str, fs.clone()).await {
+            Ok((_, parent_attr)) => {
+                let path_components: Vec<&str> =
+                    file_path_str.split('/').filter(|s| !s.is_empty()).collect();
+                let file_name = path_components.last().unwrap();
+
+                match fs.lookup(0, 0, parent_attr.ino, file_name).await {
+                    Ok((_, file_attr, _)) => match fs.open(0, 0, file_attr.ino, mode).await {
+                        Ok(fh) => {
+                            return Ok(fh);
+                        }
+                        Err(e) => {
+                            error!("Failed to open file: {:?}", e);
+                            return Err(e);
+                        }
+                    },
+                    Err(e) => {
+                        error!("Failed to lookup file: {:?}", e);
+                        return Err(e);
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Failed to find parent attr: {:?}", e);
+                return Err(e);
+            }
+        }
+    });
+
+    let _ = Arc::into_raw(fs);
+
+    match result {
+        // Return i64 to match c_longlong
+        Ok(fh) => fh as i64,
+        Err(e) => {
+            error!("Failed to open file: {:?}", e);
+            return -1;
+        }
+    }
+}
+
+/// Close a opened file
+///
+/// sdk: datenlord_sdk
+/// ino: file inode, which is returned by stat
+/// fd: file descriptor, which is returned by dl_open
+///
+/// If the file is closed successfully, return 0
+/// Otherwise, return -1.
+#[no_mangle]
+#[allow(clippy::unwrap_used)]
+pub extern "C" fn dl_close(
+    sdk: *mut datenlord_sdk,
+    ino: c_ulonglong,
+    fd: c_ulonglong,
+) -> c_longlong {
+    if sdk.is_null() {
+        error!("Invalid arguments");
+        return -1;
+    }
+
+    let sdk_ref = unsafe { &*sdk };
+    let fs = unsafe { Arc::from_raw(sdk_ref.datenlordfs as *const DatenLordFs<S3MetaData>) };
+
+    let result = RUNTIME.handle().block_on(async {
+        match fs.release(ino, fd, 0, 0, true).await {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                error!("Failed to close file: {:?}", e);
+                return Err(e);
+            }
+        }
+    });
+
+    let _ = Arc::into_raw(fs);
+    match result {
+        Ok(()) => {
+            debug!("Closed file: {:?}", fd);
+            return 0;
+        }
+        Err(_) => {
+            error!("Failed to close file: {:?}", fd);
+            return -1;
+        }
+    }
+}
+
+/// Write to a opened file
+///
+/// sdk: datenlord_sdk
+/// ino: file inode, which is returned by stat
+/// fd: file descriptor, which is returned by dl_open
+/// buf: data to write
+/// count: data size
+///
+/// If the file is written successfully, return 0
+/// Otherwise, return -1.
+#[no_mangle]
+pub extern "C" fn dl_write(
+    sdk: *mut datenlord_sdk,
+    ino: c_ulonglong,
+    fd: c_ulonglong,
+    buf: *const u8,
+    count: c_ulonglong,
+) -> c_longlong {
+    if sdk.is_null() || buf.is_null() || count == 0 {
+        error!("Invalid arguments");
+        return -1;
+    }
+
+    let data = unsafe { std::slice::from_raw_parts(buf, count as usize) };
+
+    let sdk_ref = unsafe { &*sdk };
+    let fs = unsafe { Arc::from_raw(sdk_ref.datenlordfs as *const DatenLordFs<S3MetaData>) };
+
+    let result = RUNTIME.handle().block_on(async {
+        debug!("Writing to fd: {:?}", fd);
+        match fs.write(ino, fd, 0, data, 0).await {
+            Ok(()) => {
+                debug!("Writing succeeded for fd: {:?}", fd);
+                Ok(())
+            }
+            Err(e) => {
+                error!("Failed to write to fd: {:?}", e);
+                Err(e)
+            }
+        }
+    });
+
+    let _ = Arc::into_raw(fs);
+
+    match result {
+        Ok(()) => {
+            debug!("Write succeeded for fd: {:?}", fd);
+            // Current write does not return succeeded bytes, so we return the count directly
+            count as i64
+        }
+        Err(e) => {
+            error!("Failed to write to fd: {:?}", e);
+            -1
+        }
+    }
+}
+
+/// Read from a opened file
+///
+/// sdk: datenlord_sdk
+/// ino: file inode, which is returned by stat
+/// fd: file descriptor, which is returned by dl_open
+/// buf: buffer to store read data
+/// count: buffer size
+///
+/// If the file is read successfully, return the read size
+/// Otherwise, return -1.
+#[no_mangle]
+pub extern "C" fn dl_read(
+    sdk: *mut datenlord_sdk,
+    ino: c_ulonglong,
+    fd: c_ulonglong,
+    buf: *mut u8,
+    count: c_ulonglong,
+) -> c_longlong {
+    if sdk.is_null() || buf.is_null() {
+        error!("Invalid arguments");
+        return -1;
+    }
+
+    let sdk_ref = unsafe { &*sdk };
+    let fs = unsafe { Arc::from_raw(sdk_ref.datenlordfs as *const DatenLordFs<S3MetaData>) };
+
+    let result = RUNTIME.handle().block_on(async {
+        unsafe {
+            let buffer = slice::from_raw_parts_mut(buf, count as usize);
+            match fs.read(ino, fd, 0, count as u32, buffer).await {
+                Ok(read_size) => {
+                    debug!("Read from fd: {:?}", fd);
+                    Ok(read_size)
+                }
+                Err(e) => {
+                    error!("Failed to read from fd: {:?}", e);
+                    Err(e)
+                }
+            }
+        }
+    });
+
+    let _ = Arc::into_raw(fs);
+
+    match result {
+        Ok(read_size) => {
+            debug!("Read succeeded for fd: {:?}", fd);
+            read_size as i64
+        }
+        Err(e) => {
+            error!("Failed to read from fd: {:?}", e);
+            -1
+        }
+    }
+}

--- a/sdk/c/src/lib.rs
+++ b/sdk/c/src/lib.rs
@@ -1,0 +1,77 @@
+//! DatenLord C SDK
+
+#![deny(
+    // The following are allowed by default lints according to
+    // https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+    anonymous_parameters,
+    bare_trait_objects,
+    // box_pointers,
+    // elided_lifetimes_in_paths, // allow anonymous lifetime
+    // missing_copy_implementations, // Copy may cause unnecessary memory copy
+    missing_debug_implementations,
+    missing_docs, // TODO: add documents
+    single_use_lifetimes, // TODO: fix lifetime names only used once
+    trivial_casts, // TODO: remove trivial casts in code
+    trivial_numeric_casts,
+    // unreachable_pub, allow clippy::redundant_pub_crate lint instead
+    // unsafe_code,
+    unstable_features,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    // unused_results, // TODO: fix unused results
+    variant_size_differences,
+
+    warnings, // treat all wanings as errors
+
+    clippy::all,
+    clippy::restriction,
+    clippy::pedantic,
+    clippy::cargo
+)]
+#![allow(
+    // Some explicitly allowed Clippy lints, must have clear reason to allow
+    clippy::blanket_clippy_restriction_lints, // allow clippy::restriction
+    clippy::implicit_return, // actually omitting the return keyword is idiomatic Rust code
+    clippy::module_name_repetitions, // repetition of module name in a struct name is not a big deal
+    clippy::multiple_crate_versions, // multi-version dependency crates is not able to fix
+    clippy::panic, // allow debug_assert, panic in production code
+    clippy::unreachable, // Use `unreachable!` instead of `panic!` when impossible cases occur
+    clippy::missing_errors_doc, // TODO: add error docs
+    clippy::exhaustive_structs,
+    clippy::exhaustive_enums,
+    clippy::missing_panics_doc, // TODO: add panic docs
+    clippy::panic_in_result_fn,
+    clippy::single_char_lifetime_names,
+    clippy::separated_literal_suffix, // conflict with unseparated_literal_suffix
+    clippy::undocumented_unsafe_blocks, // TODO: add safety comment
+    clippy::missing_safety_doc, // TODO: add safety comment
+    clippy::shadow_unrelated, // it’s a common pattern in Rust code
+    clippy::shadow_reuse, // it’s a common pattern in Rust code
+    clippy::shadow_same, // it’s a common pattern in Rust code
+    clippy::same_name_method, // Skip for protobuf generated code
+    clippy::mod_module_files, // TODO: fix code structure to pass this lint
+    clippy::std_instead_of_core, // Cause false positive in src/common/error.rs
+    clippy::std_instead_of_alloc,
+    clippy::pub_use, // pub use mod::item as new_name is common in Rust
+    clippy::missing_trait_methods, // TODO: fix this
+    clippy::arithmetic_side_effects, // TODO: fix this
+    clippy::use_debug, // Allow debug print
+    clippy::print_stdout, // Allow println!
+    clippy::question_mark_used, // Allow ? operator, it’s a common pattern in Rust code
+    clippy::absolute_paths, // Allow use through absolute paths, like `std::env::current_dir`
+    clippy::multiple_unsafe_ops_per_block, // Mainly caused by `etcd_delegate`, will remove later
+    clippy::ref_patterns, // Allow Some(ref x)
+    clippy::single_call_fn, // Allow function is called only once
+    clippy::pub_with_shorthand, // Allow pub(super)
+    clippy::min_ident_chars, // Allow Err(e)
+    clippy::missing_assert_message, // Allow assert! without message, mainly in test code
+    clippy::impl_trait_in_params, // Allow impl AsRef<Path>, it's common in Rust
+    clippy::module_inception, // We consider mod.rs as a declaration file
+    clippy::semicolon_outside_block, // We need to choose between this and `semicolon_inside_block`, we choose outside
+    clippy::similar_names // Allow similar names, due to the existence of uid and gid
+)]
+
+pub mod file;
+pub mod sdk;
+pub mod utils;

--- a/sdk/c/src/sdk.rs
+++ b/sdk/c/src/sdk.rs
@@ -1,0 +1,711 @@
+use bytes::BytesMut;
+use clippy_utilities::OverflowArithmetic;
+use core::panic;
+use datenlord::common::error::{DatenLordError, DatenLordResult};
+use datenlord::common::logger::init_logger;
+use datenlord::common::task_manager::{TaskName, TASK_MANAGER};
+use datenlord::config::{self, InnerConfig, NodeRole};
+use datenlord::fs::datenlordfs::{DatenLordFs, MetaData, S3MetaData};
+use datenlord::fs::fs_util::{CreateParam, FileAttr, RenameParam, ROOT_ID};
+use datenlord::fs::kv_engine::etcd_impl::EtcdKVEngine;
+use datenlord::fs::kv_engine::{KVEngine, KVEngineType};
+use datenlord::fs::virtualfs::VirtualFs;
+use datenlord::metrics;
+use datenlord::new_storage::{BackendBuilder, MemoryCache, StorageManager};
+use nix::fcntl::OFlag;
+use nix::sys::stat::SFlag;
+use once_cell::sync::Lazy;
+use parking_lot;
+use std::ffi::{c_void, CStr};
+use std::os::raw::{c_char, c_longlong, c_ulonglong};
+use std::path::Path;
+use std::ptr;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{debug, error};
+
+use crate::utils;
+
+/// Lazy runtime for current thread
+pub static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+});
+
+/// File attributes
+/// This structure is used to store the file attributes, which are used to store the file metadata.
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct datenlord_file_stat {
+    /// Inode number
+    pub ino: u64,
+    /// Size in bytes
+    pub size: u64,
+    /// Size in blocks
+    pub blocks: u64,
+    /// Permissions
+    pub perm: u16,
+    /// Number of hard links
+    pub nlink: u32,
+    /// User id
+    pub uid: u32,
+    /// Group id
+    pub gid: u32,
+    /// Rdev
+    pub rdev: u32,
+}
+
+#[repr(C)]
+#[allow(non_camel_case_types)]
+/// DatenLord SDK core data structure
+/// This structure is used to store the SDK instance, which is used to interact with the DatenLord SDK.
+/// We need to use init_sdk to initialize the SDK and free_sdk to release the SDK manually.
+pub struct datenlord_sdk {
+    // Do not expose the internal structure, use c_void instead
+    pub datenlordfs: *mut c_void,
+}
+
+/// Helper function to find the parent directory's attributes by the given path
+async fn find_parent_attr(
+    path: &str,
+    fs: Arc<DatenLordFs<S3MetaData>>,
+) -> DatenLordResult<(Duration, FileAttr)> {
+    let mut path_components: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+
+    if path_components.is_empty() || path_components.len() == 1 {
+        return fs.getattr(ROOT_ID).await;
+    }
+
+    // Delete the last component to find the parent inode
+    path_components.pop();
+
+    // Find the file from parent inode
+    let mut current_inode = ROOT_ID;
+    for component in &path_components {
+        match fs.lookup(0, 0, current_inode, component).await {
+            Ok((_duration, attr, _generation)) => {
+                current_inode = attr.ino;
+            }
+            Err(e) => {
+                return Err(e);
+            }
+        }
+    }
+    fs.getattr(current_inode).await
+}
+
+#[no_mangle]
+#[allow(clippy::unwrap_used)]
+/// Initialize the DatenLord SDK by the given config file
+///
+/// config: path to the config file
+pub extern "C" fn dl_init_sdk(config: *const c_char) -> *mut datenlord_sdk {
+    // Provide a config file for initialization
+    if config.is_null() {
+        return ptr::null_mut();
+    }
+
+    let config_str = unsafe { CStr::from_ptr(config).to_str().unwrap_or("config.toml") };
+    println!("Config file: {}", config_str);
+
+    // Parse the config file and initialize the SDK
+    let mut arg_conf = config::Config::default();
+    arg_conf.config_file = Some(config_str.to_string());
+
+    let arg_conf = config::Config::load_from_args(arg_conf) // Load config from file
+        .unwrap_or_else(|e| {
+            println!("Failed to load config: {:?}", e);
+            panic!("Failed to load config: {:?}", e);
+        });
+    let config = InnerConfig::try_from(arg_conf).unwrap_or_else(|e| {
+        println!("Failed to parse config: {:?}", e);
+        panic!("Failed to parse config: {:?}", e);
+    });
+
+    init_logger(config.role.into(), config.log_level);
+
+    // Initialize the runtime
+    let datenlord_fs = RUNTIME.handle().block_on(async {
+        match config.role {
+            NodeRole::SDK => {
+                let kv_engine: Arc<EtcdKVEngine> =
+                    Arc::new(KVEngineType::new(config.kv_addrs.clone()).await.unwrap());
+                let node_id = config.node_name.clone();
+
+                TASK_MANAGER
+                    .spawn(TaskName::Metrics, metrics::start_metrics_server)
+                    .await
+                    .unwrap();
+
+                let storage = {
+                    let storage_param = &config.storage.params;
+                    let memory_cache_config = &config.storage.memory_cache_config;
+
+                    let block_size = config.storage.block_size;
+                    let capacity_in_blocks = memory_cache_config.capacity.overflow_div(block_size);
+
+                    let cache = Arc::new(parking_lot::Mutex::new(MemoryCache::new(
+                        capacity_in_blocks,
+                        block_size,
+                    )));
+                    let backend = Arc::new(
+                        BackendBuilder::new(storage_param.clone())
+                            .build()
+                            .await
+                            .unwrap(),
+                    );
+                    StorageManager::new(cache, backend, block_size)
+                };
+
+                // Initialize the SDK and convert to void ptr.
+                let metadata = S3MetaData::new(kv_engine, node_id.as_str()).await.unwrap();
+                Arc::new(DatenLordFs::new(metadata, storage))
+            }
+            _ => {
+                panic!("Invalid role for SDK");
+            }
+        }
+    });
+
+    let fs_ptr = Arc::into_raw(datenlord_fs) as *mut c_void;
+
+    let sdk = Box::new(datenlord_sdk {
+        datenlordfs: fs_ptr,
+    });
+
+    Box::into_raw(sdk)
+}
+
+/// Free the SDK instance
+///
+/// sdk: datenlord_sdk instance
+#[no_mangle]
+pub extern "C" fn dl_free_sdk(sdk: *mut datenlord_sdk) {
+    // Stop daemon tasks
+    if !sdk.is_null() {
+        unsafe {
+            let _ = Box::from_raw(sdk);
+        }
+    }
+}
+
+/// Check if the given path exists
+///
+/// sdk: datenlord_sdk instance
+/// dir_path: path to the directory
+///
+/// Return: true if the path exists, otherwise false
+#[no_mangle]
+pub extern "C" fn dl_exists(sdk: *mut datenlord_sdk, dir_path: *const c_char) -> bool {
+    if sdk.is_null() || dir_path.is_null() {
+        return false;
+    }
+
+    let sdk = unsafe { &*sdk };
+    // let rt = unsafe { &*(sdk.rt as *const runtime::Runtime) };
+    let fs = unsafe { Arc::from_raw(sdk.datenlordfs as *const DatenLordFs<S3MetaData>) };
+
+    let dir_path_str = unsafe { CStr::from_ptr(dir_path).to_string_lossy().into_owned() };
+
+    let result = RUNTIME.handle().block_on(async {
+        match find_parent_attr(&dir_path_str, fs.clone()).await {
+            Ok((_, attr)) => {
+                // Get current dir or file name from path and find current inode
+                let path_components: Vec<&str> =
+                    dir_path_str.split('/').filter(|s| !s.is_empty()).collect();
+                fs.lookup(0, 0, attr.ino, path_components.last().unwrap())
+                    .await
+            }
+            Err(e) => Err(e.into()),
+        }
+    });
+
+    let _ = Arc::into_raw(fs);
+
+    match result {
+        Ok(_) => true,
+        Err(_) => false,
+    }
+}
+
+/// Create a directory
+///
+/// sdk: datenlord_sdk instance
+/// dir_path: path to the directory
+///
+/// If the directory is created successfully, return the inode number, otherwise -1
+#[no_mangle]
+pub extern "C" fn dl_mkdir(sdk: *mut datenlord_sdk, dir_path: *const c_char) -> c_longlong {
+    if sdk.is_null() || dir_path.is_null() {
+        error!("Invalid SDK or directory path");
+        return -1;
+    }
+
+    let sdk = unsafe { &*sdk };
+    let fs = unsafe { Arc::from_raw(sdk.datenlordfs as *const DatenLordFs<S3MetaData>) };
+
+    let dir_path_str = unsafe { CStr::from_ptr(dir_path).to_string_lossy().into_owned() };
+
+    let result = RUNTIME.handle().block_on(async {
+        let param = CreateParam {
+            parent: ROOT_ID,
+            name: dir_path_str,
+            mode: 0o777,
+            rdev: 0,
+            uid: 0,
+            gid: 0,
+            node_type: SFlag::S_IFDIR,
+            link: None,
+        };
+        fs.mkdir(param).await
+    });
+
+    let _ = Arc::into_raw(fs);
+
+    match result {
+        Ok((duration, attr, ino)) => {
+            debug!(
+                "Created directory duration:{:?} attr: {:?} with ino {:?}",
+                duration, attr, ino
+            );
+            ino as c_longlong
+        }
+        Err(e) => {
+            error!("Failed to create directory: {:?}", e);
+            -1
+        }
+    }
+}
+
+/// Remove a directory
+///
+/// sdk: datenlord_sdk instance
+/// dir_path: path to the directory
+/// recursive: whether to remove the directory recursively, current not used
+///
+/// If the directory is removed successfully, return 0, otherwise -1
+#[no_mangle]
+pub extern "C" fn dl_rmdir(
+    sdk: *mut datenlord_sdk,
+    dir_path: *const c_char,
+    recursive: bool,
+) -> c_longlong {
+    if sdk.is_null() || dir_path.is_null() {
+        error!("Invalid SDK or directory path");
+        return -1;
+    }
+
+    let sdk = unsafe { &*sdk };
+
+    let fs = unsafe { Arc::from_raw(sdk.datenlordfs as *const DatenLordFs<S3MetaData>) };
+
+    let dir_path_str = unsafe { CStr::from_ptr(dir_path).to_string_lossy().into_owned() };
+
+    let result = RUNTIME.handle().block_on(async {
+        utils::recursive_delete_dir(Arc::clone(&fs), &dir_path_str, recursive).await
+    });
+
+    let _ = Arc::into_raw(fs);
+
+    match result {
+        Ok(()) => 0,
+        Err(e) => {
+            error!("Failed to remove directory: {:?}", e);
+            -1
+        }
+    }
+}
+
+/// Remove a file
+///
+/// sdk: datenlord_sdk instance
+/// file_path: path to the file
+///
+/// If the file is removed successfully, return 0, otherwise -1
+#[no_mangle]
+pub extern "C" fn dl_remove(sdk: *mut datenlord_sdk, file_path: *const c_char) -> c_longlong {
+    if sdk.is_null() || file_path.is_null() {
+        error!("Invalid SDK or file path");
+        return -1;
+    }
+
+    let sdk = unsafe { &*sdk };
+
+    let fs = unsafe { Arc::from_raw(sdk.datenlordfs as *const DatenLordFs<S3MetaData>) };
+
+    let file_path_str = unsafe { CStr::from_ptr(file_path).to_string_lossy().into_owned() };
+
+    let result = RUNTIME.handle().block_on(async {
+        match utils::find_parent_attr(&file_path_str, fs.clone()).await {
+            Ok((_, parent_attr)) => {
+                let filename = Path::new(&file_path_str)
+                    .file_name()
+                    .ok_or(DatenLordError::ArgumentInvalid {
+                        context: vec!["Invalid file path".to_string()],
+                    })?
+                    .to_str()
+                    .ok_or(DatenLordError::ArgumentInvalid {
+                        context: vec!["Invalid file path".to_string()],
+                    })?;
+
+                match fs.lookup(0, 0, parent_attr.ino, filename).await {
+                    Ok((_, _, _)) => {
+                        // Check current file is exists
+                        match fs.unlink(0, 0, parent_attr.ino, filename).await {
+                            Ok(_) => Ok(()),
+                            Err(e) => Err(DatenLordError::ArgumentInvalid {
+                                context: vec![format!("Failed to remove file {e}")],
+                            }),
+                        }
+                    }
+                    Err(e) => Err(DatenLordError::ArgumentInvalid {
+                        context: vec![format!("Failed to lookup file {e}")],
+                    }),
+                }
+            }
+            Err(e) => Err(DatenLordError::ArgumentInvalid {
+                context: vec![format!("Failed to find parent attr {e}")],
+            }),
+        }
+    });
+
+    let _ = Arc::into_raw(fs);
+
+    match result {
+        Ok(()) => 0,
+        Err(e) => {
+            error!("Failed to remove file: {:?}", e);
+            -1
+        }
+    }
+}
+
+/// Rename a file
+///
+/// sdk: datenlord_sdk instance
+/// src_path: source file path
+/// dest_path: destination file path
+///
+/// If the file is renamed successfully, return 0, otherwise -1
+#[no_mangle]
+pub extern "C" fn dl_rename(
+    sdk: *mut datenlord_sdk,
+    src_path: *const c_char,
+    dest_path: *const c_char,
+) -> c_longlong {
+    if sdk.is_null() || src_path.is_null() || dest_path.is_null() {
+        error!("Invalid SDK or file path");
+        return -1;
+    }
+
+    let sdk = unsafe { &*sdk };
+
+    let fs = unsafe { Arc::from_raw(sdk.datenlordfs as *const DatenLordFs<S3MetaData>) };
+
+    let src_path_str = unsafe { CStr::from_ptr(src_path).to_string_lossy().into_owned() };
+    let dest_path_str = unsafe { CStr::from_ptr(dest_path).to_string_lossy().into_owned() };
+
+    let result = RUNTIME.handle().block_on(async {
+        let param = RenameParam {
+            old_parent: ROOT_ID,
+            old_name: src_path_str,
+            new_parent: ROOT_ID,
+            new_name: dest_path_str,
+            flags: 0, // TODO
+        };
+        fs.rename(0, 0, param).await
+    });
+
+    let _ = Arc::into_raw(fs);
+
+    match result {
+        Ok(()) => 0,
+        Err(e) => {
+            error!("Failed to rename file: {:?}", e);
+            -1
+        }
+    }
+}
+
+/// Create a file
+///
+/// sdk: datenlord_sdk instance
+/// file_path: path to the file
+///
+/// If the file is created successfully, return the inode number, otherwise -1
+#[no_mangle]
+pub extern "C" fn dl_mknod(sdk: *mut datenlord_sdk, file_path: *const c_char) -> c_longlong {
+    if sdk.is_null() || file_path.is_null() {
+        error!("Invalid SDK or file path");
+        return -1;
+    }
+
+    let sdk = unsafe { &*sdk };
+
+    let fs = unsafe { Arc::from_raw(sdk.datenlordfs as *const DatenLordFs<S3MetaData>) };
+
+    let file_path_str = unsafe { CStr::from_ptr(file_path).to_string_lossy().into_owned() };
+
+    let result = RUNTIME.handle().block_on(async {
+        match find_parent_attr(&file_path_str, fs.clone()).await {
+            Ok((_, attr)) => {
+                // Get current dir or file name from path and find current inode
+                let path_components: Vec<&str> =
+                    file_path_str.split('/').filter(|s| !s.is_empty()).collect();
+                let param = CreateParam {
+                    parent: attr.ino,
+                    name: path_components.last().unwrap().to_string(),
+                    mode: 0o777,
+                    rdev: 0,
+                    uid: 0,
+                    gid: 0,
+                    node_type: SFlag::S_IFREG,
+                    link: None,
+                };
+                fs.mknod(param).await
+            }
+            Err(e) => Err(e),
+        }
+    });
+
+    let _ = Arc::into_raw(fs);
+
+    match result {
+        Ok((_, _, ino)) => {
+            debug!("Created file: {:?} with ino {:?}", file_path_str, ino);
+            ino as c_longlong
+        }
+        Err(e) => {
+            error!("Failed to create file: {:?}", e);
+            -1
+        }
+    }
+}
+
+/// Get the file attributes
+///
+/// sdk: datenlord_sdk instance
+/// file_path: path to the file
+/// file_metadata: datenlord_file_stat instance
+///
+/// If the file attributes are retrieved successfully, return 0, otherwise -1
+#[no_mangle]
+pub extern "C" fn dl_stat(
+    sdk: *mut datenlord_sdk,
+    file_path: *const c_char,
+    file_metadata: *mut datenlord_file_stat,
+) -> c_longlong {
+    if sdk.is_null() || file_path.is_null() {
+        error!("Invalid SDK or file path");
+        return -1;
+    }
+    if file_metadata.is_null() {
+        error!("Invalid file metadata");
+        return -1;
+    }
+
+    let path = unsafe { CStr::from_ptr(file_path).to_str().unwrap_or_default() };
+    let sdk_ref = unsafe { &*sdk };
+    let file_metadata: &mut datenlord_file_stat = unsafe { &mut *file_metadata };
+    let fs = unsafe { Arc::from_raw(sdk_ref.datenlordfs as *const DatenLordFs<S3MetaData>) };
+
+    let result = RUNTIME.handle().block_on(async {
+        // Find the file from parent inode
+        match find_parent_attr(path, Arc::clone(&fs)).await {
+            Ok((_, attr)) => {
+                // Get current dir or file name from path and find current inode
+                let path_components: Vec<&str> =
+                    path.split('/').filter(|s| !s.is_empty()).collect();
+                fs.lookup(0, 0, attr.ino, path_components.last().unwrap())
+                    .await
+            }
+            Err(e) => Err(e),
+        }
+    });
+
+    let _ = Arc::into_raw(fs);
+
+    match result {
+        Ok((_, attr, _)) => {
+            (*file_metadata).ino = attr.ino;
+            (*file_metadata).size = attr.size;
+            (*file_metadata).blocks = attr.blocks;
+            (*file_metadata).perm = attr.perm;
+            (*file_metadata).nlink = attr.nlink;
+            (*file_metadata).uid = attr.uid;
+            (*file_metadata).gid = attr.gid;
+            (*file_metadata).rdev = attr.rdev;
+            0
+        }
+        Err(e) => {
+            // TODO: Convert error to datenlord_error with specific code
+            error!("Failed to stat file: {:?}", e);
+            -1
+        }
+    }
+}
+
+/// Write data to a file
+///
+/// sdk: datenlord_sdk instance
+/// file_path: path to the file
+/// buf: buffer to store the file content
+/// count: the size of the buffer
+///
+/// If the file is written successfully, return the number of bytes written, otherwise -1
+#[no_mangle]
+pub extern "C" fn dl_write_file(
+    sdk: *mut datenlord_sdk,
+    file_path: *const c_char,
+    buf: *const u8,
+    count: c_ulonglong,
+) -> c_longlong {
+    if sdk.is_null() || file_path.is_null() || buf.is_null() || count == 0 {
+        error!("Invalid arguments");
+        return -1;
+    }
+
+    let file_path_str = unsafe { CStr::from_ptr(file_path).to_string_lossy().into_owned() };
+
+    let data = unsafe { std::slice::from_raw_parts(buf, count as usize) };
+
+    let sdk_ref = unsafe { &*sdk };
+    let fs = unsafe { Arc::from_raw(sdk_ref.datenlordfs as *const DatenLordFs<S3MetaData>) };
+
+    let result = RUNTIME.handle().block_on(async {
+        debug!("Writing file: {:?}", file_path_str);
+        match find_parent_attr(&file_path_str, fs.clone()).await {
+            Ok((_, parent_attr)) => {
+                let path_components: Vec<&str> =
+                    file_path_str.split('/').filter(|s| !s.is_empty()).collect();
+                let file_name = path_components.last().unwrap();
+
+                match fs.lookup(0, 0, parent_attr.ino, file_name).await {
+                    Ok((_, file_attr, _)) => {
+                        match fs
+                            .open(0, 0, file_attr.ino, OFlag::O_WRONLY.bits() as u32)
+                            .await
+                        {
+                            Ok(fh) => match fs.write(file_attr.ino, fh, 0, data, 0).await {
+                                Ok(_) => {
+                                    debug!("Writing the file ok: {:?}", file_path_str);
+                                    match fs.release(file_attr.ino, fh, 0, 0, true).await {
+                                        Ok(_) => Ok(()),
+                                        Err(e) => {
+                                            error!("Failed to release file handle: {:?}", e);
+                                            Err(e)
+                                        }
+                                    }
+                                }
+                                Err(e) => Err(e),
+                            },
+                            Err(e) => Err(e),
+                        }
+                    }
+                    Err(e) => Err(e),
+                }
+            }
+            Err(e) => Err(e),
+        }
+    });
+
+    let _ = Arc::into_raw(fs);
+
+    match result {
+        Ok(()) => {
+            debug!("Write file: {:?}", file_path_str);
+            count as i64
+        }
+        Err(e) => {
+            error!("Failed to write file: {:?}", e);
+            -1
+        }
+    }
+}
+
+/// Read a hole file
+///
+/// sdk: datenlord_sdk instance
+/// file_path: path to the file
+/// buf: buffer to store the file content
+/// count: the size of the buffer
+///
+/// If the file is read successfully, return the number of bytes read, otherwise -1
+#[no_mangle]
+pub extern "C" fn dl_read_file(
+    sdk: *mut datenlord_sdk,
+    file_path: *const c_char,
+    mut buf: *const u8,
+    count: c_ulonglong,
+) -> c_longlong {
+    if sdk.is_null() || file_path.is_null() || buf.is_null() {
+        error!("Invalid arguments");
+        return -1;
+    }
+
+    let file_path_str = unsafe { CStr::from_ptr(file_path).to_string_lossy().into_owned() };
+
+    let sdk_ref = unsafe { &*sdk };
+    let fs = unsafe { Arc::from_raw(sdk_ref.datenlordfs as *const DatenLordFs<S3MetaData>) };
+
+    let result = RUNTIME.handle().block_on(async {
+        // Find current attribute
+        match find_parent_attr(&file_path_str, fs.clone()).await {
+            Ok((_, attr)) => {
+                // Get current dir or file name from path and find current inode
+                let path_components: Vec<&str> =
+                    file_path_str.split('/').filter(|s| !s.is_empty()).collect();
+                let (_, current_attr, _) = fs
+                    .lookup(0, 0, attr.ino, path_components.last().unwrap())
+                    .await
+                    .unwrap();
+
+                // Get current file handle
+                match fs
+                    .open(0, 0, current_attr.ino, OFlag::O_RDONLY.bits() as u32)
+                    .await
+                {
+                    Ok(fh) => {
+                        // TODO: convert raw ptr to buffer
+                        let mut buffer = BytesMut::with_capacity(current_attr.size as usize);
+                        match fs
+                            .read(
+                                current_attr.ino,
+                                fh,
+                                0,
+                                buffer.capacity() as u32,
+                                &mut buffer,
+                            )
+                            .await
+                        {
+                            Ok(read_size) => {
+                                buf = buffer.as_ptr();
+                                debug!("Read file: {:?} with size: {:?}", file_path_str, read_size);
+                                // Close this file handle
+                                fs.release(current_attr.ino, 0, 0, 0, true).await
+                            }
+                            Err(e) => Err(e),
+                        }
+                    }
+                    Err(e) => Err(e),
+                }
+            }
+            Err(e) => Err(e),
+        }
+    });
+
+    let _ = Arc::into_raw(fs);
+
+    match result {
+        Ok(()) => {
+            debug!("Read file: {:?}", file_path_str);
+            count as i64
+        }
+        Err(e) => {
+            error!("Failed to read file: {:?}", e);
+            -1
+        }
+    }
+}

--- a/sdk/c/src/utils.rs
+++ b/sdk/c/src/utils.rs
@@ -1,0 +1,147 @@
+use std::{collections::VecDeque, path::Path, sync::Arc, time::Duration};
+
+use datenlord::fs::fs_util::INum;
+use datenlord::{
+    common::error::{DatenLordError, DatenLordResult},
+    fs::{
+        datenlordfs::{direntry::FileType, DatenLordFs, S3MetaData},
+        fs_util::{FileAttr, ROOT_ID},
+        virtualfs::VirtualFs,
+    },
+};
+use nix::fcntl::OFlag;
+
+/// A directory entry type.
+pub struct Entry {
+    pub name: String,
+    pub ino: INum,
+    pub file_type: FileType,
+}
+
+impl Entry {
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    pub fn ino(&self) -> INum {
+        self.ino
+    }
+
+    pub fn file_type(&self) -> String {
+        match self.file_type {
+            FileType::File => "file".to_string(),
+            FileType::Dir => "dir".to_string(),
+            FileType::Symlink => "symlink".to_string(),
+        }
+    }
+}
+
+/// Find the parent inode and attribute of the given path.
+pub async fn find_parent_attr(
+    path: &str,
+    fs: Arc<DatenLordFs<S3MetaData>>,
+) -> DatenLordResult<(Duration, FileAttr)> {
+    let path = Path::new(path);
+
+    // If the path is root, return root inode
+    if path.parent().is_none() {
+        return fs.getattr(ROOT_ID).await;
+    }
+
+    // Delete the last component to find the parent inode
+    let parent_path = path.parent().ok_or(DatenLordError::ArgumentInvalid {
+        context: vec!["Cannot find parent path".to_string()],
+    })?;
+    let parent_path_components = parent_path.components();
+
+    // Find the file from parent inode
+    let mut current_inode = ROOT_ID;
+    for component in parent_path_components {
+        if let Some(name) = component.as_os_str().to_str() {
+            match fs.lookup(0, 0, current_inode, name).await {
+                Ok((_duration, attr, _generation)) => {
+                    current_inode = attr.ino;
+                }
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        } else {
+            return Err(DatenLordError::ArgumentInvalid {
+                context: vec!["Invalid path component".to_string()],
+            });
+        }
+    }
+    fs.getattr(current_inode).await
+}
+
+// The current implementation searches for items and places them into a queue.
+// It continues doing so until the subdirectory is found to be empty, at which point it deletes it.
+// This method introduces some overhead due to repeated searches.
+// An optimization could be applied to reduce the query overhead.
+pub async fn recursive_delete_dir(
+    fs: Arc<DatenLordFs<S3MetaData>>,
+    dir_path: &str,
+    recursive: bool,
+) -> DatenLordResult<()> {
+    let mut dir_stack = VecDeque::new();
+    dir_stack.push_back(dir_path.to_string());
+
+    while let Some(current_dir_path) = dir_stack.pop_front() {
+        let (_, parent_attr) = find_parent_attr(&current_dir_path, fs.clone()).await?;
+        let path = Path::new(&current_dir_path);
+
+        let current_name = path
+            .file_name()
+            .ok_or(DatenLordError::ArgumentInvalid {
+                context: vec!["Invalid file path".to_string()],
+            })?
+            .to_str()
+            .ok_or(DatenLordError::ArgumentInvalid {
+                context: vec!["Invalid file path".to_string()],
+            })?;
+
+        let (_, dir_attr, _) = fs.lookup(0, 0, parent_attr.ino, current_name).await?;
+        let current_dir_ino = dir_attr.ino;
+
+        // Open directory
+        let dir_handle = fs
+            .opendir(0, 0, current_dir_ino, OFlag::O_RDONLY.bits() as u32)
+            .await?;
+
+        // Read directory entries
+        let entries = match fs.readdir(0, 0, current_dir_ino, dir_handle, 0).await {
+            Ok(e) => e,
+            Err(e) => {
+                // Release the directory handle before returning the error
+                let _ = fs.releasedir(current_dir_ino, dir_handle, 0).await;
+                return Err(e);
+            }
+        };
+
+        for entry in entries.iter() {
+            let entry_path = Path::new(&current_dir_path).join(entry.name());
+
+            if entry.file_type() == FileType::Dir {
+                if recursive {
+                    dir_stack.push_front(entry_path.to_string_lossy().to_string());
+                }
+            } else {
+                fs.unlink(0, 0, current_dir_ino, &entry.name()).await?;
+            }
+        }
+
+        // Always release the directory handle
+        fs.releasedir(current_dir_ino, dir_handle, 0).await?;
+
+        if recursive || entries.is_empty() {
+            fs.rmdir(0, 0, parent_attr.ino, current_name).await?;
+        }
+
+        if !recursive {
+            return Ok(());
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
# Background

The current filecache provides a POSIX interface for FUSE. We hope to export a Python interface to allow developers to 
directly access local storage without the additional overhead of FUSE.

### Main Changes

This PR provides a **C language interface encapsulation SDK** for `DatenLordFs` to support convenient calling of file system functions by upper-layer C/C++ applications. The core content includes:

#### SDK Lifecycle Management

* `dl_init_sdk`: Initializes the SDK using a configuration file, builds the Etcd KV engine, backend storage, and file system instance.
* `dl_free_sdk`: Manually releases the SDK instance to prevent memory leaks.

#### Basic File Operation Interfaces

* Open/Close: `dl_open`, `dl_close`
* Read/write (by handle): `dl_read`, `dl_write`
* Read/write (entire file): `dl_read_file`, `dl_write_file`

#### Metadata and Path Management Interfaces

* File attribute retrieval: `dl_stat`
* Check if path exists: `dl_exists`
* File/directory creation and deletion: `dl_mknod`, `dl_mkdir`, `dl_rmdir`, `dl_remove`
* File renaming: `dl_rename`